### PR TITLE
ページネーション機能実装

### DIFF
--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -135,13 +135,13 @@ export default {
       commit('initPostArticle');
     },
     // アーティクルの全取得処理
-    getPageArticles({ commit, rootGetters }, pageNumber) {
+    getPageArticles({ commit, rootGetters }, pageNumber = 1) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/article?page=${pageNumber}`,
       }).then(({ data }) => {
         const pageNum = {
-          currentPage: pageNumber === undefined ? 1 : pageNumber,
+          currentPage: pageNumber,
           lastPage: data.meta.last_page,
         };
         // 取得した記事をstateに反映

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -31,7 +31,6 @@ export default {
     pageData: {
       currentPage: 'null',
       lastPage: 'null',
-      range: 5,
     },
   },
   getters: {

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -135,7 +135,7 @@ export default {
       commit('initPostArticle');
     },
     // アーティクルの全取得処理
-    getAllArticles({ commit, rootGetters }, pageNumber) {
+    getPageArticles({ commit, rootGetters }, pageNumber) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/article?page=${pageNumber}`,

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -127,10 +127,8 @@ export default {
     },
     // 取得したページ番号情報をstateに反映
     getPageNumber(state, { currentPage, lastPage }) {
-      state.pageData = Object.assign({}, { ...state.pageData }, {
-        currentPage: currentPage,
-        lastPage: lastPage,
-      });
+      state.pageData.currentPage = currentPage;
+      state.pageData.lastPage = lastPage;
     },
   },
   actions: {
@@ -142,7 +140,7 @@ export default {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/article?page=${pageNumber}`,
-      }).then(({data}) => {
+      }).then(({ data }) => {
         const pageNum = {
           currentPage: pageNumber === undefined ? 1 : pageNumber,
           lastPage: data.meta.last_page,

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -81,44 +81,10 @@
         削除
       </app-button>
     </app-modal>
-    <div class="pageNation">
-      <app-button
-        v-for="page in leftPageButton"
-        :key="page"
-        :disabled="targetButton(page) ? true : false"
-        @click="$emit('pageLoading', page)"
-      >
-        {{ page }}
-      </app-button>
-      <div
-        v-show="firstDot"
-        class="dot button"
-      >
-        …
-      </div>
-      <app-button
-        v-for="page in centerPageButton"
-        :key="page"
-        :disabled="targetButton(page) ? true : false"
-        @click="$emit('pageLoading', page)"
-      >
-        {{ page }}
-      </app-button>
-      <div
-        v-show="lastDot"
-        class="dot button"
-      >
-        …
-      </div>
-      <app-button
-        v-for="page in rightPageButton"
-        :key="page"
-        :disabled="targetButton(page) ? true : false"
-        @click="$emit('pageLoading', page)"
-      >
-        {{ page }}
-      </app-button>
-    </div>
+    <app-page-nation
+      :page-data="pageData"
+      @handle-page-button-click="handlePageButtonClick"
+    />
   </div>
 </template>
 
@@ -130,6 +96,7 @@ import {
   Button,
   Text,
 } from '@Components/atoms';
+import PageNation from '@Components/molecules/PageNation';
 
 export default {
   components: {
@@ -138,6 +105,7 @@ export default {
     appRouterLink: RouterLink,
     appButton: Button,
     appText: Text,
+    appPageNation: PageNation,
   },
   props: {
     className: {
@@ -169,13 +137,6 @@ export default {
       default: () => ({}),
     },
   },
-  data() {
-    return {
-      firstDot: false,
-      lastDot: false,
-      range: 5,
-    };
-  },
   computed: {
     articleTitle() {
       return `${this.title}の一覧`;
@@ -183,56 +144,17 @@ export default {
     buttonText() {
       return this.access.delete ? '削除' : '削除権限がありません';
     },
-    // 最初の2つのボタンを作る処理
-    leftPageButton() {
-      return this.pageArray(1, 2);
-    },
-    // 真ん中のボタンを作る処理
-    centerPageButton() {
-      let first;
-      let last;
-      const { currentPage, lastPage } = this.pageData;
-      const range = this.range;
-      if (currentPage <= range) {
-        first = 3;
-        last = range + 2;
-        this.dotchenge(false, true);
-      } else if (currentPage > lastPage - range) {
-        first = lastPage - range - 1;
-        last = lastPage - 2;
-        this.dotchenge(true, false);
-      } else {
-        first = currentPage - 2;
-        last = currentPage + 2;
-        this.dotchenge(true, true);
-      }
-      return this.pageArray(first, last);
-    },
-    // 最後の2つのボタンを作る処理
-    rightPageButton() {
-      return this.pageArray(this.pageData.lastPage - 1, this.pageData.lastPage);
-    },
   },
   methods: {
-    dotchenge(first, last) {
-      this.firstDot = first;
-      this.lastDot = last;
-    },
-    // ページ番号の配列を作る処理
-    pageArray(from, to) {
-      const pageNumber = [];
-      for (let i = from; i <= to; i += 1) {
-        pageNumber.push(i);
-      }
-      return pageNumber;
-    },
-    // 選択中のページを確認する処理(真偽地によってクラスを付与している)
-    targetButton(page) {
-      return page === this.pageData.currentPage;
-    },
     openModal(articleId) {
       if (!this.access.delete) return;
       this.$emit('openModal', articleId);
+    },
+    handlePageButtonClick(id) {
+      this.$router.push({
+        path: '/articles',
+        query: { page: id },
+      });
     },
   },
 };
@@ -262,18 +184,6 @@ export default {
     }
     &__notice--create {
       margin-bottom: 16px;
-    }
-    .pageNation {
-      text-align: center;
-      margin-top: 50px;
-      .dot {
-        display: inline-block;
-        padding: 8px 10px;
-        font-size: 16px;
-      }
-      .button {
-        margin-left: 10px;
-      }
     }
   }
 </style>

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -173,6 +173,7 @@ export default {
     return {
       firstDot: false,
       lastDot: false,
+      range: 5,
     };
   },
   computed: {
@@ -190,7 +191,8 @@ export default {
     centerPageButton() {
       let first;
       let last;
-      const { currentPage, lastPage, range } = this.pageData;
+      const { currentPage, lastPage } = this.pageData;
+      const range = this.range;
       if (currentPage <= range) {
         first = 3;
         last = range + 2;

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -81,6 +81,44 @@
         削除
       </app-button>
     </app-modal>
+    <div class="pageNation">
+      <app-button
+        v-for="page in leftPageButton"
+        :key="page"
+        @click="$emit('pageLoading', page)"
+        :disabled="targetButton(page) ? true : false"
+      >
+        {{ page }}
+      </app-button>
+      <div
+        class="dot button"
+        v-show="this.firstDot"
+      >
+        …
+      </div>
+      <app-button
+        v-for="page in centerPageButton"
+        :key="page"
+        @click="$emit('pageLoading', page)"
+        :disabled="targetButton(page) ? true : false"
+      >
+        {{ page }}
+      </app-button>
+      <div
+        class="dot button"
+        v-show="this.lastDot"
+      >
+        …
+      </div>
+      <app-button
+        v-for="page in rightPageButton"
+        :key="page"
+        @click="$emit('pageLoading', page)"
+        :disabled="targetButton(page) ? true : false"
+      >
+        {{ page }}
+      </app-button>
+    </div>
   </div>
 </template>
 
@@ -100,6 +138,12 @@ export default {
     appRouterLink: RouterLink,
     appButton: Button,
     appText: Text,
+  },
+  data() {
+    return {
+      firstDot: false,
+      lastDot: false
+    }
   },
   props: {
     className: {
@@ -126,6 +170,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    pageData: {
+      type: Object,
+      default: () => ({}),
+    }
   },
   computed: {
     articleTitle() {
@@ -134,8 +182,50 @@ export default {
     buttonText() {
       return this.access.delete ? '削除' : '削除権限がありません';
     },
+    // 最初の2つのボタンを作る処理
+    leftPageButton() {
+      return this.pageArray(1, 2);
+    },
+    // 真ん中のボタンを作る処理
+    centerPageButton() {
+      let first;
+      let last;
+      if (this.pageData.currentPage <= this.pageData.range) {
+        first = 3;
+        last = this.pageData.range + 2;
+        this.firstDot = false;
+        this.lastDot = true;
+      } else if (this.pageData.currentPage > this.pageData.lastPage - this.pageData.range) {
+        first = this.pageData.lastPage - this.pageData.range - 1;
+        last = this.pageData.lastPage - 2;
+        this.firstDot = true;
+        this.lastDot = false;
+      } else {
+        first = this.pageData.currentPage - 2;
+        last = this.pageData.currentPage + 2;
+        this.firstDot = true;
+        this.lastDot = true;
+      }
+      return this.pageArray(first, last);
+    },
+    // 最後の2つのボタンを作る処理
+    rightPageButton() {
+      return this.pageArray(this.pageData.lastPage - 1, this.pageData.lastPage);
+    }
   },
   methods: {
+    // ページ番号の配列を作る処理
+    pageArray(from, to) {
+      const pageNumber = [];
+      for (let i = from; i <= to; i++) {
+        pageNumber.push(i);
+      }
+      return pageNumber;
+    },
+    // 選択中のページを確認する処理(真偽地によってクラスを付与している)
+    targetButton(page) {
+      return page === this.pageData.currentPage;
+    },
     openModal(articleId) {
       if (!this.access.delete) return;
       this.$emit('openModal', articleId);
@@ -168,6 +258,18 @@ export default {
     }
     &__notice--create {
       margin-bottom: 16px;
+    }
+    .pageNation {
+      text-align: center;
+      margin-top: 50px;
+      .dot {
+        display: inline-block;
+        padding: 8px 10px;
+        font-size: 16px;
+      }
+      .button {
+        margin-left: 10px;
+      }
     }
   }
 </style>

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -85,36 +85,36 @@
       <app-button
         v-for="page in leftPageButton"
         :key="page"
-        @click="$emit('pageLoading', page)"
         :disabled="targetButton(page) ? true : false"
+        @click="$emit('pageLoading', page)"
       >
         {{ page }}
       </app-button>
       <div
+        v-show="firstDot"
         class="dot button"
-        v-show="this.firstDot"
       >
         …
       </div>
       <app-button
         v-for="page in centerPageButton"
         :key="page"
-        @click="$emit('pageLoading', page)"
         :disabled="targetButton(page) ? true : false"
+        @click="$emit('pageLoading', page)"
       >
         {{ page }}
       </app-button>
       <div
+        v-show="lastDot"
         class="dot button"
-        v-show="this.lastDot"
       >
         …
       </div>
       <app-button
         v-for="page in rightPageButton"
         :key="page"
-        @click="$emit('pageLoading', page)"
         :disabled="targetButton(page) ? true : false"
+        @click="$emit('pageLoading', page)"
       >
         {{ page }}
       </app-button>
@@ -138,12 +138,6 @@ export default {
     appRouterLink: RouterLink,
     appButton: Button,
     appText: Text,
-  },
-  data() {
-    return {
-      firstDot: false,
-      lastDot: false
-    }
   },
   props: {
     className: {
@@ -173,7 +167,13 @@ export default {
     pageData: {
       type: Object,
       default: () => ({}),
-    }
+    },
+  },
+  data() {
+    return {
+      firstDot: false,
+      lastDot: false,
+    };
   },
   computed: {
     articleTitle() {
@@ -190,34 +190,36 @@ export default {
     centerPageButton() {
       let first;
       let last;
-      if (this.pageData.currentPage <= this.pageData.range) {
+      const { currentPage, lastPage, range } = this.pageData;
+      if (currentPage <= range) {
         first = 3;
-        last = this.pageData.range + 2;
-        this.firstDot = false;
-        this.lastDot = true;
-      } else if (this.pageData.currentPage > this.pageData.lastPage - this.pageData.range) {
-        first = this.pageData.lastPage - this.pageData.range - 1;
-        last = this.pageData.lastPage - 2;
-        this.firstDot = true;
-        this.lastDot = false;
+        last = range + 2;
+        this.dotchenge(false, true);
+      } else if (currentPage > lastPage - range) {
+        first = lastPage - range - 1;
+        last = lastPage - 2;
+        this.dotchenge(true, false);
       } else {
-        first = this.pageData.currentPage - 2;
-        last = this.pageData.currentPage + 2;
-        this.firstDot = true;
-        this.lastDot = true;
+        first = currentPage - 2;
+        last = currentPage + 2;
+        this.dotchenge(true, true);
       }
       return this.pageArray(first, last);
     },
     // 最後の2つのボタンを作る処理
     rightPageButton() {
       return this.pageArray(this.pageData.lastPage - 1, this.pageData.lastPage);
-    }
+    },
   },
   methods: {
+    dotchenge(first, last) {
+      this.firstDot = first;
+      this.lastDot = last;
+    },
     // ページ番号の配列を作る処理
     pageArray(from, to) {
       const pageNumber = [];
-      for (let i = from; i <= to; i++) {
+      for (let i = from; i <= to; i += 1) {
         pageNumber.push(i);
       }
       return pageNumber;

--- a/src/js/components/molecules/CategoryUpdate/index.vue
+++ b/src/js/components/molecules/CategoryUpdate/index.vue
@@ -85,7 +85,6 @@ export default {
   methods: {
     // 更新ボタンのクリック処理
     updateCategory() {
-      console.log("submit");
       if (!this.access.create) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {

--- a/src/js/components/molecules/PageNation/index.vue
+++ b/src/js/components/molecules/PageNation/index.vue
@@ -13,7 +13,7 @@
       </app-button>
     </li>
     <li
-      v-show="firstDot"
+      v-show="firstDotChenge"
       class="dot button"
     >
       …
@@ -31,7 +31,7 @@
       </app-button>
     </li>
     <li
-      v-show="lastDot"
+      v-show="lastDotChenge"
       class="dot button"
     >
       …
@@ -66,8 +66,6 @@ export default {
   },
   data() {
     return {
-      firstDot: false,
-      lastDot: false,
       range: 5,
     };
   },
@@ -101,21 +99,32 @@ export default {
     isCurrentPage() {
       return page => this.pageData.currentPage === page;
     },
-  },
-  created() {
-    if (this.pageData.currentPage <= this.range) {
-      this.dotchenge(false, true);
-    } else if (this.pageData.currentPage > this.pageData.lastPage - this.range) {
-      this.dotchenge(true, false);
-    } else {
-      this.dotchenge(true, true);
-    }
+    // 最初のdotを表示するかしないかの判定
+    firstDotChenge() {
+      let firstDot;
+      if (this.pageData.currentPage <= this.range) {
+        firstDot = false;
+      } else if (this.pageData.currentPage > this.pageData.lastPage - this.range) {
+        firstDot = true;
+      } else {
+        firstDot = true;
+      }
+      return firstDot;
+    },
+    // 最後のdotを表示するかしないかの判定
+    lastDotChenge() {
+      let lastDot;
+      if (this.pageData.currentPage <= this.range) {
+        lastDot = true;
+      } else if (this.pageData.currentPage > this.pageData.lastPage - this.range) {
+        lastDot = false;
+      } else {
+        lastDot = true;
+      }
+      return lastDot;
+    },
   },
   methods: {
-    dotchenge(first, last) {
-      this.firstDot = first;
-      this.lastDot = last;
-    },
     // ページ番号の配列を作る処理
     pageArray(from, to) {
       const pageNumber = [];

--- a/src/js/components/molecules/PageNation/index.vue
+++ b/src/js/components/molecules/PageNation/index.vue
@@ -1,0 +1,147 @@
+<template lang="html">
+  <ul class="pageNation">
+    <li
+      v-for="page in leftPageButton"
+      :key="page"
+      class="pageNation_item"
+    >
+      <app-button
+        :disabled="isCurrentPage(page)"
+        @click="$emit('handle-page-button-click', page)"
+      >
+        {{ page }}
+      </app-button>
+    </li>
+    <li
+      v-show="firstDot"
+      class="dot button"
+    >
+      …
+    </li>
+    <li
+      v-for="page in centerPageButton"
+      :key="page"
+      class="pageNation_item"
+    >
+      <app-button
+        :disabled="isCurrentPage(page)"
+        @click="$emit('handle-page-button-click', page)"
+      >
+        {{ page }}
+      </app-button>
+    </li>
+    <li
+      v-show="lastDot"
+      class="dot button"
+    >
+      …
+    </li>
+    <li
+      v-for="page in rightPageButton"
+      :key="page"
+      class="pageNation_item"
+    >
+      <app-button
+        :disabled="isCurrentPage(page)"
+        @click="$emit('handle-page-button-click', page)"
+      >
+        {{ page }}
+      </app-button>
+    </li>
+  </ul>
+</template>
+
+<script>
+import { Button } from '@Components/atoms';
+
+export default {
+  components: {
+    appButton: Button,
+  },
+  props: {
+    pageData: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      firstDot: false,
+      lastDot: false,
+      range: 5,
+    };
+  },
+  computed: {
+    // 最初の2つのボタンを作る処理
+    leftPageButton() {
+      return this.pageArray(1, 2);
+    },
+    // 真ん中のボタンを作る処理
+    centerPageButton() {
+      let first;
+      let last;
+      const { currentPage, lastPage } = this.pageData;
+      if (currentPage <= this.range) {
+        first = 3;
+        last = this.range + 2;
+      } else if (currentPage > lastPage - this.range) {
+        first = lastPage - this.range - 1;
+        last = lastPage - 2;
+      } else {
+        first = currentPage - 2;
+        last = currentPage + 2;
+      }
+      return this.pageArray(first, last);
+    },
+    // 最後の2つのボタンを作る処理
+    rightPageButton() {
+      return this.pageArray(this.pageData.lastPage - 1, this.pageData.lastPage);
+    },
+    // 現在のページかどうか判定する処理
+    isCurrentPage() {
+      return page => this.pageData.currentPage === page;
+    },
+  },
+  created() {
+    if (this.pageData.currentPage <= this.range) {
+      this.dotchenge(false, true);
+    } else if (this.pageData.currentPage > this.pageData.lastPage - this.range) {
+      this.dotchenge(true, false);
+    } else {
+      this.dotchenge(true, true);
+    }
+  },
+  methods: {
+    dotchenge(first, last) {
+      this.firstDot = first;
+      this.lastDot = last;
+    },
+    // ページ番号の配列を作る処理
+    pageArray(from, to) {
+      const pageNumber = [];
+      for (let i = from; i <= to; i += 1) {
+        pageNumber.push(i);
+      }
+      return pageNumber;
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+  .pageNation {
+    text-align: center;
+    margin-top: 50px;
+    &_item {
+      display: inline-block;
+    }
+    .dot {
+      display: inline-block;
+      padding: 8px 10px;
+      font-size: 16px;
+    }
+    .button {
+      margin-left: 10px;
+    }
+  }
+</style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -16,6 +16,7 @@ import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
 import DeleteModal from './Modal';
 import Notice from './Notice';
+import PageNation from './PageNation';
 
 export {
   SigninForm,
@@ -36,4 +37,5 @@ export {
   ArticleDetail,
   DeleteModal,
   Notice,
+  PageNation,
 };

--- a/src/js/pages/Articles/List.vue
+++ b/src/js/pages/Articles/List.vue
@@ -75,7 +75,7 @@ export default {
             // console.log(err);
           });
       } else {
-        this.$store.dispatch('articles/getAllArticles');
+        this.$store.dispatch('articles/getPageArticles');
       }
     },
     // created後にデータを取得するための処理
@@ -92,7 +92,7 @@ export default {
             // console.log(err);
           });
       } else {
-        this.$store.dispatch('articles/getAllArticles', id);
+        this.$store.dispatch('articles/getPageArticles', id);
       }
     },
 

--- a/src/js/pages/Articles/List.vue
+++ b/src/js/pages/Articles/List.vue
@@ -5,7 +5,7 @@
       :target-array="articlesList"
       :done-message="doneMessage"
       :access="access"
-      :pageData="pageData"
+      :page-data="pageData"
       border-gray
       @openModal="openModal"
       @handleClick="handleClick"
@@ -45,7 +45,7 @@ export default {
     },
     pageData() {
       return this.$store.state.articles.pageData;
-    }
+    },
   },
   created() {
     this.fetchArticles(this.$route.query.page ? Number(this.$route.query.page) : 1);
@@ -99,9 +99,9 @@ export default {
     pageLoading(id) {
       this.$router.push({
         path: '/articles',
-        query: { page: id }
-      })
-    }
+        query: { page: id },
+      });
+    },
   },
 };
 </script>

--- a/src/js/pages/Articles/List.vue
+++ b/src/js/pages/Articles/List.vue
@@ -9,7 +9,6 @@
       border-gray
       @openModal="openModal"
       @handleClick="handleClick"
-      @pageLoading="pageLoading"
     />
   </div>
 </template>
@@ -94,13 +93,6 @@ export default {
       } else {
         this.$store.dispatch('articles/getPageArticles', id);
       }
-    },
-
-    pageLoading(id) {
-      this.$router.push({
-        path: '/articles',
-        query: { page: id },
-      });
     },
   },
 };

--- a/src/js/pages/Home/index.vue
+++ b/src/js/pages/Home/index.vue
@@ -19,7 +19,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('articles/getAllArticles');
+    this.$store.dispatch('articles/getPageArticles');
   },
 };
 </script>


### PR DESCRIPTION
## 作業内容
- ページネーションの追加
- ページ遷移後にクエリーパラメータを付与
- 遷移した後のページ情報をAxiosで通信を行い再表示
- 現在いるページのページネーションスタイルの変更
## 動作確認
- 指定したページの情報を取得できる
- リロードをした時リロード前にいたページを再表示