### PR TITLE
カテゴリ一更新機能実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14",
     "webpack-notifier": "^1.7.0"
+  },
+  "volta": {
+    "node": "10.15.0"
   }
 }

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home';
 // カテゴリー
 import Categories from '@Pages/Categories';
 import CategoriesList from '@Pages/Categories/Lists';
+import CategoriesEdit from '@Pages/Categories/Edit';
 
 // 記事
 import Articles from '@Pages/Articles';
@@ -76,9 +77,14 @@ const router = new VueRouter({
       component: Categories,
       children: [
         {
-          name: 'categories',
+          name: 'categoriesList',
           path: '',
           component: CategoriesList,
+        },
+        {
+          name: 'categoriesEdit',
+          path: ':id',
+          component: CategoriesEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -17,8 +17,10 @@ export default {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
-    updateInputCategories(state, event) {
+    inputCategories(state, event) {
       state.category.name = event;
+    },
+    updateCategories(state, event) {
       state.category.updateName = event;
     },
     toggleIsConnecting(state) {
@@ -51,8 +53,7 @@ export default {
     displayUpdatedMessage(state) {
       state.doneMessage = 'カテゴリー更新しました！';
     },
-    deleteCategoryData(state) {
-      state.category.name = '';
+    deleteUpdateCategory(state) {
       state.category.id = null;
       state.category.updateName = '';
     },
@@ -125,8 +126,11 @@ export default {
           commit('failRequest', { message: err.message });
         });
     },
-    updateInputCategories({ commit }, event) {
-      commit('updateInputCategories', event);
+    updateCategories({ commit }, event) {
+      commit('updateCategories', event);
+    },
+    inputCategories({ commit }, event) {
+      commit('inputCategories', event);
     },
     clearMessage({ commit }) {
       commit('clearMessage');
@@ -160,8 +164,8 @@ export default {
           commit('displayErrorMessage', { message: err.message });
         });
     },
-    deleteCategoryData({ commit }) {
-      commit('deleteCategoryData');
+    deleteUpdateCategory({ commit }) {
+      commit('deleteUpdateCategory');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -6,6 +6,7 @@ export default {
     category: {
       id: null,
       name: '',
+      updateName: '',
     },
     categoryList: [],
     isConnecting: false,
@@ -18,6 +19,7 @@ export default {
     },
     updateInputCategories(state, event) {
       state.category.name = event;
+      state.category.updateName = event;
     },
     toggleIsConnecting(state) {
       state.isConnecting = !state.isConnecting;
@@ -26,7 +28,7 @@ export default {
       state.category.name = '';
     },
     setCategoryData(state, { id, name }) {
-      state.category.name = name;
+      state.category.updateName = name;
       state.category.id = id;
     },
     displayDoneMessage(state) {
@@ -48,6 +50,11 @@ export default {
     },
     displayUpdatedMessage(state) {
       state.doneMessage = 'カテゴリー更新しました！';
+    },
+    deleteCategoryData(state) {
+      state.category.name = '';
+      state.category.id = null;
+      state.category.updateName = '';
     },
   },
   actions: {
@@ -141,7 +148,7 @@ export default {
         method: 'PUT',
         url: `/category/${state.category.id}`,
         data: {
-          name: state.category.name,
+          name: state.category.updateName,
         },
       })
         .then(() => {
@@ -152,6 +159,9 @@ export default {
           commit('toggleIsConnecting');
           commit('displayErrorMessage', { message: err.message });
         });
+    },
+    deleteCategoryData({ commit }) {
+      commit('deleteCategoryData');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -25,6 +25,10 @@ export default {
     deleteCategoryName(state) {
       state.category.name = '';
     },
+    setCategoryData(state, { id, name }) {
+      state.category.name = name;
+      state.category.id = id;
+    },
     displayDoneMessage(state) {
       state.doneMessage = 'カテゴリー作成しました！';
     },
@@ -42,8 +46,22 @@ export default {
     setDeleteCategoryId(state, { id }) {
       state.category.id = id;
     },
+    displayUpdatedMessage(state) {
+      state.doneMessage = 'カテゴリー更新しました！';
+    },
   },
   actions: {
+    getCategoryName({ commit, rootGetters }, id) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then((val) => {
+        const { name } = val.data.category;
+        commit('setCategoryData', { id, name });
+      }).catch((err) => {
+        commit('displayErrorMessage', { message: err.message });
+      });
+    },
     postCategory({
       commit,
       state,
@@ -108,6 +126,32 @@ export default {
     },
     setDeleteCategoryId({ commit }, { id }) {
       commit('setDeleteCategoryId', { id });
+    },
+    deleteCategoryName({ commit }) {
+      commit('deleteCategoryName');
+    },
+    updateCategoryName({
+      state,
+      rootGetters,
+      commit,
+    }) {
+      commit('clearMessage');
+      commit('toggleIsConnecting');
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.category.id}`,
+        data: {
+          name: state.category.name,
+        },
+      })
+        .then(() => {
+          commit('toggleIsConnecting');
+          commit('displayUpdatedMessage');
+        })
+        .catch((err) => {
+          commit('toggleIsConnecting');
+          commit('displayErrorMessage', { message: err.message });
+        });
     },
   },
 };

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -78,9 +78,12 @@ export default {
     const categoryId = this.$route.params.id;
     this.$store.dispatch('categories/getCategoryName', categoryId);
   },
+  destroyed() {
+    this.$store.dispatch('categories/deleteCategoryData');
+  },
   computed: {
     categoryName() {
-      return this.$store.state.categories.category.name;
+      return this.$store.state.categories.category.updateName;
     },
     buttonText() {
       if (!this.access.edit) return '更新権限がありません';

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -10,6 +10,11 @@
     </div>
     <div class="make-space-top">
       <app-input
+        name="category"
+        type="text"
+        v-validate="'required'"
+        data-vv-as="カテゴリー名"
+        :error-messages="errors.collect('category')"
         :value="categoryName"
         @updateValue="$emit('updateValue', $event)"
       ></app-input>
@@ -18,7 +23,7 @@
       <app-button
         button-type="submit"
         round
-        :disabled="disabled || !access.create"
+        :disabled="disabled || !access.edit"
         @click="updateCategory"
       >
       {{ buttonText }}
@@ -70,22 +75,25 @@ export default {
     },
   },
   created() {
-    const getId = this.$route.params.id;
-    this.$store.dispatch('categories/getCategoryName', getId);
+    const categoryId = this.$route.params.id;
+    this.$store.dispatch('categories/getCategoryName', categoryId);
   },
   computed: {
     categoryName() {
       return this.$store.state.categories.category.name;
     },
     buttonText() {
-      if (!this.access.create) return '更新権限がありません';
+      if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {
     updateCategory() {
-      if (!this.access.create) return;
-      this.$store.dispatch('categories/updateCategoryName');
+      if (!this.access.edit) return;
+      this.$store.dispatch('categories/clearMessage');
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$store.dispatch('categories/updateCategoryName');
+      });
     },
   },
 };

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -79,7 +79,7 @@ export default {
     this.$store.dispatch('categories/getCategoryName', categoryId);
   },
   destroyed() {
-    this.$store.dispatch('categories/deleteCategoryData');
+    this.$store.dispatch('categories/deleteUpdateCategory');
   },
   computed: {
     categoryName() {

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,100 @@
+<template lang="html">
+  <section>
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="make-space-top">
+      <app-router-link
+        underline
+        hover-opacity
+        :to="`/categories`"
+      >カテゴリー一覧へ戻る</app-router-link>
+    </div>
+    <div class="make-space-top">
+      <app-input
+        :value="categoryName"
+        @updateValue="$emit('updateValue', $event)"
+      ></app-input>
+    </div>
+    <div class="make-space-top">
+      <app-button
+        button-type="submit"
+        round
+        :disabled="disabled || !access.create"
+        @click="updateCategory"
+      >
+      {{ buttonText }}
+      </app-button>
+    </div>
+    <div v-if="errorMessage" class="make-space-top">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="make-space-top">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </section>
+</template>
+
+<script>
+import {
+  Button,
+  Heading,
+  Input,
+  RouterLink,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appButton: Button,
+    appHeading: Heading,
+    appInput: Input,
+    appRouterLink: RouterLink,
+    appText: Text,
+  },
+  props: {
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  created() {
+    const getId = this.$route.params.id;
+    this.$store.dispatch('categories/getCategoryName', getId);
+  },
+  computed: {
+    categoryName() {
+      return this.$store.state.categories.category.name;
+    },
+    buttonText() {
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    updateCategory() {
+      if (!this.access.create) return;
+      this.$store.dispatch('categories/updateCategoryName');
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+
+.make-space-top {
+  margin-top: 20px;
+}
+
+</style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -15,6 +15,7 @@ import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
 import DeleteModal from './Modal';
 import Notice from './Notice';
+import CategoryEdit from './CategoryEdit';
 
 export {
   SigninForm,
@@ -34,4 +35,5 @@ export {
   ArticleDetail,
   DeleteModal,
   Notice,
+  CategoryEdit,
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -34,7 +34,7 @@ export default {
   },
   methods: {
     updateValue($event) {
-      this.$store.dispatch('categories/updateInputCategories', $event.target.value);
+      this.$store.dispatch('categories/updateCategories', $event.target.value);
     },
   },
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,0 +1,41 @@
+<template>
+  <app-category-edit
+    :access="access"
+    :disabled="disabled"
+    :error-message="errorMessage"
+    :done-message="doneMessage"
+    @updateValue="inputValue"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  created() {
+    this.$store.dispatch('categories/clearMessage');
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    disabled() {
+      return this.$store.state.categories.isConnecting;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+  },
+  methods: {
+    inputValue($event) {
+      this.$store.dispatch('categories/updateInputCategories', $event.target.value);
+    },
+  },
+};
+</script>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -4,7 +4,7 @@
     :disabled="disabled"
     :error-message="errorMessage"
     :done-message="doneMessage"
-    @updateValue="inputValue"
+    @updateValue="updateValue"
   />
 </template>
 
@@ -33,7 +33,7 @@ export default {
     },
   },
   methods: {
-    inputValue($event) {
+    updateValue($event) {
       this.$store.dispatch('categories/updateInputCategories', $event.target.value);
     },
   },

--- a/src/js/pages/Categories/Lists.vue
+++ b/src/js/pages/Categories/Lists.vue
@@ -65,12 +65,11 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
-    this.$store.dispatch('categories/deleteCategoryName');
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     inputValue($event) {
-      this.$store.dispatch('categories/updateInputCategories', $event.target.value);
+      this.$store.dispatch('categories/inputCategories', $event.target.value);
     },
     handleSubmit() {
       if (this.disabled) return;

--- a/src/js/pages/Categories/Lists.vue
+++ b/src/js/pages/Categories/Lists.vue
@@ -65,6 +65,8 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/deleteCategoryName');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     inputValue($event) {


### PR DESCRIPTION
- チケットのリンク
https://gizumo.backlog.com/view/GIZFE-378#comment-172161163

- 作業内容
　- 必要なファイルの作成、ルーターの設定
　　- モルキュレスファイル
　　- ページファイル
　　- routerの設定
　- 遷移先のレイアウト作成
　　- atomsから部品をインポートし運用
　　- 値の受け渡し
　- 値の更新

- 動作確認
　- 画面遷移先がidとあっているか
　- 遷移先でインプット欄に値が渡されているか
　- 更新ボタンが押された時の表示されるメッセージは正しいか
　- 更新成功後、カテゴリーリストでちゃんと更新されているか
　- 更新成功後、カテゴリーポストのインプット欄は空になっているか
　- メッセージが表示されている状態で遷移したときにメッセージはちゃんと消えているか

