### PR TITLE
feat:ページネーション機能の改修

### DIFF
--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -302,7 +302,7 @@ export default {
         const payload = {
           articles: res.data.articles,
         };
-        commit('doneGetAllArticles', payload);
+        commit('doneGetPageArticles', payload);
       }).catch((err) => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -28,6 +28,7 @@ export default {
     loading: false,
     doneMessage: '',
     errorMessage: '',
+    currentPage: null,
     lastPage: null,
   },
   getters: {
@@ -88,8 +89,9 @@ export default {
       );
       state.articleList = [...filteredArticles];
     },
-    doneGetAllArticles(state, payload) {
+    doneGetPageArticles(state, payload) {
       state.articleList = [...payload.articles];
+      state.currentPage = payload.currentPage;
       state.lastPage = payload.lastPage;
     },
     failRequest(state, { message }) {
@@ -126,16 +128,17 @@ export default {
     initPostArticle({ commit }) {
       commit('initPostArticle');
     },
-    getAllArticles({ commit, rootGetters }, pageNum) {
+    getPageArticles({ commit, rootGetters }, pageNum) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/article?page=${pageNum}`,
       }).then((res) => {
         const payload = {
           articles: res.data.articles,
+          currentPage: res.data.meta.current_page,
           lastPage: res.data.meta.last_page,
         };
-        commit('doneGetAllArticles', payload);
+        commit('doneGetPageArticles', payload);
       }).catch((err) => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -93,21 +93,6 @@
         削除
       </app-button>
     </app-modal>
-    <div class="article-list__pager">
-      <app-button
-        :disabled="isPrevDisabled"
-        @click="$emit('prevPage')"
-      >
-        前へ
-      </app-button>
-      <app-button
-        class="article-list__pager-next"
-        :disabled="isNextDisabled"
-        @click="$emit('nextPage')"
-      >
-        次へ
-      </app-button>
-    </div>
   </div>
 </template>
 
@@ -152,14 +137,6 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
-    },
-    isPrevDisabled: {
-      type: Boolean,
-      require: true,
-    },
-    isNextDisabled: {
-      type: Boolean,
-      require: true,
     },
   },
   computed: {
@@ -206,13 +183,6 @@ export default {
     }
     &__notice--create {
       margin-bottom: 16px;
-    }
-    &__pager {
-      text-align: center;
-      margin-top: 30px;
-      &-next {
-        margin-left: 20px;
-      }
     }
   }
 </style>

--- a/src/js/components/molecules/PageNation/index.vue
+++ b/src/js/components/molecules/PageNation/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="page-nation">
-    <div v-if="currentPage > 3" class="page-nation__first">
+  <ul class="page-nation">
+    <li v-if="currentPage > 3" class="page-nation__first">
       <app-button
         :disabled="1 === currentPage"
         @click="$emit('getPage', 1)"
@@ -12,17 +12,20 @@
       >
         ...
       </app-text>
-    </div>
-    <app-button
+    </li>
+    <li
       v-for="(page, index) in pageNation"
       :key="index"
       class="page-nation__button"
-      :disabled="page === currentPage"
-      @click="$emit('getPage', page)"
     >
-      {{ page }}
-    </app-button>
-    <div v-if="currentPage < lastPage - 2" class="page-nation__last">
+      <app-button
+        :disabled="page === currentPage"
+        @click="$emit('getPage', page)"
+      >
+        {{ page }}
+      </app-button>
+    </li>
+    <li v-if="currentPage < lastPage - 2" class="page-nation__last">
       <app-text
         class="page-nation__text"
       >
@@ -35,8 +38,8 @@
       >
         {{ lastPage }}
       </app-button>
-    </div>
-  </div>
+    </li>
+  </ul>
 </template>
 
 <script>

--- a/src/js/components/molecules/PageNation/index.vue
+++ b/src/js/components/molecules/PageNation/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="page-nation">
-    <div v-show="currentPage > 3" class="page-nation__first">
+    <div v-if="currentPage > 3" class="page-nation__first">
       <app-button
         :disabled="1 === currentPage"
         @click="$emit('getPage', 1)"
@@ -22,7 +22,7 @@
     >
       {{ page }}
     </app-button>
-    <div v-show="currentPage < lastPage - 2" class="page-nation__last">
+    <div v-if="currentPage < lastPage - 2" class="page-nation__last">
       <app-text
         class="page-nation__text"
       >

--- a/src/js/components/molecules/PageNation/index.vue
+++ b/src/js/components/molecules/PageNation/index.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="page-nation">
+    <div v-show="currentPage > 3" class="page-nation__first">
+      <app-button
+        :disabled="1 === currentPage"
+        @click="$emit('getPage', 1)"
+      >
+        1
+      </app-button>
+      <app-text
+        class="page-nation__text"
+      >
+        ...
+      </app-text>
+    </div>
+    <app-button
+      v-for="(page, index) in pageNation"
+      :key="index"
+      class="page-nation__button"
+      :disabled="page === currentPage"
+      @click="$emit('getPage', page)"
+    >
+      {{ page }}
+    </app-button>
+    <div v-show="currentPage < lastPage - 2" class="page-nation__last">
+      <app-text
+        class="page-nation__text"
+      >
+        ...
+      </app-text>
+      <app-button
+        class="page-nation__next"
+        :disabled="lastPage === currentPage"
+        @click="$emit('getPage', lastPage)"
+      >
+        {{ lastPage }}
+      </app-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { Button, Text } from '@Components/atoms';
+
+export default {
+  components: {
+    appButton: Button,
+    appText: Text,
+  },
+  props: {
+    lastPage: {
+      type: Number,
+      require: true,
+      default: null,
+    },
+    currentPage: {
+      type: Number,
+      require: true,
+      default: null,
+    },
+    pageNation: {
+      type: Array,
+      require: true,
+      default() {
+        return [];
+      },
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+  .page-nation {
+    display: flex;
+    justify-content: center;
+    margin-top: 30px;
+    &__first {
+      display: flex;
+    }
+    &__button {
+      margin-left: 20px;
+    }
+    &__text {
+      margin-left: 20px;
+    }
+    &__last {
+      display: flex;
+    }
+    &__next {
+      margin-left: 20px;
+    }
+  }
+</style>

--- a/src/js/components/molecules/PageNation/index.vue
+++ b/src/js/components/molecules/PageNation/index.vue
@@ -50,20 +50,15 @@ export default {
   props: {
     lastPage: {
       type: Number,
-      require: true,
       default: null,
     },
     currentPage: {
       type: Number,
-      require: true,
       default: null,
     },
     pageNation: {
       type: Array,
-      require: true,
-      default() {
-        return [];
-      },
+      required: true,
     },
   },
 };

--- a/src/js/components/molecules/PageNation/index.vue
+++ b/src/js/components/molecules/PageNation/index.vue
@@ -3,7 +3,7 @@
     <li v-if="currentPage > 3" class="page-nation__first">
       <app-button
         :disabled="1 === currentPage"
-        @click="$emit('getPage', 1)"
+        @click="$emit('handle-page-button-click', 1)"
       >
         1
       </app-button>
@@ -20,7 +20,7 @@
     >
       <app-button
         :disabled="page === currentPage"
-        @click="$emit('getPage', page)"
+        @click="$emit('handle-page-button-click', page)"
       >
         {{ page }}
       </app-button>
@@ -34,7 +34,7 @@
       <app-button
         class="page-nation__next"
         :disabled="lastPage === currentPage"
-        @click="$emit('getPage', lastPage)"
+        @click="$emit('handle-page-button-click', lastPage)"
       >
         {{ lastPage }}
       </app-button>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -16,6 +16,7 @@ import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
 import ArticleTrashed from './ArticleTrashed';
 import ArticleTable from './ArticleTable';
+import PageNation from './PageNation';
 import DeleteModal from './Modal';
 import Notice from './Notice';
 
@@ -38,6 +39,7 @@ export {
   ArticleDetail,
   ArticleTrashed,
   ArticleTable,
+  PageNation,
   DeleteModal,
   Notice,
 };

--- a/src/js/pages/Articles/List.vue
+++ b/src/js/pages/Articles/List.vue
@@ -13,7 +13,7 @@
       :last-page="lastPage"
       :current-page="currentPage"
       :page-nation="pageNation"
-      @getPage="getPage"
+      @handle-page-button-click="handlePageButtonClick"
     />
   </div>
 </template>
@@ -104,7 +104,7 @@ export default {
         this.$store.dispatch('articles/getPageArticles', pageNum);
       }
     },
-    getPage(pageNum) {
+    handlePageButtonClick(pageNum) {
       this.$router.push({
         path: '/articles',
         query: { page: pageNum },

--- a/src/js/pages/Articles/List.vue
+++ b/src/js/pages/Articles/List.vue
@@ -5,24 +5,27 @@
       :target-array="articlesList"
       :done-message="doneMessage"
       :access="access"
-      :is-prev-disabled="isPrevDisabled"
-      :is-next-disabled="isNextDisabled"
       border-gray
       @openModal="openModal"
       @handleClick="handleClick"
-      @prevPage="prevPage"
-      @nextPage="nextPage"
+    />
+    <app-page-nation
+      :last-page="lastPage"
+      :current-page="currentPage"
+      :page-nation="pageNation"
+      @getPage="getPage"
     />
   </div>
 </template>
 
 <script>
-import { ArticleList } from '@Components/molecules';
+import { ArticleList, PageNation } from '@Components/molecules';
 import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appArticleList: ArticleList,
+    appPageNation: PageNation,
   },
   mixins: [Mixins],
   beforeRouteUpdate(to, from, next) {
@@ -44,11 +47,19 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
-    isPrevDisabled() {
-      return (Number(this.$route.query.page) || 1) === 1;
+    lastPage() {
+      return this.$store.state.articles.lastPage;
     },
-    isNextDisabled() {
-      return Number(this.$route.query.page) === this.$store.state.articles.lastPage;
+    currentPage() {
+      return this.$store.state.articles.currentPage;
+    },
+    pageNation() {
+      const pageArray = [...Array(this.lastPage)].map((_, i) => i + 1);
+      if (this.currentPage < 3) return pageArray.slice(0, 5);
+      if (this.currentPage > this.lastPage - 2) {
+        return pageArray.slice(this.lastPage - 5, this.lastPage);
+      }
+      return pageArray.slice(this.currentPage - 3, this.currentPage + 2);
     },
   },
   created() {
@@ -74,7 +85,7 @@ export default {
             // console.log(err);
           });
       } else {
-        this.$store.dispatch('articles/getAllArticles');
+        this.$store.dispatch('articles/getPageArticles');
       }
     },
     fetchArticles(pageNum) {
@@ -90,23 +101,13 @@ export default {
             // console.log(err);
           });
       } else {
-        this.$store.dispatch('articles/getAllArticles', pageNum);
+        this.$store.dispatch('articles/getPageArticles', pageNum);
       }
     },
-    prevPage() {
-      if (this.isPrevDisabled) return;
-      const pageId = Number(this.$route.query.page) - 1;
+    getPage(pageNum) {
       this.$router.push({
         path: '/articles',
-        query: { page: pageId },
-      });
-    },
-    nextPage() {
-      if (this.isNextDisabled) return;
-      const pageId = this.$route.query.page ? Number(this.$route.query.page) + 1 : 2;
-      this.$router.push({
-        path: '/articles',
-        query: { page: pageId },
+        query: { page: pageNum },
       });
     },
   },

--- a/src/js/pages/Home/index.vue
+++ b/src/js/pages/Home/index.vue
@@ -19,7 +19,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('articles/getAllArticles');
+    this.$store.dispatch('articles/getPageArticles');
   },
 };
 </script>


### PR DESCRIPTION
## 作業内容
- 作成されていたページネーションを変更
- 現在のページの時にはボタンを非活性化

## 動作確認
- ボタンをクリックしたら、そのページのAPIを取得し表示させる
- 現在のページの時にはボタンが非活性化さている
- 3ページ目よりも前の時は１のボタンを表示しない
- 最終ページの３つ前以降のページの時は最後のボタンを表示しない