### PR TITLE
GIZFE-351：カテゴリ一新規作成機能実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -119,6 +119,16 @@ const router = new VueRouter({
           name: 'categoryManagement',
           path: '',
           component: CategoryManagement,
+          beforeEnter(to, from, next) {
+            const isCategory = from.name ? from.name.indexOf('category') >= 0 : false;
+            const isRedirect = to.query.redirect;
+            if (isCategory && isRedirect) {
+              next();
+            } else {
+              Store.dispatch('categories/clearMessage');
+              next();
+            }
+          },
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -67,8 +67,8 @@ export default {
         name: payload.name,
       });
     },
-    displayDoneMessage(state, payload = { message: '成功しました' }) {
-      state.doneMessage = payload.message;
+    displayDoneMessage(state, message = '成功しました') {
+      state.doneMessage = message;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
@@ -113,7 +113,7 @@ export default {
           data,
         }).then(() => {
           commit('toggleLoading');
-          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          commit('displayDoneMessage', 'カテゴリーを作成しました');
           resolve();
         }).catch((err) => {
           commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -102,7 +102,7 @@ export default {
       });
     },
     postCategory({ commit, rootGetters }) {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve) => {
         commit('clearMessage');
         commit('toggleLoading');
         const data = new URLSearchParams();
@@ -118,7 +118,6 @@ export default {
         }).catch((err) => {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });
-          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -24,6 +24,9 @@ export default {
       },
     },
     categoryList: [],
+    loading: false,
+    doneMessage: '',
+    errorMessage: '',
   },
   getters: {
     transformedCategories(state) {
@@ -35,14 +38,53 @@ export default {
     targetCategory: state => state.targetCategory,
   },
   mutations: {
+    initPostCategory(state) {
+      state.targetCategory = Object.assign({}, {
+        id: null,
+        name: '',
+        article: {
+          id: null,
+          title: '',
+          content: '',
+        },
+        user: {
+          account_name: '',
+          created_at: '',
+          email: '',
+          full_name: '',
+          id: '',
+          password_reset_flg: null,
+          role: '',
+          updated_at: '',
+        },
+      });
+    },
     doneGetAllCategories(state, { categories }) {
       state.categoryList = [...categories].reverse();
+    },
+    updateValue(state, payload) {
+      state.targetCategory = Object.assign({}, { ...state.targetCategory }, {
+        name: payload.name,
+      });
+    },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
   },
   actions: {
+    initPostCategory({ commit }) {
+      commit('initPostCategory');
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -52,6 +94,36 @@ export default {
       }).catch((err) => {
         commit('failRequest', { message: err.message });
       });
+    },
+    updateValue({ commit }, name) {
+      commit({
+        type: 'updateValue',
+        name,
+      });
+    },
+    postCategory({ commit, rootGetters }) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', rootGetters['categories/targetCategory'].name);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          commit('failRequest', { message: err.message });
+          reject();
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @updateValue="$emit('udpateValue', $event)"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -76,7 +76,8 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory').then(() => {
-        this.$router.push('/categories');
+        this.$store.dispatch('categories/getAllCategories');
+        this.$store.dispatch('categories/initPostCategory');
       });
     },
   },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -1,9 +1,16 @@
 <template lang="html">
   <div class="categories">
     <app-category-post
+      :category="category"
+      :loading="loading"
       :access="access"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
       border-gray
       class="categories-post"
+      @clearMessage="clearMessage"
+      @updateValue="updateValue"
+      @handleSubmit="handleSubmit"
     />
     <app-category-list
       :theads="theads"
@@ -27,6 +34,7 @@ export default {
   mixins: [Mixins],
   data() {
     return {
+      name: '',
       theads: ['カテゴリー名'],
     };
   },
@@ -34,16 +42,42 @@ export default {
     categoriesList() {
       return this.$store.state.categories.categoryList;
     },
+    category() {
+      const { name } = this.$store.state.categories.targetCategory;
+      return name;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
   },
   created() {
     this.getAllCategories();
+    this.$store.dispatch('categories/initPostCategory');
   },
   methods: {
     getAllCategories() {
       this.$store.dispatch('categories/getAllCategories');
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory').then(() => {
+        this.$router.push('/categories');
+      });
     },
   },
 };


### PR DESCRIPTION
## タスクのリンク
- [1-2 カテゴリ一新規作成機能実装](https://gizumo.backlog.com/view/GIZFE-351)
  - [3_カテゴリ新規作成](https://gizumo.backlog.com/wiki/GIZFE/04_Gizumo+Wiki%E3%81%AE%E6%A6%82%E8%A6%81%2F%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E6%A9%9F%E8%83%BD%E8%A9%B3%E7%B4%B0%E8%A8%AD%E8%A8%88%2F3_%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E6%96%B0%E8%A6%8F%E4%BD%9C%E6%88%90)

## やったこと
- カテゴリーnameの挿入
- カテゴリーの新規登録POST機能追加
- メッセージの表示（doneMessage、errorMessage）
- カテゴリー一覧表示更新

## 動作確認

https://user-images.githubusercontent.com/80578563/162378957-d75fc5e9-46ea-4d8b-baec-903379a4b70b.mov


