### PR TITLE
feat:カテゴリー削除機能追加

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -16,9 +16,6 @@ export default {
       name: '',
     },
   },
-  getters: {
-    targetCategory: state => state.targetCategory,
-  },
   mutations: {
     doneGetAllCategories(state, payload) {
       state.categoryList = payload.categories.reverse();
@@ -77,11 +74,11 @@ export default {
       commit('updateName', name);
     },
     // カテゴリー追加
-    postCategory({ commit, rootGetters }) {
+    postCategory({ commit, state, rootGetters }) {
       commit('toggleDisabled');
       return new Promise((resolve) => {
         const data = new URLSearchParams();
-        data.append('name', rootGetters['categories/targetCategory'].name);
+        data.append('name', state.targetCategory.name);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,9 +11,14 @@ export default {
     errorMessage: '',
     doneMessage: '',
     isLoading: false,
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
   },
   getters: {
     targetCategory: state => state.targetCategory,
+    deleteCategoryId: state => state.deleteCategory.id,
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -35,11 +40,23 @@ export default {
         name: '',
       };
     },
-    doneMessage(state) {
-      state.doneMessage = 'カテゴリー名を登録しました';
+    doneMessage(state, { message }) {
+      state.doneMessage = message;
     },
     toggleDisabled(state) {
       state.isLoading = !state.isLoading;
+    },
+    confirmDeleteCategory(state, { id, name }) {
+      state.deleteCategory = {
+        id,
+        name,
+      };
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategory = {
+        id: null,
+        name: '',
+      };
     },
   },
   actions: {
@@ -72,13 +89,36 @@ export default {
           data,
         }).then(() => {
           commit('toggleDisabled');
-          commit('doneMessage');
+          commit('doneMessage', { message: 'カテゴリー名を登録しました' });
           resolve();
         }).catch((err) => {
           commit('toggleDisabled');
           commit('failRequest', { message: err.message });
         }).finally(() => {
           commit('initTargetCategory');
+        });
+      });
+    },
+    confirmDeleteCategory({ commit }, { id, name }) {
+      commit('confirmDeleteCategory', { id, name });
+    },
+    // カテゴリー削除
+    deleteCategory({ commit, rootGetters }) {
+      commit('clearMessage');
+      return new Promise((resolve) => {
+        const data = new URLSearchParams();
+        data.append('id', rootGetters['categories/deleteCategoryId']);
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          data,
+        }).then(() => {
+          commit('doneMessage', { message: 'カテゴリー名を削除しました' });
+          resolve();
+        }).catch((err) => {
+          commit('failRequest', { message: err.message });
+        }).finally(() => {
+          commit('doneDeleteCategory');
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -103,14 +103,14 @@ export default {
       commit('confirmDeleteCategory', { id, name });
     },
     // カテゴリー削除
-    deleteCategory({ commit, rootGetters }) {
+    deleteCategory({ commit, state, rootGetters }) {
       commit('clearMessage');
       return new Promise((resolve) => {
         const data = new URLSearchParams();
-        data.append('id', rootGetters['categories/deleteCategoryId']);
+        data.append('id', state.deleteCategory.id);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          url: `/category/${state.deleteCategory.id}`,
           data,
         }).then(() => {
           commit('doneMessage', { message: 'カテゴリー名を削除しました' });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -18,7 +18,6 @@ export default {
   },
   getters: {
     targetCategory: state => state.targetCategory,
-    deleteCategoryId: state => state.deleteCategory.id,
   },
   mutations: {
     doneGetAllCategories(state, payload) {

--- a/src/js/pages/Categories/index.vue
+++ b/src/js/pages/Categories/index.vue
@@ -14,20 +14,25 @@
     <app-category-list
       class="category-wrapper__list"
       :theads="theads"
-      :access="access"
       :categories="categoriesList"
+      :delete-category-name="deleteCategoryName"
+      :access="access"
+      @openModal="openModal"
+      @handleClick="handleClick"
     />
   </div>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名', '', '', ''],
@@ -49,6 +54,9 @@ export default {
     isLoading() {
       return this.$store.state.categories.isLoading;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategory.name;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -67,6 +75,16 @@ export default {
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(id, name) {
+      this.toggleModal();
+      this.$store.dispatch('categories/confirmDeleteCategory', { id, name });
+    },
+    handleClick() {
+      this.toggleModal();
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
     },
   },
 };


### PR DESCRIPTION
## チケット
https://gizumo.backlog.com/view/GIZFE-373

## 実装内容
- カテゴリー削除機能

##  動作確認
- 削除ボタンを押したら、削除確認用のモーダルが出現する
- 削除確認用のモーダルに、削除対象のカテゴリ名が表示される
- 削除確認用のモーダル内部の削除ボタンをクリックしたら削除APIが実行される
- 成功したら一覧が更新され、「カテゴリー名を削除しました」のメッセージを表示