### PR TITLE
削除済記事一覧ページ作成

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -119,7 +119,7 @@ const router = new VueRouter({
         },
         {
           name: 'articleDeleted',
-          path: 'deleted',
+          path: 'trashed',
           component: ArticleDeleted,
         },
         {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -18,6 +18,7 @@ import ArticleList from '@Pages/Articles/List';
 import ArticleDetail from '@Pages/Articles/Detail';
 import ArticleEdit from '@Pages/Articles/Edit';
 import ArticlePost from '@Pages/Articles/Post';
+import ArticleDeleted from '@Pages/Articles/Deleted';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile';
@@ -115,6 +116,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleDeleted',
+          path: 'deleted',
+          component: ArticleDeleted,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -24,6 +24,7 @@ export default {
       },
     },
     articleList: [],
+    deletedList: [],
     deleteArticleId: null,
     loading: false,
     doneMessage: '',
@@ -126,6 +127,9 @@ export default {
     getPageNumber(state, { current_page: currentPage, last_page: lastPage }) {
       state.pageData.currentPage = currentPage;
       state.pageData.lastPage = lastPage;
+    },
+    doneGetDeleteArticles(state, payload) {
+      state.deletedList = payload;
     },
   },
   actions: {
@@ -293,6 +297,17 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    getDeletedArticles({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then((res) => {
+        const deletedList = res.data.articles;
+        commit('doneGetDeleteArticles', deletedList);
+      }).catch((err) => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };

--- a/src/js/components/molecules/ArticleDeletedList/index.vue
+++ b/src/js/components/molecules/ArticleDeletedList/index.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="deleted-list">
+    <app-heading :level="1">削除済み記事一覧</app-heading>
+    <app-router-link
+      to="/articles"
+      hover-opacity
+      small
+      white
+      round
+      bg-lightgreen
+      class="deleted-list__back-link"
+    >
+      すべての記事一覧へ戻る
+    </app-router-link>
+  </div>
+</template>
+
+<script>
+import { Heading, RouterLink } from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+  .deleted-list__back-link {
+    margin-top: 16px;
+  }
+</style>

--- a/src/js/components/molecules/ArticleDeletedTable/index.vue
+++ b/src/js/components/molecules/ArticleDeletedTable/index.vue
@@ -2,7 +2,7 @@
   <table class="deleted-table">
     <thead class="deleted-table__head">
       <tr>
-        <th v-for="(thead, index) in theads" :key="index">
+        <th v-for="(thead, index) in $options.theads" :key="index">
           <app-text tag="span" theme-color bold>
             {{ thead }}
           </app-text>
@@ -29,22 +29,19 @@
 import { Text } from '@Components/atoms';
 
 export default {
+  theads: ['タイトル', '本文', '作成日'],
   components: {
     appText: Text,
   },
   props: {
     deletedList: {
       type: Array,
-      default: () => [],
-    },
-    theads: {
-      type: Array,
-      default: () => [],
+      required: true,
     },
   },
   computed: {
     formatText() {
-      return text => (text.length >= 30 ? `${text.slice(0, 30)}...` : text);
+      return text => (text.length > 30 ? `${text.slice(0, 30)}...` : text);
     },
     formatDate() {
       return date => date.slice(0, 10);

--- a/src/js/components/molecules/ArticleDeletedTable/index.vue
+++ b/src/js/components/molecules/ArticleDeletedTable/index.vue
@@ -1,0 +1,77 @@
+<template lang="html">
+  <table class="deleted-table">
+    <thead class="deleted-table__head">
+      <tr>
+        <th v-for="(thead, index) in theads" :key="index">
+          <app-text tag="span" theme-color bold>
+            {{ thead }}
+          </app-text>
+        </th>
+      </tr>
+    </thead>
+    <tbody name="fade" tag="tbody" class="deleted-table__body">
+      <tr v-for="deleted in deletedList" :key="deleted.id">
+        <td>
+          <app-text tag="span" small>{{ formatText(deleted.title) }}</app-text>
+        </td>
+        <td>
+          <app-text tag="span" small>{{ formatText(deleted.content) }}</app-text>
+        </td>
+        <td>
+          <app-text tag="span" small>{{ formatDate(deleted.created_at) }}</app-text>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import { Text } from '@Components/atoms';
+
+export default {
+  components: {
+    appText: Text,
+  },
+  props: {
+    deletedList: {
+      type: Array,
+      default: () => [],
+    },
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    formatText() {
+      return text => (text.length >= 30 ? `${text.slice(0, 30)}...` : text);
+    },
+    formatDate() {
+      return date => date.slice(0, 10);
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+.deleted-table {
+  width: 100%;
+  text-align: left;
+  background-color: #fff;
+  tr {
+    border-bottom: 1px solid var(--separatorColor);
+  }
+  &__head {
+    th {
+      padding: 5px 10px;
+      vertical-align: middle;
+    }
+  }
+  &__body {
+    td {
+      padding: 10px;
+      vertical-align: middle;
+    }
+  }
+}
+</style>

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -17,7 +17,7 @@
       新しいドキュメントを作る
     </app-router-link>
     <app-router-link
-      to="articles/deleted"
+      to="articles/trashed"
       key-color
       white
       bg-lightgreen
@@ -26,7 +26,7 @@
       hover-opacity
       class="article-list__create-link"
     >
-      削除済み記事一覧を表示する
+      削除済み記事一覧へ
     </app-router-link>
     <transition-group
       class="article-list__articles"

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/deleted"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__create-link"
+    >
+      削除済み記事一覧を表示する
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -14,6 +14,8 @@ import CategoryEdit from './CategoryEdit';
 import ArticleEdit from './ArticleEdit';
 import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
+import ArticleDeletedList from './ArticleDeletedList';
+import ArticleDeletedTable from './ArticleDeletedTable';
 import DeleteModal from './Modal';
 import Notice from './Notice';
 import PageNation from './PageNation';
@@ -35,6 +37,8 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleDeletedList,
+  ArticleDeletedTable,
   DeleteModal,
   Notice,
   PageNation,

--- a/src/js/pages/Articles/Deleted.vue
+++ b/src/js/pages/Articles/Deleted.vue
@@ -3,7 +3,6 @@
     <app-article-deleted-list />
     <app-article-deleted-table
       :deleted-list="deletedList"
-      :theads="theads"
     />
   </div>
 </template>
@@ -15,11 +14,6 @@ export default {
   components: {
     appArticleDeletedList: ArticleDeletedList,
     appArticleDeletedTable: ArticleDeletedTable,
-  },
-  data() {
-    return {
-      theads: ['タイトル', '本文', '作成日'],
-    };
   },
   computed: {
     deletedList() {

--- a/src/js/pages/Articles/Deleted.vue
+++ b/src/js/pages/Articles/Deleted.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <app-article-deleted-list />
+    <app-article-deleted-table
+      :deleted-list="deletedList"
+      :theads="theads"
+    />
+  </div>
+</template>
+
+<script>
+import { ArticleDeletedList, ArticleDeletedTable } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleDeletedList: ArticleDeletedList,
+    appArticleDeletedTable: ArticleDeletedTable,
+  },
+  data() {
+    return {
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    deletedList() {
+      return this.$store.state.articles.deletedList;
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getDeletedArticles');
+  },
+};
+</script>


### PR DESCRIPTION
### チケット
[GIZFE-401 1-7  削除済記事一覧画面実装](https://gizumo.backlog.com/view/GIZFE-401)
### 実装内容
画面レイアウト作成
削除済記事一覧取得
取得記事フォーマット
### 動作確認
見た目が設計書通りになっているか
削除済記事一覧ボタン、全ての記事に戻るボタンが正常に動作するか
記事のフォーマットが適正か