### PR TITLE
:sparkles: feature: カテゴリ一新規作成機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,17 +4,57 @@ export default {
   namespaced: true,
   state: {
     categoriesList: [],
+    loading: false,
     errorMessage: '',
+    doneMessage: '',
+    clearMessage: '',
   },
   mutations: {
+
+    // Create
+    donePostCategory(state) {
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
+    },
+
+    // Read
     doneGetAllCategories(state, payload) {
       state.categoriesList = payload;
     },
+
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMesssage = '';
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
   },
   actions: {
+
+    // Create
+    postCategory({ commit, rootGetters }, category) {
+      commit('toggleLoading');
+
+      return new Promise((resolve) => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data: new URLSearchParams(`name=${category}`),
+        }).then(() => {
+          commit('toggleLoading');
+          commit('donePostCategory');
+          resolve();
+        }).catch((err) => {
+          commit('failRequest', { message: err.message });
+          commit('toggleLoading');
+        });
+      });
+    },
+
+    // Read
     getAllCategoriesByDesc({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -25,6 +65,10 @@ export default {
       }).catch((err) => {
         commit('failRequest', { message: err.message });
       });
+    },
+
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @updateValue="$emit('udpateValue', $event)"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/js/pages/Categories/index.vue
+++ b/src/js/pages/Categories/index.vue
@@ -2,7 +2,14 @@
   <div class="category__inner">
     <div class="category__post">
       <app-category-post
+        :category="category"
+        :error-message="errorMessage"
+        :done-message="doneMessage"
+        :disabled="disabled"
         :access="access"
+        @updateValue="updateValue"
+        @clearMessage="clearMessage"
+        @handleSubmit="handleSubmit"
       />
     </div>
     <div class="vertical-line" />
@@ -26,6 +33,7 @@ export default {
   },
   data() {
     return {
+      category: '',
       theads: ['カテゴリー名'],
     };
   },
@@ -33,12 +41,41 @@ export default {
     categories() {
       return this.$store.state.categories.categoriesList;
     },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    disabled() {
+      return this.$store.state.categories.loading;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
   },
   created() {
     this.$store.dispatch('categories/getAllCategoriesByDesc');
+  },
+  methods: {
+    updateValue($event) {
+      this.category = $event.target.value;
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    handleSubmit() {
+      // cannot push button when be loading
+      if (this.disabled) {
+        return;
+      }
+
+      this.$store.dispatch('categories/postCategory', this.category)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategoriesByDesc');
+          this.category = '';
+        });
+    },
   },
 };
 </script>


### PR DESCRIPTION
# チケットのリンク

[GIZFE-364](https://gizumo.backlog.com/view/GIZFE-364#comment-163900615)

# 作業内容

- 作成ボタンがクリックされたら、新規作成APIを実行する

- 成功時、一覧画面が更新されメッセージを表示する

# 確認項目

- カテゴリ名を入力して、作成ボタンをクリックすると、「カテゴリーの追加が完了しました。」の Notification を出す。

- Notification が出た後に、カテゴリー一覧が更新され、反映される。

https://user-images.githubusercontent.com/98820485/174696374-f4a76c52-3d80-4bde-8594-999b672ccf18.mov


