### PR TITLE
:sparkles: カテゴリ一削除機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,7 +7,8 @@ export default {
     loading: false,
     errorMessage: '',
     doneMessage: '',
-    clearMessage: '',
+    deleteCategoryId: null,
+    deleteCategoryName: '',
   },
   mutations: {
 
@@ -19,6 +20,17 @@ export default {
     // Read
     doneGetAllCategories(state, payload) {
       state.categoriesList = payload;
+    },
+
+    // Delete
+    confirmDeleteCategory(state, { id, name }) {
+      state.deleteCategoryId = id;
+      state.deleteCategoryName = name;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
+      state.doneMessage = 'カテゴリーの削除が完了しました。';
     },
 
     failRequest(state, { message }) {
@@ -64,6 +76,24 @@ export default {
         commit('doneGetAllCategories', reverseCategories);
       }).catch((err) => {
         commit('failRequest', { message: err.message });
+      });
+    },
+
+    // Delete
+    confirmDeleteCategory({ commit }, { categoryId: id, categoryName: name }) {
+      commit('confirmDeleteCategory', { id, name });
+    },
+    deleteCategory({ commit, rootGetters }, categoryId) {
+      return new Promise((resolve) => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${categoryId}`,
+        }).then(() => {
+          commit('doneDeleteCategory');
+          resolve();
+        }).catch((err) => {
+          commit('failRequest', { message: err.message });
+        });
       });
     },
 

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -38,7 +38,7 @@ export default {
     },
     clearMessage(state) {
       state.errorMessage = '';
-      state.doneMesssage = '';
+      state.doneMessage = '';
     },
     toggleLoading(state) {
       state.loading = !state.loading;

--- a/src/js/pages/Categories/index.vue
+++ b/src/js/pages/Categories/index.vue
@@ -17,7 +17,10 @@
       <app-category-list
         :theads="theads"
         :categories="categories"
+        :delete-category-name="deleteCategoryName"
         :access="access"
+        @handleClick="deleteCategory"
+        @openModal="openModal"
       />
     </div>
   </div>
@@ -50,6 +53,12 @@ export default {
     disabled() {
       return this.$store.state.categories.loading;
     },
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategoryId;
+    },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -75,6 +84,23 @@ export default {
           this.$store.dispatch('categories/getAllCategoriesByDesc');
           this.category = '';
         });
+    },
+    toggleModal() {
+      this.$root.$emit('toggleModal');
+    },
+    openModal(categoryId, categoryName) {
+      this.toggleModal();
+      this.$store.dispatch('categories/confirmDeleteCategory', {
+        categoryId,
+        categoryName,
+      });
+    },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategoriesByDesc');
+        });
+      this.toggleModal();
     },
   },
 };

--- a/src/js/pages/Categories/index.vue
+++ b/src/js/pages/Categories/index.vue
@@ -89,6 +89,7 @@ export default {
       this.$root.$emit('toggleModal');
     },
     openModal(categoryId, categoryName) {
+      this.clearMessage();
       this.toggleModal();
       this.$store.dispatch('categories/confirmDeleteCategory', {
         categoryId,


### PR DESCRIPTION
# チケットのリンク

[GIZFE-365](https://gizumo.backlog.com/view/GIZFE-365#comment-164322429)

# 作業内容

- 削除ボタンを押したら、削除確認用のモーダルが出現する

- 削除確認用のモーダルには、削除対象のカテゴリ名が表示される

- 削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行される

- 成功したら一覧が更新され、メッセージを表示する

# 確認項目

- リストにある削除ボタンを押すと、モーダルと共に、「削除しますか？のアナウンス・削除する項目名・削除ボタン」が出る

- 削除ボタンを押すと、該当項目リストが削除され一覧が更新される

https://user-images.githubusercontent.com/98820485/174927737-70b24201-48a7-41ce-ade4-edf75fe4a762.mov


