### PR TITLE
feat: カテゴリ削除機能実装

### DIFF
--- a/src/components/pages/Categories/CategoryManagement.vue
+++ b/src/components/pages/Categories/CategoryManagement.vue
@@ -18,6 +18,9 @@
         :access="access"
         :theads="theads"
         :categories="categoryList"
+        :delete-category-name="deleteCategoryName"
+        @open-modal="openModal"
+        @handle-click="deleteCategory"
       />
     </div>
   </div>
@@ -25,12 +28,14 @@
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -52,6 +57,12 @@ export default {
     },
     isLoading() {
       return this.$store.state.categories.loading;
+    },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategoryId;
     },
   },
   created() {
@@ -75,6 +86,21 @@ export default {
         .then(() => {
           this.fetchCategories();
           this.category = '';
+        });
+    },
+    openModal(categoryId, categoryName) {
+      this.clearMessage();
+      this.toggleModal();
+      this.$store.dispatch('categories/confirmDeleteCategory', {
+        categoryId,
+        categoryName,
+      });
+    },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.fetchCategories();
+          this.toggleModal();
         });
     },
   },

--- a/src/components/pages/Categories/CategoryManagement.vue
+++ b/src/components/pages/Categories/CategoryManagement.vue
@@ -73,7 +73,7 @@ export default {
       }
       this.$store.dispatch('categories/postCategory', this.category)
         .then(() => {
-          this.$store.dispatch('categories/getAllCategories');
+          this.fetchCategories();
           this.category = '';
         });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,8 @@ export default {
     errorMessage: '',
     doneMessage: '',
     loading: false,
+    deleteCategoryId: null,
+    deleteCategoryName: '',
   },
 
   mutations: {
@@ -25,6 +27,15 @@ export default {
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
+      state.doneMessage = 'カテゴリーを削除しました';
     },
   },
 
@@ -60,6 +71,22 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
+    deleteCategory({ commit, rootGetters }, categoryId) {
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${categoryId}`,
+        }).then(() => {
+          commit('doneDeleteCategory');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
+      });
     },
   },
 };


### PR DESCRIPTION
- チケットのリンク
https://gizumo.backlog.com/view/GIZFE-413

- 作業内容
カテゴリの削除機能の実装

- 動作確認
1. 削除ボタンを押したら、削除確認用のモーダルが出現する
2. 削除確認用のモーダルには、削除対象のカテゴリ名が表示される
3. 削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行される
4. 成功したら一覧が更新され、メッセージを表示する