### PR TITLE
feat:カテゴリ新規作成機能実装

### DIFF
--- a/src/components/pages/Categories/CategoryManagement.vue
+++ b/src/components/pages/Categories/CategoryManagement.vue
@@ -6,7 +6,7 @@
         :category="category"
         :error-message="errorMessage"
         :done-message="doneMessage"
-        :disabled="disabled"
+        :disabled="isLoading"
         @update-value="updateValue"
         @clear-message="clearMessage"
         @handle-submit="handleSubmit"
@@ -50,7 +50,7 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
-    disabled() {
+    isLoading() {
       return this.$store.state.categories.loading;
     },
   },

--- a/src/components/pages/Categories/CategoryManagement.vue
+++ b/src/components/pages/Categories/CategoryManagement.vue
@@ -3,6 +3,13 @@
     <article class="category__content">
       <app-category-post
         :access="access"
+        :category="category"
+        :error-message="errorMessage"
+        :done-message="doneMessage"
+        :disabled="disabled"
+        @update-value="updateValue"
+        @clear-message="clearMessage"
+        @handle-submit="handleSubmit"
       />
     </article>
     <div class="category__article">
@@ -27,6 +34,7 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      category: '',
     };
   },
   computed: {
@@ -36,6 +44,15 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    disabled() {
+      return this.$store.state.categories.loading;
+    },
   },
   created() {
     this.fetchCategories();
@@ -43,6 +60,22 @@ export default {
   methods: {
     fetchCategories() {
       this.$store.dispatch('categories/getAllCategories');
+    },
+    updateValue($event) {
+      this.category = $event.target.value;
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    handleSubmit() {
+      if (this.disabled) {
+        return;
+      }
+      this.$store.dispatch('categories/postCategory', this.category)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+          this.category = '';
+        });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -6,7 +6,6 @@ export default {
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
-    clearMessage: '',
     loading: false,
   },
 

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,6 +5,9 @@ export default {
   state: {
     categoryList: [],
     errorMessage: '',
+    doneMessage: '',
+    clearMessage: '',
+    loading: false,
   },
 
   mutations: {
@@ -13,6 +16,16 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+    },
+    donePostCategory(state) {
+      state.doneMessage = 'カテゴリーを追加しました。';
+    },
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
     },
   },
 
@@ -26,6 +39,28 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
+    },
+    postCategory({ commit, rootGetters }, category) {
+      commit('toggleLoading');
+      return new Promise(resolve => {
+        const params = new URLSearchParams();
+        params.append('name', category);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          params,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('donePostCategory');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+          commit('toggleLoading');
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };


### PR DESCRIPTION
- チケットのリンク
GIZFE-406

- 作業内容
カテゴリ新規作成機能の実装

- 動作確認
1. 作成ボタンをクリックしたら、新規作成APIを実行し、カテゴリを追加する。
2. 成功後、一覧画面が更新され、成功した旨のメッセージが表示される。