### PR TITLE
削除済み一覧の実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -17,6 +17,7 @@ import ArticleList from '@Pages/Articles/List';
 import ArticleDetail from '@Pages/Articles/Detail';
 import ArticleEdit from '@Pages/Articles/Edit';
 import ArticlePost from '@Pages/Articles/Post';
+import ArticleTrashed from '@Pages/Articles/trashed';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile';
@@ -114,6 +115,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -24,6 +24,7 @@ export default {
       },
     },
     articleList: [],
+    articleTrashedList: [],
     deleteArticleId: null,
     loading: false,
     doneMessage: '',
@@ -89,6 +90,9 @@ export default {
     },
     doneGetAllArticles(state, payload) {
       state.articleList = [...payload.articles];
+    },
+    doneGetArticleTrashed(state, payload) {
+      state.articleTrashedList = payload;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
@@ -163,6 +167,16 @@ export default {
           commit('failRequest', { message: err.message });
           reject();
         });
+      });
+    },
+    getArticleTrashed({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(({ data }) => {
+        commit('doneGetArticleTrashed', data.articles);
+      }).catch((err) => {
+        commit('failRequest', { message: err.message });
       });
     },
     editedTitle({ commit }, title) {

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-danger
+      small
+      round
+      hover-opacity
+      class="article-list__create-link"
+    >
+      削除済みの記事
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"

--- a/src/js/components/molecules/ArticleTrashedHead/index.vue
+++ b/src/js/components/molecules/ArticleTrashedHead/index.vue
@@ -1,0 +1,36 @@
+<template lang="html">
+  <div class="trashed-head">
+    <app-heading :level="1">削除済み記事一覧</app-heading>
+    <app-router-link
+      to="/articles"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="trashed-head__create-link"
+    >
+      すべての記事一覧へ戻る
+    </app-router-link>
+  </div>
+</template>
+
+<script>
+import { Heading, RouterLink } from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+.trashed-head {
+  &__create-link {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/js/components/molecules/ArticleTrashedTable/index.vue
+++ b/src/js/components/molecules/ArticleTrashedTable/index.vue
@@ -1,0 +1,94 @@
+<template lang="html">
+  <table class="trashed-table">
+    <thead class="trashed-table__head">
+      <tr>
+        <th v-for="(thead, index) in theads" :key="index">
+          <app-text
+            tag="span"
+            theme-color
+            bold
+          >
+            {{ thead }}
+          </app-text>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="trashed-table__body">
+      <tr v-for="trashed in trashedList" :key="trashed.id">
+        <td>
+          <app-text
+            tag="span"
+          >
+            {{ cutText(trashed.title) }}
+          </app-text>
+        </td>
+        <td>
+          <app-text
+            tag="span"
+          >
+            {{ cutText(trashed.content) }}
+          </app-text>
+        </td>
+        <td>
+          <app-text
+            tag="span"
+          >
+            {{ formatDate(trashed.created_at) }}
+          </app-text>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import { Text } from '@Components/atoms';
+
+export default {
+  components: {
+    appText: Text,
+  },
+  props: {
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+    trashedList: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    cutText() {
+      return text => (text.length >= 30 ? `${text.slice(0, 30)}...` : text);
+    },
+    formatDate() {
+      return data => data.slice(0, 10);
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+.trashed-table {
+  width: 100%;
+  text-align: left;
+  background-color: #fff;
+  margin-top: 16px;
+  tr {
+    border-bottom: 1px solid var(--separatorColor);
+  }
+  &__head {
+    th {
+      padding: 5px 10px;
+      vertical-align: middle;
+    }
+  }
+  &__body {
+    td {
+      padding: 10px;
+      vertical-align: middle;
+    }
+  }
+}
+</style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -14,6 +14,8 @@ import CategoryUpdate from './CategoryUpdate';
 import ArticleEdit from './ArticleEdit';
 import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
+import ArticleTrashedTable from './ArticleTrashedTable';
+import ArticleTrashedHead from './ArticleTrashedHead';
 import DeleteModal from './Modal';
 import Notice from './Notice';
 
@@ -34,6 +36,8 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrashedTable,
+  ArticleTrashedHead,
   DeleteModal,
   Notice,
 };

--- a/src/js/pages/Articles/trashed.vue
+++ b/src/js/pages/Articles/trashed.vue
@@ -3,7 +3,7 @@
     <app-article-trashed-head />
     <app-article-trashed-table
       :theads="theads"
-      :trashe-list="trashedList"
+      :trashed-list="trashedList"
     />
   </div>
 </template>

--- a/src/js/pages/Articles/trashed.vue
+++ b/src/js/pages/Articles/trashed.vue
@@ -1,0 +1,33 @@
+<template lang="html">
+  <div class="article_trashed">
+    <app-article-trashed-head />
+    <app-article-trashed-table
+      :theads="theads"
+      :trashe-list="trashedList"
+    />
+  </div>
+</template>
+
+<script>
+import { ArticleTrashedTable, ArticleTrashedHead } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashedHead: ArticleTrashedHead,
+    appArticleTrashedTable: ArticleTrashedTable,
+  },
+  data() {
+    return {
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    trashedList() {
+      return this.$store.state.articles.articleTrashedList;
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getArticleTrashed');
+  },
+};
+</script>


### PR DESCRIPTION
## 実装項目
- 削除済み一覧ページの制作
- 削除済み内容の取得
- 記事一覧ページへのボタンの制作

## 動作確認
- 記事タイトルと本文を30文字以上の場合...で表記するように実装
- 記事一覧ページへのボタンクリックによりページの遷移