### PR TITLE
カテゴリー削除機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,12 @@ export default {
     errorMessage: '',
     doneMessage: '',
     disabled: false,
+    deleteCategoryName: '',
+    deleteCategoryId: null,
+  },
+
+  getters: {
+    deleteCategoryId: state => state.deleteCategoryId,
   },
 
   mutations: {
@@ -26,6 +32,13 @@ export default {
     toggleLoading(state) {
       state.disabled = !state.disabled;
     },
+    confirmTargetCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryName = categoryName;
+      state.deleteCategoryId = categoryId;
+    },
+    deleteDoneMessage(state) {
+      state.doneMessage = 'カテゴリーを削除しました。';
+    },
   },
 
   actions: {
@@ -40,6 +53,7 @@ export default {
       });
     },
     postCategory({ commit, rootGetters }, targetCategory) {
+      commit('clearMessage');
       return new Promise((resolve) => {
         commit('toggleLoading');
         axios(rootGetters['auth/token'])({
@@ -54,6 +68,23 @@ export default {
           commit('doneMessage');
         }).catch((err) => {
           commit('toggleLoading');
+          commit('failRequest', { message: err.message });
+        });
+      });
+    },
+    confirmTargetCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmTargetCategory', { categoryId, categoryName });
+    },
+    deleteCategory({ commit, rootGetters }) {
+      commit('clearMessage');
+      return new Promise((resolve) => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        }).then(() => {
+          commit('deleteDoneMessage');
+          resolve();
+        }).catch((err) => {
           commit('failRequest', { message: err.message });
         });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -83,6 +83,8 @@ export default {
           url: `/category/${rootGetters['categories/deleteCategoryId']}`,
         }).then(() => {
           commit('deleteDoneMessage');
+          this.state.deleteCategoryName = '';
+          this.state.deleteCategoryId = null;
           resolve();
         }).catch((err) => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,9 +11,6 @@ export default {
     deleteCategoryId: null,
   },
 
-  getters: {
-    deleteCategoryId: state => state.deleteCategoryId,
-  },
 
   mutations: {
     setCategoryList(state, payload) {
@@ -75,12 +72,12 @@ export default {
     confirmTargetCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmTargetCategory', { categoryId, categoryName });
     },
-    deleteCategory({ commit, rootGetters }) {
+    deleteCategory({ commit, rootGetters }, deleteCategoryId) {
       commit('clearMessage');
       return new Promise((resolve) => {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          url: `/category/${deleteCategoryId}`,
         }).then(() => {
           commit('deleteDoneMessage');
           this.state.deleteCategoryName = '';

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -35,6 +35,8 @@ export default {
     },
     deleteDoneMessage(state) {
       state.doneMessage = 'カテゴリーを削除しました。';
+      this.state.deleteCategoryName = '';
+      this.state.deleteCategoryId = null;
     },
   },
 
@@ -80,8 +82,6 @@ export default {
           url: `/category/${deleteCategoryId}`,
         }).then(() => {
           commit('deleteDoneMessage');
-          this.state.deleteCategoryName = '';
-          this.state.deleteCategoryId = null;
           resolve();
         }).catch((err) => {
           commit('failRequest', { message: err.message });

--- a/src/js/pages/Categories/CategoryManagement.vue
+++ b/src/js/pages/Categories/CategoryManagement.vue
@@ -18,7 +18,7 @@
       :theads="theads"
       :delete-category-name="deleteCategoryName"
       :categories="categoryList"
-      @handleClick="clickDeleteButton"
+      @handleClick="deleteTargetCategory"
       @openModal="openModal"
     />
   </div>
@@ -60,6 +60,9 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategoryId;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -83,12 +86,13 @@ export default {
         { categoryId, categoryName });
       this.toggleModal();
     },
-    clickDeleteButton(categoryId) {
+    deleteTargetCategory() {
       if (!this.access.delete) return;
-      this.$store.dispatch('categories/deleteCategory', categoryId).then(() => {
-        this.toggleModal();
-        this.$store.dispatch('categories/getAllCategories');
-      });
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.toggleModal();
+          this.$store.dispatch('categories/getAllCategories');
+        });
     },
   },
 };

--- a/src/js/pages/Categories/CategoryManagement.vue
+++ b/src/js/pages/Categories/CategoryManagement.vue
@@ -16,7 +16,10 @@
       class="category__article"
       :access="access"
       :theads="theads"
+      :delete-category-name="deleteCategoryName"
       :categories="categoryList"
+      @handleClick="handleClick"
+      @openModal="openModal"
     />
   </div>
 </template>
@@ -54,6 +57,9 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -71,6 +77,18 @@ export default {
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/confirmTargetCategory',
+        { categoryId, categoryName });
+      this.toggleModal();
+    },
+    handleClick(categoryId) {
+      if (!this.access.delete) return;
+      this.$store.dispatch('categories/deleteCategory', categoryId).then(() => {
+        this.toggleModal();
+        this.$store.dispatch('categories/getAllCategories');
+      });
     },
   },
 };

--- a/src/js/pages/Categories/CategoryManagement.vue
+++ b/src/js/pages/Categories/CategoryManagement.vue
@@ -18,7 +18,7 @@
       :theads="theads"
       :delete-category-name="deleteCategoryName"
       :categories="categoryList"
-      @handleClick="handleClick"
+      @handleClick="clickDeleteButton"
       @openModal="openModal"
     />
   </div>
@@ -83,7 +83,7 @@ export default {
         { categoryId, categoryName });
       this.toggleModal();
     },
-    handleClick(categoryId) {
+    clickDeleteButton(categoryId) {
       if (!this.access.delete) return;
       this.$store.dispatch('categories/deleteCategory', categoryId).then(() => {
         this.toggleModal();


### PR DESCRIPTION
チケットのリンク
[https://gizumo.backlog.com/view/GIZFE-414](https://gizumo.backlog.com/view/GIZFE-414)

作業内容（今回やったこと）
- カテゴリー削除機能の実装

動作確認
- 削除ボタンを押したら、削除確認用のモーダルが出現する
- 削除確認用のモーダルには、削除対象のカテゴリ名が表示される
- 削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行される
- 成功したら一覧が更新され、メッセージを表示する