### PR TITLE
カテゴリー削除機能

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,6 +8,8 @@ export default {
     targetCategory: '',
     doneMessage: '',
     loading: false,
+    deleteCategoryId: null,
+    deleteCategoryName: '',
   },
   mutations: {
     resetTargetCategory(state) {
@@ -31,6 +33,14 @@ export default {
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
     },
   },
   actions: {
@@ -72,6 +82,25 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    deleteCategory({ commit, rootGetters, state }) {
+      commit('clearMessage');
+      return new Promise((resolve) => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${state.deleteCategoryId}`,
+        }).then(() => {
+          commit('doneDeleteCategory');
+          commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+          resolve();
+        }).catch((err) => {
+          const errTxt = err.message;
+          commit('failRequest', errTxt);
+        });
+      });
+    },
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
     },
   },
 };

--- a/src/js/pages/Categories/List.vue
+++ b/src/js/pages/Categories/List.vue
@@ -13,20 +13,26 @@
     />
     <app-category-List
       class="categories__list"
+      :access="access"
       :theads="theads"
       :categories="categoriesList"
+      :delete-category-name="deleteCategoryName"
+      @handleClick="deleteCategory"
+      @openModal="openModal"
     />
   </div>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -51,6 +57,9 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/getCategoriesList');
@@ -69,6 +78,20 @@ export default {
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/confirmDeleteCategory',
+        {
+          categoryId, categoryName,
+        });
+      this.toggleModal();
+    },
+    deleteCategory() {
+      this.toggleModal();
+      console.log('削除しました');
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/getCategoriesList');
+      });
     },
   },
 };

--- a/src/js/pages/Categories/List.vue
+++ b/src/js/pages/Categories/List.vue
@@ -88,7 +88,6 @@ export default {
     },
     deleteCategory() {
       this.toggleModal();
-      console.log('削除しました');
       this.$store.dispatch('categories/deleteCategory').then(() => {
         this.$store.dispatch('categories/getCategoriesList');
       });


### PR DESCRIPTION
### チケットリンク
[ここをクリック](https://gizumo.backlog.com/view/GIZFE-398)

### 作業内容
・削除確認用のモーダルには、削除対象のカテゴリ名が表示される
・削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行される
・成功したら一覧が更新され、メッセージを表示する

### 動作確認
・削除ボタンをクリックしたら画面に「削除しますか？」と表示するのか
・「削除しますか？」と表示して更に削除ボタンを押してカテゴリーが削除されているのか
・カテゴリーを削除しましたとメッセージが表示するのか