### PR TITLE
feat: カテゴリ一新規作成機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,7 +8,7 @@ export default {
       name: '',
     },
     categoryList: [],
-    isConecting: false,
+    isConnecting: false,
     doneMessage: '',
     errorMessage: '',
   },
@@ -19,8 +19,8 @@ export default {
     updateInputCategories(state, event) {
       state.category.name = event;
     },
-    toggleIsConecting(state) {
-      state.isConecting = !state.isConecting;
+    toggleIsConnecting(state) {
+      state.isConnecting = !state.isConnecting;
     },
     deleteCategoryName(state) {
       state.category.name = null;
@@ -32,14 +32,13 @@ export default {
       state.doneMessage = null;
       state.errorMessage = null;
     },
-    displayErrorMessage(state, errorObject) {
-      state.errorMessage = errorObject.message;
+    displayErrorMessage(state, { message }) {
+      state.errorMessage = message;
     },
   },
   actions: {
     postCategory({ state, commit, rootGetters }) {
-      return new Promise(() => {
-        commit('toggleIsConecting');
+        commit('toggleIsConnecting');
         commit('clearMessage');
         axios(rootGetters['auth/token'])({
           method: 'POST',
@@ -48,15 +47,14 @@ export default {
             name: state.category.name,
           },
         }).then(() => {
-          commit('toggleIsConecting');
+          commit('toggleIsConnecting');
           commit('deleteCategoryName');
           commit('displayDoneMessage');
           this.dispatch('categories/getAllCategories');
         }).catch((err) => {
-          commit('toggleIsConecting');
+          commit('toggleIsConnecting');
           commit('displayErrorMessage', { message: err.message });
         });
-      });
     },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -16,7 +16,7 @@ export default {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
-    getInputCategories(state, event) {
+    updateInputCategories(state, event) {
       state.category.name = event;
     },
     toggleIsConecting(state) {
@@ -88,8 +88,8 @@ export default {
           commit('failRequest', { message: err.message });
         });
     },
-    getInputCategories({ commit }, event) {
-      commit('getInputCategories', event);
+    updateInputCategories({ commit }, event) {
+      commit('updateInputCategories', event);
     },
     clearMessage({ commit }) {
       commit('clearMessage');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,13 +8,71 @@ export default {
       name: '',
     },
     categoryList: [],
+    disabled: false,
+    doneMessage: '',
+    errorMessage: '',
   },
   mutations: {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
+    getInputCategories(state, event) {
+      state.category.name = event;
+    },
+    toggleDisabled(state) {
+      state.disabled = !state.disabled;
+    },
+    deleteCategoryName(state) {
+      state.category.name = null;
+    },
+    displayDoneMessage(state) {
+      state.doneMessage = 'カテゴリー作成しました！';
+    },
+    deleteDisplayedMessage(state) {
+      state.doneMessage = null;
+      state.errorMessage = null;
+    },
+    displayErrorMessage(state) {
+      state.errorMessage = 'すでに存在してるカテゴリーです！';
+    },
   },
   actions: {
+    postCategory({ state, commit, rootGetters }) {
+      return new Promise((resolve, reject) => {
+        commit('toggleDisabled');
+        commit('deleteDisplayedMessage');
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data: {
+            name: state.category.name,
+          },
+        }).then(() => {
+          resolve();
+          commit('toggleDisabled');
+          commit('deleteCategoryName');
+          commit('displayDoneMessage');
+          axios(rootGetters['auth/token'])({
+            method: 'GET',
+            url: '/category',
+          })
+            .then((res) => {
+              const payload = {
+                categories: res.data.categories.reverse(),
+              };
+              commit('doneGetAllCategories', payload);
+            })
+            .catch((err) => {
+              commit('failRequest', { message: err.message });
+            });
+        }).catch((err) => {
+          console.log({ message: err.message });
+          commit('toggleDisabled');
+          commit('displayErrorMessage');
+          reject();
+        });
+      });
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -29,6 +87,12 @@ export default {
         .catch((err) => {
           commit('failRequest', { message: err.message });
         });
+    },
+    getInputCategories({ commit }, event) {
+      commit('getInputCategories', event);
+    },
+    deleteDisplayedMessage({ commit }) {
+      commit('deleteDisplayedMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -52,19 +52,7 @@ export default {
           commit('toggleIsConecting');
           commit('deleteCategoryName');
           commit('displayDoneMessage');
-          axios(rootGetters['auth/token'])({
-            method: 'GET',
-            url: '/category',
-          })
-            .then((res) => {
-              const payload = {
-                categories: res.data.categories.reverse(),
-              };
-              commit('doneGetAllCategories', payload);
-            })
-            .catch((err) => {
-              commit('failRequest', { message: err.message });
-            });
+          this.dispatch('categories/getAllCategories');
         }).catch((err) => {
           console.log({ message: err.message });
           commit('toggleIsConecting');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -28,7 +28,7 @@ export default {
     displayDoneMessage(state) {
       state.doneMessage = 'カテゴリー作成しました！';
     },
-    deleteDisplayedMessage(state) {
+    clearMessage(state) {
       state.doneMessage = null;
       state.errorMessage = null;
     },
@@ -40,7 +40,7 @@ export default {
     postCategory({ state, commit, rootGetters }) {
       return new Promise((resolve, reject) => {
         commit('toggleDisabled');
-        commit('deleteDisplayedMessage');
+        commit('clearMessage');
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
@@ -91,8 +91,8 @@ export default {
     getInputCategories({ commit }, event) {
       commit('getInputCategories', event);
     },
-    deleteDisplayedMessage({ commit }) {
-      commit('deleteDisplayedMessage');
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -32,8 +32,8 @@ export default {
       state.doneMessage = null;
       state.errorMessage = null;
     },
-    displayErrorMessage(state) {
-      state.errorMessage = 'すでに存在してるカテゴリーです！';
+    displayErrorMessage(state, errorObject) {
+      state.errorMessage = errorObject.message;
     },
   },
   actions: {
@@ -52,9 +52,9 @@ export default {
           commit('deleteCategoryName');
           commit('displayDoneMessage');
           this.dispatch('categories/getAllCategories');
-        }).catch(() => {
+        }).catch((err) => {
           commit('toggleIsConecting');
-          commit('displayErrorMessage');
+          commit('displayErrorMessage', { message: err.message });
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -37,24 +37,29 @@ export default {
     },
   },
   actions: {
-    postCategory({ state, commit, rootGetters }) {
+    postCategory({
+      commit,
+      state,
+      dispatch,
+      rootGetters,
+    }) {
+      commit('toggleIsConnecting');
+      commit('clearMessage');
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data: {
+          name: state.category.name,
+        },
+      }).then(() => {
         commit('toggleIsConnecting');
-        commit('clearMessage');
-        axios(rootGetters['auth/token'])({
-          method: 'POST',
-          url: '/category',
-          data: {
-            name: state.category.name,
-          },
-        }).then(() => {
-          commit('toggleIsConnecting');
-          commit('deleteCategoryName');
-          commit('displayDoneMessage');
-          this.dispatch('categories/getAllCategories');
-        }).catch((err) => {
-          commit('toggleIsConnecting');
-          commit('displayErrorMessage', { message: err.message });
-        });
+        commit('deleteCategoryName');
+        commit('displayDoneMessage');
+        dispatch('getAllCategories');
+      }).catch((err) => {
+        commit('toggleIsConnecting');
+        commit('displayErrorMessage', { message: err.message });
+      });
     },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,7 +8,7 @@ export default {
       name: '',
     },
     categoryList: [],
-    disabled: false,
+    isConecting: false,
     doneMessage: '',
     errorMessage: '',
   },
@@ -19,8 +19,8 @@ export default {
     getInputCategories(state, event) {
       state.category.name = event;
     },
-    toggleDisabled(state) {
-      state.disabled = !state.disabled;
+    toggleIsConecting(state) {
+      state.isConecting = !state.isConecting;
     },
     deleteCategoryName(state) {
       state.category.name = null;
@@ -39,7 +39,7 @@ export default {
   actions: {
     postCategory({ state, commit, rootGetters }) {
       return new Promise((resolve, reject) => {
-        commit('toggleDisabled');
+        commit('toggleIsConecting');
         commit('clearMessage');
         axios(rootGetters['auth/token'])({
           method: 'POST',
@@ -49,7 +49,7 @@ export default {
           },
         }).then(() => {
           resolve();
-          commit('toggleDisabled');
+          commit('toggleIsConecting');
           commit('deleteCategoryName');
           commit('displayDoneMessage');
           axios(rootGetters['auth/token'])({
@@ -67,7 +67,7 @@ export default {
             });
         }).catch((err) => {
           console.log({ message: err.message });
-          commit('toggleDisabled');
+          commit('toggleIsConecting');
           commit('displayErrorMessage');
           reject();
         });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -38,7 +38,7 @@ export default {
   },
   actions: {
     postCategory({ state, commit, rootGetters }) {
-      return new Promise((resolve, reject) => {
+      return new Promise(() => {
         commit('toggleIsConecting');
         commit('clearMessage');
         axios(rootGetters['auth/token'])({
@@ -48,16 +48,13 @@ export default {
             name: state.category.name,
           },
         }).then(() => {
-          resolve();
           commit('toggleIsConecting');
           commit('deleteCategoryName');
           commit('displayDoneMessage');
           this.dispatch('categories/getAllCategories');
-        }).catch((err) => {
-          console.log({ message: err.message });
+        }).catch(() => {
           commit('toggleIsConecting');
           commit('displayErrorMessage');
-          reject();
         });
       });
     },

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @updateValue="$emit('udpateValue', $event)"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/js/pages/Categories/Lists.vue
+++ b/src/js/pages/Categories/Lists.vue
@@ -62,7 +62,7 @@ export default {
   },
   methods: {
     inputValue($event) {
-      this.$store.dispatch('categories/getInputCategories', $event.target.value);
+      this.$store.dispatch('categories/updateInputCategories', $event.target.value);
     },
     handleSubmit() {
       if (this.disabled) return;

--- a/src/js/pages/Categories/Lists.vue
+++ b/src/js/pages/Categories/Lists.vue
@@ -69,7 +69,7 @@ export default {
       this.$store.dispatch('categories/postCategory');
     },
     clearMessage() {
-      this.$store.dispatch('categories/deleteDisplayedMessage');
+      this.$store.dispatch('categories/clearMessage');
     },
   },
 };

--- a/src/js/pages/Categories/Lists.vue
+++ b/src/js/pages/Categories/Lists.vue
@@ -3,6 +3,13 @@
     <div class="categories-post">
       <app-category-post
         :access="access"
+        :disabled="disabled"
+        :category="category"
+        :error-message="errorMessage"
+        :done-message="doneMessage"
+        @updateValue="inputValue"
+        @handleSubmit="handleSubmit"
+        @clearMessage="clearMessage"
       />
     </div>
     <div class="categories-border" />
@@ -37,9 +44,33 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    category() {
+      return this.$store.state.categories.category.name;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    inputValue($event) {
+      this.$store.dispatch('categories/getInputCategories', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.disabled) return;
+      this.$store.dispatch('categories/postCategory');
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/deleteDisplayedMessage');
+    },
   },
 };
 </script>

--- a/src/js/pages/Categories/Lists.vue
+++ b/src/js/pages/Categories/Lists.vue
@@ -45,7 +45,7 @@ export default {
       return this.$store.getters['auth/access'];
     },
     disabled() {
-      return this.$store.state.categories.disabled;
+      return this.$store.state.categories.isConnecting;
     },
     category() {
       return this.$store.state.categories.category.name;


### PR DESCRIPTION
カテゴリ一新規作成機能：実装

チケットのリンク
　　[https://gizumo.backlog.com/view/GIZFE-374](https://github.com/gizumo-inc/gizumo_wiki_lesson/pull/url)

作業内容
　- コンポーネントに入力された文字と、ストアでのデータの連動
　- 作成ボタンが押された時の処理
　- 適切なエラーメッセージの表示

動作確認事項
　- 入力された文字とStoreのデータの連動をコンソールで確認
　- 作成ボタンが押された時に、文字が入力されていなければ、適切なエラーを表示
　- 作成ボタンが押された時に、文字が入力されていて、422が吐かれなければ、リストに追加
　- エラーメッセージが表示されている状態で、作成ボタンが押された時に、既存のエラーを削除