### PR TITLE
feat:カテゴリー新規作成機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -71,6 +71,7 @@ export default {
         }).catch((err) => {
           commit('failRequest', { message: err.message });
         });
+      }).finally(() => {
         commit('initTargetCategory');
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -77,9 +77,9 @@ export default {
         }).catch((err) => {
           commit('toggleDisabled');
           commit('failRequest', { message: err.message });
+        }).finally(() => {
+          commit('initTargetCategory');
         });
-      }).finally(() => {
-        commit('initTargetCategory');
       });
     },
     clearMessage({ commit }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,7 +10,7 @@ export default {
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
-    disabled: false,
+    isLoading: false,
   },
   getters: {
     targetCategory: state => state.targetCategory,
@@ -39,7 +39,7 @@ export default {
       state.doneMessage = 'カテゴリー名を登録しました';
     },
     toggleDisabled(state) {
-      state.disabled = !state.disabled;
+      state.isLoading = !state.isLoading;
     },
   },
   actions: {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,8 +3,16 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    targetCategory: {
+      id: null,
+      name: '',
+    },
     categoryList: [],
     errorMessage: '',
+    doneMessage: '',
+  },
+  getters: {
+    targetCategory: state => state.targetCategory,
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -12,6 +20,22 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+    },
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
+    updateName(state, name) {
+      state.targetCategory.name = name;
+    },
+    initTargetCategory(state) {
+      state.targetCategory = {
+        id: null,
+        name: '',
+      };
+    },
+    doneMessage(state) {
+      state.doneMessage = 'カテゴリー名を登録しました';
     },
   },
   actions: {
@@ -28,6 +52,30 @@ export default {
       }).catch((err) => {
         commit('failRequest', { message: err.message });
       });
+    },
+    updateName({ commit }, name) {
+      commit('updateName', name);
+    },
+    // カテゴリー追加
+    postCategory({ commit, rootGetters }) {
+      return new Promise((resolve) => {
+        const data = new URLSearchParams();
+        data.append('name', rootGetters['categories/targetCategory'].name);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('doneMessage');
+          resolve();
+        }).catch((err) => {
+          commit('failRequest', { message: err.message });
+        });
+        commit('initTargetCategory');
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,6 +10,7 @@ export default {
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
+    disabled: false,
   },
   getters: {
     targetCategory: state => state.targetCategory,
@@ -37,6 +38,9 @@ export default {
     doneMessage(state) {
       state.doneMessage = 'カテゴリー名を登録しました';
     },
+    toggleDisabled(state) {
+      state.disabled = !state.disabled;
+    },
   },
   actions: {
     // カテゴリー一覧取得
@@ -58,6 +62,7 @@ export default {
     },
     // カテゴリー追加
     postCategory({ commit, rootGetters }) {
+      commit('toggleDisabled');
       return new Promise((resolve) => {
         const data = new URLSearchParams();
         data.append('name', rootGetters['categories/targetCategory'].name);
@@ -66,9 +71,11 @@ export default {
           url: '/category',
           data,
         }).then(() => {
+          commit('toggleDisabled');
           commit('doneMessage');
           resolve();
         }).catch((err) => {
+          commit('toggleDisabled');
           commit('failRequest', { message: err.message });
         });
       }).finally(() => {

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @updateValue="$emit('udpateValue', $event)"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/js/pages/Categories/index.vue
+++ b/src/js/pages/Categories/index.vue
@@ -5,7 +5,7 @@
       :category="category"
       :error-message="errorMessage"
       :done-message="doneMessage"
-      :disabled="disabled"
+      :disabled="isLoading"
       :access="access"
       @updateValue="updateName"
       @clearMessage="clearMessage"
@@ -46,8 +46,8 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
-    disabled() {
-      return this.$store.state.categories.disabled;
+    isLoading() {
+      return this.$store.state.categories.isLoading;
     },
     access() {
       return this.$store.getters['auth/access'];

--- a/src/js/pages/Categories/index.vue
+++ b/src/js/pages/Categories/index.vue
@@ -2,7 +2,13 @@
   <div class="category-wrapper">
     <app-category-post
       class="category-wrapper__post"
+      :category="category"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
       :access="access"
+      @updateValue="updateName"
+      @clearMessage="clearMessage"
+      @handleSubmit="handleSubmit"
     />
     <app-category-list
       class="category-wrapper__list"
@@ -30,12 +36,34 @@ export default {
     categoriesList() {
       return this.$store.state.categories.categoryList;
     },
+    category() {
+      return this.$store.state.categories.targetCategory.name;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    updateName($event) {
+      this.$store.dispatch('categories/updateName', $event.target.value);
+    },
+    handleSubmit() {
+      this.$store.dispatch('categories/postCategory').then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
   },
 };
 </script>

--- a/src/js/pages/Categories/index.vue
+++ b/src/js/pages/Categories/index.vue
@@ -5,6 +5,7 @@
       :category="category"
       :error-message="errorMessage"
       :done-message="doneMessage"
+      :disabled="disabled"
       :access="access"
       @updateValue="updateName"
       @clearMessage="clearMessage"
@@ -44,6 +45,9 @@ export default {
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
     },
     access() {
       return this.$store.getters['auth/access'];


### PR DESCRIPTION
## チケット
https://gizumo.backlog.com/view/GIZFE-369

## 実装内容
- 作成ボタンがクリックされたら、新規作成APIを実行する
- 成功時、一覧画面が更新されメッセージを表示する

## 確認項目
- カテゴリー名を入力し作成ボタンをクリックして、登録できたら「カテゴリー名を登録しました」が表示される
- 登録完了後、一覧画面が更新される