### PR TITLE
feat:削除済み記事一覧の実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -18,6 +18,7 @@ import ArticleList from '@Pages/Articles/List';
 import ArticleDetail from '@Pages/Articles/Detail';
 import ArticleEdit from '@Pages/Articles/Edit';
 import ArticlePost from '@Pages/Articles/Post';
+import ArticleTrashed from '@Pages/Articles/Trashed';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile';
@@ -115,6 +116,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -291,5 +291,18 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
+    getTrashedArticles({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then((res) => {
+        const payload = {
+          articles: res.data.articles,
+        };
+        commit('doneGetAllArticles', payload);
+      }).catch((err) => {
+        commit('failRequest', { message: err.message });
+      });
+    },
   },
 };

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="/articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__create-link--trashed"
+    >
+      削除済み記事一覧
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -183,6 +195,9 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+      &--trashed {
+        margin-left: 15px;
+      }
     }
     &__links {
       *:not(first-child) {

--- a/src/js/components/molecules/ArticleTable/index.vue
+++ b/src/js/components/molecules/ArticleTable/index.vue
@@ -57,7 +57,7 @@ export default {
   props: {
     targetArray: {
       type: Array,
-      default: () => [],
+      required: true,
     },
   },
   data() {

--- a/src/js/components/molecules/ArticleTable/index.vue
+++ b/src/js/components/molecules/ArticleTable/index.vue
@@ -14,17 +14,17 @@
         <tr v-for="article in targetArray" :key="article.id">
           <td>
             <app-text tag="span" small>
-              {{ article.title | readMore(30, '...') }}
+              {{ readMore(article.title) }}
             </app-text>
           </td>
           <td>
             <app-text tag="span" small>
-              {{ article.content | readMore(30, '...') }}
+              {{ readMore(article.content) }}
             </app-text>
           </td>
           <td>
             <app-text tag="span" small>
-              {{ article.created_at | displayDate(10) }}
+              {{ displayDate(article.created_at) }}
             </app-text>
           </td>
         </tr>
@@ -43,24 +43,18 @@ export default {
   components: {
     appText: Text,
   },
-  filters: {
-    readMore(text, length, suffix) {
-      let articleText = '';
-      if (text.length > 30) {
-        articleText = text.substring(0, length) + suffix;
-      } else {
-        articleText = text.substring(0, length);
-      }
-      return articleText;
-    },
-    displayDate(text, length) {
-      return text.substring(0, length);
-    },
-  },
   props: {
     targetArray: {
       type: Array,
       required: true,
+    },
+  },
+  computed: {
+    readMore() {
+      return articleText => (articleText.length > 30 ? `${articleText.substring(0, 30)}...` : articleText);
+    },
+    displayDate() {
+      return createdDate => createdDate.substring(0, 10);
     },
   },
 };

--- a/src/js/components/molecules/ArticleTable/index.vue
+++ b/src/js/components/molecules/ArticleTable/index.vue
@@ -3,7 +3,7 @@
     <table class="article-table">
       <thead class="article-table__head">
         <tr>
-          <th v-for="(thead, index) in theads" :key="index">
+          <th v-for="(thead, index) in $options.const.theads" :key="index">
             <app-text tag="span" theme-color bold>
               {{ thead }}
             </app-text>
@@ -37,6 +37,9 @@
 import { Text } from '@Components/atoms';
 
 export default {
+  const: {
+    theads: ['タイトル', '本文', '作成日'],
+  },
   components: {
     appText: Text,
   },
@@ -59,11 +62,6 @@ export default {
       type: Array,
       required: true,
     },
-  },
-  data() {
-    return {
-      theads: ['タイトル', '本文', '作成日'],
-    };
   },
 };
 </script>

--- a/src/js/components/molecules/ArticleTable/index.vue
+++ b/src/js/components/molecules/ArticleTable/index.vue
@@ -1,0 +1,89 @@
+<template lang="html">
+  <div>
+    <table class="article-table">
+      <thead class="article-table__head">
+        <tr>
+          <th v-for="(thead, index) in theads" :key="index">
+            <app-text tag="span" theme-color bold>
+              {{ thead }}
+            </app-text>
+          </th>
+        </tr>
+      </thead>
+      <transition-group name="fade" tag="tbody" class="article-table__body">
+        <tr v-for="article in targetArray" :key="article.id">
+          <td>
+            <app-text tag="span" small>
+              {{ article.title | readMore(30, '...') }}
+            </app-text>
+          </td>
+          <td>
+            <app-text tag="span" small>
+              {{ article.content | readMore(30, '...') }}
+            </app-text>
+          </td>
+          <td>
+            <app-text tag="span" small>{{ article.created_at | displayDate(10) }}</app-text>
+          </td>
+        </tr>
+      </transition-group>
+    </table>
+  </div>
+</template>
+
+<script>
+import { Text } from '@Components/atoms';
+
+export default {
+  components: {
+    appText: Text,
+  },
+  filters: {
+    readMore(text, length, suffix) {
+      let articleText = '';
+      if (text.length > 30) {
+        articleText = text.substring(0, length) + suffix;
+      } else {
+        articleText = text.substring(0, length);
+      }
+      return articleText;
+    },
+    displayDate(text, length) {
+      return text.substring(0, length);
+    }
+  },
+  props: {
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  data() {
+    return {
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+  .article-table {
+    width: 100%;
+    margin-top: 10px;
+    tr {
+      border-bottom: 1px solid var(--separatorColor);
+    }
+    &__head {
+      th {
+        text-align: left;
+        padding: 5px 10px;
+      }
+    }
+    &__body {
+      td {
+        padding: 5px;
+        vertical-align: middle;
+      }
+    }
+  }
+</style>

--- a/src/js/components/molecules/ArticleTable/index.vue
+++ b/src/js/components/molecules/ArticleTable/index.vue
@@ -23,7 +23,9 @@
             </app-text>
           </td>
           <td>
-            <app-text tag="span" small>{{ article.created_at | displayDate(10) }}</app-text>
+            <app-text tag="span" small>
+              {{ article.created_at | displayDate(10) }}
+            </app-text>
           </td>
         </tr>
       </transition-group>
@@ -50,7 +52,7 @@ export default {
     },
     displayDate(text, length) {
       return text.substring(0, length);
-    }
+    },
   },
   props: {
     targetArray: {

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -13,27 +13,30 @@
     >
       すべての記事一覧へ戻る
     </app-router-link>
-    <app-list-item />
+    <div v-if="errorMessage" class="users-list__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
   </div>
 </template>
 
 <script>
-import { Heading, RouterLink, ListItem } from '@Components/atoms';
+import {
+  Heading,
+  RouterLink,
+  Text,
+} from '@Components/atoms';
 
 export default {
   components: {
     appHeading: Heading,
     appRouterLink: RouterLink,
-    appListItem: ListItem,
+    appText: Text,
   },
   props: {
-    targetArray: {
-      type: Array,
-      default: () => [],
-    },
-    access: {
-      type: Object,
-      default: () => ({}),
+    errorMessage: {
+      type: String,
+      default: '',
     },
   },
 };

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -1,0 +1,48 @@
+<template lang="html">
+  <div class="article-trashed">
+    <app-heading>削除済み記事一覧</app-heading>
+    <app-router-link
+      to="/articles"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-trashed__create-link"
+    >
+      すべての記事一覧へ戻る
+    </app-router-link>
+    <app-list-item />
+  </div>
+</template>
+
+<script>
+import { Heading, RouterLink, ListItem } from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+    appListItem: ListItem,
+  },
+  props: {
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+  .article-trashed {
+    &__create-link {
+      margin-top: 15px;
+    }
+  }
+</style>

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -13,10 +13,10 @@
     >
       すべての記事一覧へ戻る
     </app-router-link>
-    <div v-if="errorMessage" class="users-list__notice">
+    <div v-if="errorMessage" class="article-trashed__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
-
+    
   </div>
 </template>
 
@@ -45,6 +45,9 @@ export default {
 <style lang="postcss" scoped>
   .article-trashed {
     &__create-link {
+      margin-top: 15px;
+    }
+    &__notice {
       margin-top: 15px;
     }
   }

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -16,7 +16,6 @@
     <div v-if="errorMessage" class="article-trashed__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
-    
   </div>
 </template>
 

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -15,6 +15,7 @@ import ArticleEdit from './ArticleEdit';
 import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
 import ArticleTrashed from './ArticleTrashed';
+import ArticleTable from './ArticleTable';
 import DeleteModal from './Modal';
 import Notice from './Notice';
 
@@ -36,6 +37,7 @@ export {
   ArticlePost,
   ArticleDetail,
   ArticleTrashed,
+  ArticleTable,
   DeleteModal,
   Notice,
 };

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -14,6 +14,7 @@ import CategoryList from './CategoryList';
 import ArticleEdit from './ArticleEdit';
 import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
+import ArticleTrashed from './ArticleTrashed';
 import DeleteModal from './Modal';
 import Notice from './Notice';
 
@@ -34,6 +35,7 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrashed,
   DeleteModal,
   Notice,
 };

--- a/src/js/pages/Articles/Trashed.vue
+++ b/src/js/pages/Articles/Trashed.vue
@@ -4,7 +4,7 @@
       :error-message="errorMessage"
     />
     <app-article-table
-      v-if="articleList"
+      v-if="articleList.length"
       :target-array="articleList"
     />
   </div>

--- a/src/js/pages/Articles/Trashed.vue
+++ b/src/js/pages/Articles/Trashed.vue
@@ -4,6 +4,7 @@
       :error-message="errorMessage"
     />
     <app-article-table
+      v-if="articleList"
       :target-array="articleList"
     />
   </div>

--- a/src/js/pages/Articles/Trashed.vue
+++ b/src/js/pages/Articles/Trashed.vue
@@ -1,0 +1,13 @@
+<template lang="html">
+  <app-article-trashed />
+</template>
+
+<script>
+import { ArticleTrashed } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashed: ArticleTrashed,
+  },
+};
+</script>

--- a/src/js/pages/Articles/Trashed.vue
+++ b/src/js/pages/Articles/Trashed.vue
@@ -1,13 +1,32 @@
 <template lang="html">
-  <app-article-trashed />
+  <div>
+    <app-article-trashed
+      :error-message="errorMessage"
+    />
+    <app-article-table
+      :target-array="articleList"
+    />
+  </div>
 </template>
 
 <script>
-import { ArticleTrashed } from '@Components/molecules';
+import { ArticleTrashed, ArticleTable } from '@Components/molecules';
 
 export default {
   components: {
     appArticleTrashed: ArticleTrashed,
+    appArticleTable: ArticleTable,
+  },
+  computed: {
+    articleList() {
+      return this.$store.state.articles.articleList;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getTrashedArticles');
   },
 };
 </script>


### PR DESCRIPTION
## 作業内容
- 削除済み記事一覧ページの作成
- 削除済みの記事をリスト表示
- リストには、タイトル、本文、作成日を表示

## 動作確認
- 全ての一覧画面から「削除済み記事一覧」をクリックすると、削除済み記事一覧が表示される
- タイトル、本文は30文字まで表示し、それ以降のテキストは「...」で表示される
- 「すべての記事一覧へ戻る」をクリックすると、すべての一覧画面が表示される