### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home';
 // カテゴリー
 import Categories from '@Pages/Categories';
 import CategoriesList from '@Pages/Categories/List';
+import CategoriesEdit from '@Pages/Categories/Edit';
 
 // 記事
 import Articles from '@Pages/Articles';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'CategoriesList',
           path: '',
           component: CategoriesList,
+        },
+        {
+          name: 'CategoriesEdit',
+          path: ':id',
+          component: CategoriesEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,6 +10,7 @@ export default {
     loading: false,
     deleteCategoryId: null,
     deleteCategoryName: '',
+    editCategoryName: '',
   },
 
   mutations: {
@@ -42,6 +43,9 @@ export default {
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
+    },
+    getCategory(state, payload) {
+      state.editCategoryName = payload;
     },
   },
   actions: {
@@ -102,6 +106,18 @@ export default {
     },
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
+    getCategory({ commit, rootGetters }, categoryId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(({ data }) => {
+        console.log(data.category.name);
+        commit('getCategory', data.category.name);
+      }).catch((err) => {
+        const errTxt = err.message;
+        commit('failRequest', errTxt);
+      });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -132,22 +132,19 @@ export default {
     updateCategoryName({ commit, rootGetters, state }) {
       commit('clearMessage');
       commit('toggleLoading');
-      return new Promise((resolve) => {
-        const data = new URLSearchParams();
-        data.append('name', state.editCategory.name);
-        axios(rootGetters['auth/token'])({
-          method: 'PUT',
-          url: `/category/${state.editCategory.id}`,
-          data,
-        }).then(() => {
-          commit('toggleLoading');
-          commit('displayDoneMessage', { message: 'カテゴリー名を更新しました' });
-          resolve();
-        }).catch((err) => {
-          commit('toggleLoading');
-          const errTxt = err.message;
-          commit('failRequest', errTxt);
-        });
+      const data = new URLSearchParams();
+      data.append('name', state.editCategory.name);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.editCategory.id}`,
+        data,
+      }).then(() => {
+        commit('toggleLoading');
+        commit('displayDoneMessage', { message: 'カテゴリー名を更新しました' });
+      }).catch((err) => {
+        commit('toggleLoading');
+        const errTxt = err.message;
+        commit('failRequest', errTxt);
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,7 +10,10 @@ export default {
     loading: false,
     deleteCategoryId: null,
     deleteCategoryName: '',
-    editCategoryName: '',
+    editCategory: {
+      id: null,
+      name: '',
+    },
   },
 
   mutations: {
@@ -44,8 +47,12 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
     },
-    getCategory(state, payload) {
-      state.editCategoryName = payload;
+    getCategory(state, { categoryId, getName }) {
+      state.editCategory.id = categoryId;
+      state.editCategory.name = getName;
+    },
+    updateCategoryName(state, payload) {
+      state.updateCategoryName = payload;
     },
   },
   actions: {
@@ -112,11 +119,34 @@ export default {
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then(({ data }) => {
-        console.log(data.category.name);
-        commit('getCategory', data.category.name);
+        const getName = data.category.name;
+        commit('getCategory', { categoryId, getName });
       }).catch((err) => {
         const errTxt = err.message;
         commit('failRequest', errTxt);
+      });
+    },
+    updateCategoryName({ commit, rootGetters, state }) {
+      commit('clearMessage');
+      commit('toggleLoading');
+      return new Promise((resolve) => {
+        const data = new URLSearchParams();
+        data.append('name', state.editCategory.name);
+        axios(rootGetters['auth/token'])({
+          method: 'PUT',
+          url: `/categories/${state.editCategory.id}`,
+          data,
+        }).then((res) => {
+          commit('toggleLoading');
+          console.log(res);
+          const payload = res.data.categoryName;
+          commit('updateCategoryName', payload);
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          const errTxt = err.message;
+          commit('failRequest', errTxt);
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -51,8 +51,8 @@ export default {
       state.editCategory.id = categoryId;
       state.editCategory.name = getName;
     },
-    updateCategoryName(state, payload) {
-      state.updateCategoryName = payload;
+    updateEditValue(state, payload) {
+      state.editCategory.name = payload;
     },
   },
   actions: {
@@ -126,6 +126,9 @@ export default {
         commit('failRequest', errTxt);
       });
     },
+    updateEditValue({ commit }, $event) {
+      commit('updateEditValue', $event);
+    },
     updateCategoryName({ commit, rootGetters, state }) {
       commit('clearMessage');
       commit('toggleLoading');
@@ -134,13 +137,11 @@ export default {
         data.append('name', state.editCategory.name);
         axios(rootGetters['auth/token'])({
           method: 'PUT',
-          url: `/categories/${state.editCategory.id}`,
+          url: `/category/${state.editCategory.id}`,
           data,
-        }).then((res) => {
+        }).then(() => {
           commit('toggleLoading');
-          console.log(res);
-          const payload = res.data.categoryName;
-          commit('updateCategoryName', payload);
+          commit('displayDoneMessage', { message: 'カテゴリー名を更新しました' });
           resolve();
         }).catch((err) => {
           commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -47,9 +47,9 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
     },
-    getCategory(state, { categoryId, getName }) {
+    setCategoryDetail(state, { categoryId, categoryName }) {
       state.editCategory.id = categoryId;
-      state.editCategory.name = getName;
+      state.editCategory.name = categoryName;
     },
     updateEditValue(state, payload) {
       state.editCategory.name = payload;
@@ -89,8 +89,8 @@ export default {
         });
       });
     },
-    updateValue({ commit }, $event) {
-      commit('updateValue', $event);
+    updateValue({ commit }, inputText) {
+      commit('updateValue', inputText);
     },
     clearMessage({ commit }) {
       commit('clearMessage');
@@ -114,20 +114,20 @@ export default {
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
     },
-    getCategory({ commit, rootGetters }, categoryId) {
+    getCategoryDetail({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then(({ data }) => {
-        const getName = data.category.name;
-        commit('getCategory', { categoryId, getName });
+        const categoryName = data.category.name;
+        commit('setCategoryDetail', { categoryId, categoryName });
       }).catch((err) => {
         const errTxt = err.message;
         commit('failRequest', errTxt);
       });
     },
-    updateEditValue({ commit }, $event) {
-      commit('updateEditValue', $event);
+    updateEditValue({ commit }, inputText) {
+      commit('updateEditValue', inputText);
     },
     updateCategoryName({ commit, rootGetters, state }) {
       commit('clearMessage');

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <form @submit.prevent="addCategory">
+  <form @submit.prevent="updateCategoryName">
     <app-heading :level="1">カテゴリー管理</app-heading>
     <app-router-link
       class="category-edit"
@@ -19,7 +19,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="editCategoryName"
-      @updateValue="$emit('updateValue', $event)"
+      @updateValue="$emit('editCategory', $event)"
     />
     <app-button
       class="category-edit__submit"
@@ -74,7 +74,7 @@ export default {
       default: () => ({}),
     },
     editCategoryName: {
-      // type:string,
+      type: String,
       default: '',
     },
   },
@@ -85,11 +85,11 @@ export default {
     },
   },
   methods: {
-    addCategory() {
-      if (!this.access.create) return;
+    updateCategoryName() {
+      if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('handleSubmit');
+        if (valid) this.$emit('updateCategoryName');
       });
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -1,11 +1,9 @@
 <template lang="html">
-  <form @submit.prevent="updateCategoryName">
+  <form @submit.prevent="handleSubmit">
     <app-heading :level="1">カテゴリー管理</app-heading>
     <app-router-link
       class="category-edit"
-      block
       underline
-      key-color
       hover-opacity
       to="/categories"
     >
@@ -19,7 +17,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="editCategoryName"
-      @updateValue="$emit('editCategory', $event)"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-edit__submit"
@@ -53,10 +51,6 @@ export default {
     appRouterLink: RouterLink,
   },
   props: {
-    category: {
-      type: String,
-      default: '',
-    },
     errorMessage: {
       type: String,
       default: '',
@@ -85,11 +79,11 @@ export default {
     },
   },
   methods: {
-    updateCategoryName() {
+    handleSubmit() {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('updateCategoryName');
+        if (valid) this.$emit('handleSubmit');
       });
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,111 @@
+<template lang="html">
+  <form @submit.prevent="addCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      class="category-edit"
+      block
+      underline
+      key-color
+      hover-opacity
+      to="/categories"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      name="category"
+      type="text"
+      placeholder="更新するカテゴリー名を入力してください"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="editCategoryName"
+      @updateValue="$emit('updateValue', $event)"
+    />
+    <app-button
+      class="category-edit__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.edit"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    category: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    editCategoryName: {
+      // type:string,
+      default: '',
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    addCategory() {
+      if (!this.access.create) return;
+      this.$emit('clearMessage');
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('handleSubmit');
+      });
+    },
+  },
+};
+</script>
+<style lang="postcss" scoped>
+.category-edit {
+  margin-top: 16px;
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail';
 import UserList from './UserList';
 import CategoryPost from './CategoryPost';
 import CategoryList from './CategoryList';
+import CategoryEdit from './CategoryEdit';
 import ArticleEdit from './ArticleEdit';
 import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,0 +1,47 @@
+<template lang="html">
+  <app-category-edit
+    :access="access"
+    :category="categoryName"
+    :done-message="doneMessage"
+    :error-message="errorMessage"
+    :disabled="loading"
+    :editCategoryName="editCategoryName"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    categoryName() {
+      return this.$store.state.categories.targetCategory;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    editCategoryName() {
+      return this.$store.state.categories.editCategoryName;
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategory', id);
+  },
+
+
+};
+</script>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,14 +1,13 @@
 <template lang="html">
   <app-category-edit
     :access="access"
-    :category="categoryName"
     :done-message="doneMessage"
     :error-message="errorMessage"
     :disabled="loading"
     :edit-category-name="editCategoryName"
     @clearMessage="clearMessage"
-    @editCategory="editCategory"
-    @updateCategoryName="updateCategoryName"
+    @updateValue="updateValue"
+    @handleSubmit="handleSubmit"
   />
 </template>
 
@@ -23,9 +22,6 @@ export default {
   computed: {
     access() {
       return this.$store.getters['auth/access'];
-    },
-    categoryName() {
-      return this.$store.state.categories.targetCategory;
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
@@ -49,10 +45,13 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    editCategory($event) {
-      this.$store.dispatch('categories/editCategory', $event.target.value);
+    updateValue($event) {
+      this.$store.dispatch('categories/updateEditValue', $event.target.value);
     },
-    updateCategoryName() {
+    handleSubmit() {
+      if (this.loading) {
+        return;
+      }
       this.$store.dispatch('categories/updateCategoryName')
         .then(() => {
           this.$store.dispatch('categories/getAllCategories');

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -39,14 +39,14 @@ export default {
   created() {
     this.clearMessage();
     const { id } = this.$route.params;
-    this.$store.dispatch('categories/getCategory', id);
+    this.$store.dispatch('categories/getCategoryDetail', id);
   },
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    updateValue($event) {
-      this.$store.dispatch('categories/updateEditValue', $event.target.value);
+    updateValue(inputEvent) {
+      this.$store.dispatch('categories/updateEditValue', inputEvent.target.value);
     },
     handleSubmit() {
       if (this.loading) {

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -52,10 +52,7 @@ export default {
       if (this.loading) {
         return;
       }
-      this.$store.dispatch('categories/updateCategoryName')
-        .then(() => {
-          this.$store.dispatch('categories/getAllCategories');
-        });
+      this.$store.dispatch('categories/updateCategoryName');
     },
   },
 

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -5,7 +5,10 @@
     :done-message="doneMessage"
     :error-message="errorMessage"
     :disabled="loading"
-    :editCategoryName="editCategoryName"
+    :edit-category-name="editCategoryName"
+    @clearMessage="clearMessage"
+    @editCategory="editCategory"
+    @updateCategoryName="updateCategoryName"
   />
 </template>
 
@@ -34,12 +37,27 @@ export default {
       return this.$store.state.categories.loading;
     },
     editCategoryName() {
-      return this.$store.state.categories.editCategoryName;
+      return this.$store.state.categories.editCategory.name;
     },
   },
   created() {
+    this.clearMessage();
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategory', id);
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    editCategory($event) {
+      this.$store.dispatch('categories/editCategory', $event.target.value);
+    },
+    updateCategoryName() {
+      this.$store.dispatch('categories/updateCategoryName')
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+    },
   },
 
 

--- a/src/js/pages/Categories/List.vue
+++ b/src/js/pages/Categories/List.vue
@@ -62,6 +62,7 @@ export default {
     },
   },
   created() {
+    this.clearMessage();
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {


### PR DESCRIPTION
### チケット
https://gizumo.backlog.com/view/GIZFE-391
### 作業内容
カテゴリー名編集画面作成
元カテゴリー名の取得
更新API実行
一覧更新、メッセージ表示
### 動作確認
- カテゴリー編集画面にて元カテゴリー名の表示
- 文字の編集内容のstateへの反映
- 更新後、一覧取得、新カテゴリー名への変更
- エラーメッセージの表示