### PR TITLE
GIZFE-352：カテゴリ一削除機能：実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -136,15 +136,12 @@ export default {
     confirmDeleteCategory({ commit }, deleteTargetCategory) {
       commit('confirmDeleteCategory', deleteTargetCategory);
     },
-    deleteCategory({ commit, rootGetters }) {
+    deleteCategory({ commit, rootGetters, state }) {
       return new Promise((resolve) => {
         commit('clearMessage');
-        const data = new URLSearchParams();
-        data.append('id', rootGetters['categories/deleteCategoryId']);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
-          data,
+          url: `/category/${state.deleteCategoryId}`,
         }).then(() => {
           commit('doneDeleteCategory');
           commit('displayDoneMessage', 'カテゴリーを削除しました');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -27,6 +27,8 @@ export default {
     loading: false,
     doneMessage: '',
     errorMessage: '',
+    deleteCategoryId: null,
+    deleteCategoryName: '',
   },
   getters: {
     transformedCategories(state) {
@@ -36,6 +38,8 @@ export default {
       }));
     },
     targetCategory: state => state.targetCategory,
+    deleteCategoryId: state => state.deleteCategoryId,
+    deleteCategoryName: state => state.deleteCategoryName,
   },
   mutations: {
     initPostCategory(state) {
@@ -80,6 +84,14 @@ export default {
       state.doneMessage = '';
       state.errorMessage = '';
     },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
+    },
   },
   actions: {
     initPostCategory({ commit }) {
@@ -117,6 +129,27 @@ export default {
           resolve();
         }).catch((err) => {
           commit('toggleLoading');
+          commit('failRequest', { message: err.message });
+        });
+      });
+    },
+    confirmDeleteCategory({ commit }, deleteTargetCategory) {
+      commit('confirmDeleteCategory', deleteTargetCategory);
+    },
+    deleteCategory({ commit, rootGetters }) {
+      return new Promise((resolve) => {
+        commit('clearMessage');
+        const data = new URLSearchParams();
+        data.append('id', rootGetters['categories/deleteCategoryId']);
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          data,
+        }).then(() => {
+          commit('doneDeleteCategory');
+          commit('displayDoneMessage', 'カテゴリーを削除しました');
+          resolve();
+        }).catch((err) => {
           commit('failRequest', { message: err.message });
         });
       });

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -16,8 +16,11 @@
       :theads="theads"
       :categories="categoriesList"
       :access="access"
+      :deleteCategoryName="deleteCategoryName"
       border-gray
       class="categories-list"
+      @openModal="openModal"
+      @handleClick="handleClick"
     />
   </div>
 </template>
@@ -52,6 +55,9 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
     loading() {
       return this.$store.state.categories.loading;
     },
@@ -78,6 +84,17 @@ export default {
       this.$store.dispatch('categories/postCategory').then(() => {
         this.$store.dispatch('categories/getAllCategories');
         this.$store.dispatch('categories/initPostCategory');
+      });
+    },
+    openModal(categoryId, categoryName) {
+      const deleteTargetCategory = { categoryId, categoryName };
+      this.$store.dispatch('categories/confirmDeleteCategory', deleteTargetCategory);
+      this.toggleModal();
+    },
+    handleClick() {
+      this.toggleModal();
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/getAllCategories');
       });
     },
   },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -16,7 +16,7 @@
       :theads="theads"
       :categories="categoriesList"
       :access="access"
-      :deleteCategoryName="deleteCategoryName"
+      :delete-category-name="deleteCategoryName"
       border-gray
       class="categories-list"
       @openModal="openModal"


### PR DESCRIPTION
## タスクのリンク
- [1-3 カテゴリ一削除機能実装](https://gizumo.backlog.com/view/GIZFE-352)
  - [4_削除](https://gizumo.backlog.com/wiki/GIZFE/04_Gizumo+Wiki%E3%81%AE%E6%A6%82%E8%A6%81%2F%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E6%A9%9F%E8%83%BD%E8%A9%B3%E7%B4%B0%E8%A8%AD%E8%A8%88%2F4_%E5%89%8A%E9%99%A4)

## やったこと
- 削除モーダルの表示
- 削除モーダルに対象カテゴリー名表示
- カテゴリー削除処理DELETEの追加
- 処理後メッセージの表示
- カテゴリー一覧表示の更新

## 動作確認
https://user-images.githubusercontent.com/80578563/162697463-6f78868b-bc4c-41ed-a61a-6b4be294c443.mov
