### PR TITLE
カテゴリー新規作成

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,13 +5,32 @@ export default {
   state: {
     categoriesList: [],
     errorMessage: '',
+    targetCategory: '',
+    doneMessage: '',
+    loading: false,
   },
   mutations: {
+    resetTargetCategory(state) {
+      state.targetCategory = '';
+    },
     putCategoriesList(state, payload) {
       state.categoriesList = payload;
     },
     failRequest(state, payload) {
       state.errorMessage = payload;
+    },
+    updateValue(state, payload) {
+      state.targetCategory = payload;
+    },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
+    displayDoneMessage(state, { message }) {
+      state.doneMessage = message;
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
     },
   },
   actions: {
@@ -25,6 +44,34 @@ export default {
         const errTxt = err.message;
         commit('failRequest', errTxt);
       });
+    },
+    updateValue({ commit }, $event) {
+      commit('updateValue', $event);
+    },
+    postCategory({ commit, rootGetters, state }) {
+      commit('clearMessage');
+      commit('toggleLoading');
+      return new Promise((resolve) => {
+        const data = new URLSearchParams();
+        data.append('name', state.targetCategory);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          commit('resetTargetCategory');
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          const errTxt = err.message;
+          commit('failRequest', errTxt);
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @updateValue="$emit('udpateValue', $event)"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/js/pages/Categories/List.vue
+++ b/src/js/pages/Categories/List.vue
@@ -3,7 +3,7 @@
     <app-category-Post
       class="categories__post"
       :access="access"
-      :error-messages="errorMessage"
+      :error-message="errorMessage"
       :category="categoryName"
       :done-message="doneMessage"
       :disabled="loading"

--- a/src/js/pages/Categories/List.vue
+++ b/src/js/pages/Categories/List.vue
@@ -2,7 +2,14 @@
   <div class="categories">
     <app-category-Post
       class="categories__post"
-      :errorMessage="errorMessage"
+      :access="access"
+      :error-messages="errorMessage"
+      :category="categoryName"
+      :done-message="doneMessage"
+      :disabled="loading"
+      @updateValue="updateValue"
+      @handleSubmit="handleSubmit"
+      @clearMessage="clearMessage"
     />
     <app-category-List
       class="categories__list"
@@ -26,15 +33,43 @@ export default {
     };
   },
   computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
     categoriesList() {
       return this.$store.state.categories.categoriesList;
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    categoryName() {
+      return this.$store.state.categories.targetCategory;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
   },
   created() {
     this.$store.dispatch('categories/getCategoriesList');
+  },
+  methods: {
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) {
+        return;
+      }
+      this.$store.dispatch('categories/postCategory').then(() => {
+        this.$store.dispatch('categories/getCategoriesList');
+      });
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
   },
 };
 </script>


### PR DESCRIPTION
### チケットリンク
[ここをクリック](https://gizumo.backlog.com/view/GIZFE-395)

### 作業内容
・作成ボタンがクリックされたら、新規作成APIを実行しレスポンンスデータを取得する機能の実装
・取得したデータをもとにカテゴリ新規作成後一覧表示が更新される機能の実装

### 動作確認
・作成ボタン押したら文字が消える処理
・エラー・ローディングの処理
・新規作成して表示されているのか