### PR TITLE
GIZFE-353：カテゴリ一更新機能：実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -17,6 +17,7 @@ import ArticlePost from '@Pages/Articles/Post';
 // カテゴリー
 import Categories from '@Pages/Categories';
 import CategoryManagement from '@Pages/Categories/Management';
+import CategoryDetail from '@Pages/Categories/Detail';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile';
@@ -129,6 +130,11 @@ const router = new VueRouter({
               next();
             }
           },
+        },
+        {
+          name: 'categoryDetail',
+          path: ':id',
+          component: CategoryDetail,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -151,11 +151,11 @@ export default {
           },
         };
         commit('updateCategory', payload);
-        commit('toggleLoading');
         commit('displayDoneMessage', 'カテゴリーを更新しました');
-      }).catch((err) => {
         commit('toggleLoading');
+      }).catch((err) => {
         commit('failRequest', { message: err.message });
+        commit('toggleLoading');
       });
     },
     postCategory({ commit, rootGetters }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -66,10 +66,16 @@ export default {
     doneGetAllCategories(state, { categories }) {
       state.categoryList = [...categories].reverse();
     },
+    doneGetCategory(state, payload) {
+      state.targetCategory = Object.assign({}, state.targetCategory, payload.category);
+    },
     updateValue(state, payload) {
       state.targetCategory = Object.assign({}, { ...state.targetCategory }, {
         name: payload.name,
       });
+    },
+    updateCategory(state, { category }) {
+      state.targetCategory = Object.assign({}, state.targetCategory, { ...category });
     },
     displayDoneMessage(state, message = '成功しました') {
       state.doneMessage = message;
@@ -107,10 +113,49 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
+    getCategoryDetail({ commit, rootGetters }, { id }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then((res) => {
+        const payload = {
+          category: {
+            id: res.data.category.id,
+            name: res.data.category.name,
+          },
+        };
+        commit('doneGetCategory', payload);
+      }).catch((err) => {
+        commit('failRequest', { message: err.message });
+      });
+    },
     updateValue({ commit }, name) {
       commit({
         type: 'updateValue',
         name,
+      });
+    },
+    updateCategory({ commit, rootGetters, state }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', state.targetCategory.name);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.targetCategory.id}`,
+        data,
+      }).then((res) => {
+        const payload = {
+          category: {
+            id: res.data.category.id,
+            name: res.data.category.name,
+          },
+        };
+        commit('updateCategory', payload);
+        commit('toggleLoading');
+        commit('displayDoneMessage', 'カテゴリーを更新しました');
+      }).catch((err) => {
+        commit('toggleLoading');
+        commit('failRequest', { message: err.message });
       });
     },
     postCategory({ commit, rootGetters }) {

--- a/src/js/components/molecules/CategoryDetail/index.vue
+++ b/src/js/components/molecules/CategoryDetail/index.vue
@@ -17,7 +17,7 @@
       placeholder="カテゴリー名"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('name')"
-      :value="category.name"
+      :value="categoryName"
       @updateValue="updateValue"
     />
     <app-button
@@ -52,9 +52,9 @@ export default {
     appRouterLink: RouterLink,
   },
   props: {
-    category: {
-      type: Object,
-      default: () => ({}),
+    categoryName: {
+      type: String,
+      default: '',
     },
     errorMessage: {
       type: String,

--- a/src/js/components/molecules/CategoryDetail/index.vue
+++ b/src/js/components/molecules/CategoryDetail/index.vue
@@ -24,7 +24,7 @@
       class="category-detail__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.edit"
+      :disabled="!disabled"
     >
       {{ buttonText }}
     </app-button>
@@ -64,7 +64,7 @@ export default {
       type: String,
       default: '',
     },
-    disabled: {
+    loading: {
       type: Boolean,
       default: false,
     },
@@ -76,7 +76,10 @@ export default {
   computed: {
     buttonText() {
       if (!this.access.edit) return '変更権限がありません';
-      return this.disabled ? '更新中...' : '更新';
+      return this.loading ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
     },
   },
   methods: {

--- a/src/js/components/molecules/CategoryDetail/index.vue
+++ b/src/js/components/molecules/CategoryDetail/index.vue
@@ -1,0 +1,112 @@
+<template lang="html">
+  <form @submit.prevent="updateCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      underline
+      large
+      hover-opacity
+      :to="`/categories`"
+      class="category-detail__link"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      name="name"
+      type="text"
+      placeholder="カテゴリー名"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('name')"
+      :value="category.name"
+      @updateValue="updateValue"
+    />
+    <app-button
+      class="category-detail__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.edit"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-detail__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-detail__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    category: {
+      type: Object,
+      default: () => ({}),
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '変更権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    updateCategory() {
+      if (!this.access.edit) return;
+      this.$emit('clearMessage');
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('handleSubmit');
+      });
+    },
+    updateValue($event) {
+      this.$emit('updateValue', $event.target);
+    },
+  },
+};
+</script>
+<style lang="postcss" scoped>
+.category-detail {
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+  &__link {
+    padding: 0;
+    margin: 15px 0;
+  }
+}
+</style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail';
 import UserList from './UserList';
 import CategoryPost from './CategoryPost';
 import CategoryList from './CategoryList';
+import CategoryDetail from './CategoryDetail';
 import ArticleEdit from './ArticleEdit';
 import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryDetail,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/js/pages/Categories/Detail.vue
+++ b/src/js/pages/Categories/Detail.vue
@@ -51,6 +51,7 @@ export default {
       if (!this.loading) this.$store.dispatch('categories/updateValue', target.value);
     },
     handleSubmit() {
+      if (this.loading) return;
       this.$store.dispatch('categories/updateCategory', {
         id: this.category.id,
         name: this.category.name,

--- a/src/js/pages/Categories/Detail.vue
+++ b/src/js/pages/Categories/Detail.vue
@@ -1,6 +1,6 @@
 <template lang="html">
   <app-category-detail
-    :category="category"
+    :category-name="categoryName"
     :error-message="errorMessage"
     :done-message="doneMessage"
     :loading="loading"
@@ -19,8 +19,8 @@ export default {
     appCategoryDetail: CategoryDetail,
   },
   computed: {
-    category() {
-      return this.$store.state.categories.targetCategory;
+    categoryName() {
+      return this.$store.state.categories.targetCategory.name;
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
@@ -52,10 +52,7 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/updateCategory', {
-        id: this.category.id,
-        name: this.category.name,
-      });
+      this.$store.dispatch('categories/updateCategory');
     },
   },
 };

--- a/src/js/pages/Categories/Detail.vue
+++ b/src/js/pages/Categories/Detail.vue
@@ -13,13 +13,11 @@
 
 <script>
 import { CategoryDetail } from '@Components/molecules';
-import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryDetail: CategoryDetail,
   },
-  mixins: [Mixins],
   computed: {
     category() {
       return this.$store.state.categories.targetCategory;

--- a/src/js/pages/Categories/Detail.vue
+++ b/src/js/pages/Categories/Detail.vue
@@ -1,0 +1,63 @@
+<template lang="html">
+  <app-category-detail
+    :category="category"
+    :error-message="errorMessage"
+    :done-message="doneMessage"
+    :loading="loading"
+    :access="access"
+    @clearMessage="clearMessage"
+    @updateValue="updateValue"
+    @handleSubmit="handleSubmit"
+  />
+</template>
+
+<script>
+import { CategoryDetail } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appCategoryDetail: CategoryDetail,
+  },
+  mixins: [Mixins],
+  computed: {
+    category() {
+      return this.$store.state.categories.targetCategory;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategoryDetail', { id });
+    this.$store.dispatch('categories/clearMessage');
+  },
+  destroyed() {
+    this.$store.dispatch('categories/clearMessage');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue(target) {
+      if (!this.loading) this.$store.dispatch('categories/updateValue', target.value);
+    },
+    handleSubmit() {
+      this.$store.dispatch('categories/updateCategory', {
+        id: this.category.id,
+        name: this.category.name,
+      });
+    },
+  },
+};
+</script>


### PR DESCRIPTION
## タスクのリンク
- [1-4 カテゴリ一更新機能実装](https://gizumo.backlog.com/view/GIZFE-353)
  - [5_カテゴリ更新](https://gizumo.backlog.com/wiki/GIZFE/04_Gizumo+Wiki%E3%81%AE%E6%A6%82%E8%A6%81%2F%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E6%A9%9F%E8%83%BD%E8%A9%B3%E7%B4%B0%E8%A8%AD%E8%A8%88%2F5_%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E6%9B%B4%E6%96%B0)

## やったこと
- molecules CategoryDetail作成
- カテゴリー更新画面作成
- カテゴリー情報（一件）の取得とカテゴリー名表示
- カテゴリー更新処理機能の追加
- 処理後メッセージの表示

## 動作確認

https://user-images.githubusercontent.com/80578563/162912203-a144b6d5-b6ea-4e2b-991a-5e9336d15378.mov


