### PR TITLE
カテゴリー削除機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -9,6 +9,8 @@ export default {
     errorMessage: '',
     doneMessage: '',
     disabled: false,
+    deleteCategoryId: null,
+    deleteCategoryName: '',
   },
   mutations: {
     setAllCategories(state, payload) {
@@ -26,6 +28,13 @@ export default {
     },
     toggleDisabled(state) {
       state.disabled = !state.disabled;
+    },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
     },
   },
   actions: {
@@ -60,6 +69,23 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
+    deleteCategory({ commit, rootGetters }, deleteCrticleId) {
+      return new Promise((resolve) => {
+        commit('clearMessage');
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${deleteCrticleId}`,
+        }).then(() => {
+          commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
+          resolve();
+        }).catch((err) => {
+          commit('failRequest', { message: err.message });
+        });
+      });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -35,6 +35,7 @@ export default {
     },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
     },
   },
   actions: {
@@ -80,6 +81,7 @@ export default {
           method: 'DELETE',
           url: `/category/${deleteCrticleId}`,
         }).then(() => {
+          commit('doneDeleteCategory')
           commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
           resolve();
         }).catch((err) => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -81,7 +81,7 @@ export default {
           method: 'DELETE',
           url: `/category/${deleteCrticleId}`,
         }).then(() => {
-          commit('doneDeleteCategory')
+          commit('doneDeleteCategory');
           commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
           resolve();
         }).catch((err) => {

--- a/src/js/pages/Categories/Manage.vue
+++ b/src/js/pages/Categories/Manage.vue
@@ -12,10 +12,13 @@
       @clearMessage="clearMessage"
     />
     <app-category-list
+      class="category_list"
       :access="access"
       :theads="theads"
       :categories="categoryList"
-      class="category_list"
+      :delete-category-name="deleteCategoryName"
+      @openModal="openModal"
+      @handleClick="handleClick"
     />
   </div>
 </template>
@@ -48,8 +51,14 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
-    toggleLoading() {
+    toggleDisabled() {
       return this.$store.state.categories.disabled;
+    },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategoryId;
     },
   },
   created() {
@@ -68,6 +77,20 @@ export default {
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/confirmDeleteCategory', {
+        categoryId,
+        categoryName,
+      });
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+          this.toggleModal();
+        });
     },
   },
 };


### PR DESCRIPTION
・チケットのリンク
https://gizumo.backlog.com/view/GIZFE-415

・作業内容（今回やったこと）
カテゴリー削除機能実装

・動作確認
削除ボタンを押すとモーダルが表示される
選択したカテゴリーとモーダル内のカテゴリー名が一致している
モーダル内の削除ボタンを押すとカテゴリーが削除され一覧が再表示される
削除しましたのメッセージが表示される