### PR TITLE
feat: カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,111 @@
+<template>
+  <form @submit.prevent="updateCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      class="category-edit__link"
+      underline
+      hover-opacity
+      to="/categories"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      class="category-edit__input"
+      name="category"
+      type="text"
+      placeholder="更新するカテゴリー名を入力してください"
+      data-vv-as="カテゴリー名"
+      :error-message="errors.collect('category')"
+      :value="editCategoryName"
+      @update-value="$emit('update-value', $event)"
+    />
+    <app-button
+      class="category-edit__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.edit"
+    >
+      {{ buttonText }}
+    </app-button>
+    <div v-if="errorMessage" class="category-edit__message">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+    <div v-if="doneMessage" class="category-edit__message">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+
+<script>
+import {
+  Heading, Input, Button, RouterLink, Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appRouterLink: RouterLink,
+    appText: Text,
+  },
+  props: {
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    editCategoryName: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    updateCategory() {
+      if (!this.access.edit) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-edit {
+  &__link {
+    margin-top: 16px;
+  }
+
+  &__input {
+    margin-top: 16px;
+  }
+
+  &__submit {
+    margin-top: 16px;
+  }
+
+  &__message {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -10,7 +10,6 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
-      v-validate="'required'"
       class="category-edit__input"
       name="category"
       type="text"

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -10,12 +10,13 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-edit__input"
       name="category"
       type="text"
       placeholder="更新するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
-      :error-message="errors.collect('category')"
+      :error-messages="errors.collect('category')"
       :value="editCategoryName"
       @update-value="$emit('update-value', $event)"
     />

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/CategoryManagement.vue
+++ b/src/components/pages/Categories/CategoryManagement.vue
@@ -67,6 +67,7 @@ export default {
   },
   created() {
     this.fetchCategories();
+    this.clearMessage();
   },
   methods: {
     fetchCategories() {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,58 @@
+<template>
+  <div>
+    <app-category-edit
+      :access="access"
+      :disabled="isLoading"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      :edit-category-name="editCategoryName"
+      @update-value="updateValue"
+      @clear-message="clearMessage"
+      @handle-submit="updateCategory"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    isLoading() {
+      return this.$store.state.categories.loading;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    editCategoryName() {
+      return this.$store.state.categories.editCategory.name;
+    },
+  },
+  created() {
+    this.clearMessage();
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategoryDetail', id);
+  },
+  methods: {
+    updateValue($event) {
+      this.$store.dispatch('categories/updateEditValue', $event.target.value);
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateCategory() {
+      if (this.isLoading) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -37,6 +37,7 @@ export default {
   },
   created() {
     this.clearMessage();
+    this.clearEditCategory();
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategoryDetail', id);
   },
@@ -50,6 +51,9 @@ export default {
     updateCategory() {
       if (this.isLoading) return;
       this.$store.dispatch('categories/updateCategory');
+    },
+    clearEditCategory() {
+      this.$store.dispatch('categories/clearEditCategory');
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,16 +1,14 @@
 <template>
-  <div>
-    <app-category-edit
-      :access="access"
-      :disabled="isLoading"
-      :error-message="errorMessage"
-      :done-message="doneMessage"
-      :edit-category-name="editCategoryName"
-      @update-value="updateValue"
-      @clear-message="clearMessage"
-      @handle-submit="updateCategory"
-    />
-  </div>
+  <app-category-edit
+    :access="access"
+    :disabled="isLoading"
+    :error-message="errorMessage"
+    :done-message="doneMessage"
+    :edit-category-name="editCategoryName"
+    @update-value="updateValue"
+    @clear-message="clearMessage"
+    @handle-submit="updateCategory"
+  />
 </template>
 
 <script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryManagement from '@Pages/Categories/CategoryManagement.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'CategoryManagement',
           path: '',
           component: CategoryManagement,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -122,18 +122,15 @@ export default {
       commit('toggleLoading');
       const params = new URLSearchParams();
       params.append('name', state.editCategory.name);
-      return new Promise(resolve => {
-        axios(rootGetters['auth/token'])({
-          method: 'PUT',
-          url: `/category/${state.editCategory.id}`,
-          params,
-        }).then(() => {
-          commit('toggleLoading');
-          commit('displayDoneMessage', { message: 'カテゴリーを更新しました。' });
-          resolve();
-        }).catch(err => {
-          commit('failRequest', { message: err.message });
-        });
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.editCategory.id}`,
+        params,
+      }).then(() => {
+        commit('toggleLoading');
+        commit('displayDoneMessage', { message: 'カテゴリーを更新しました。' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -127,10 +127,11 @@ export default {
         url: `/category/${state.editCategory.id}`,
         params,
       }).then(() => {
-        commit('toggleLoading');
         commit('displayDoneMessage', { message: 'カテゴリーを更新しました。' });
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      }).finally(() => {
+        commit('toggleLoading');
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -22,8 +22,8 @@ export default {
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
-    donePostCategory(state) {
-      state.doneMessage = 'カテゴリーを追加しました。';
+    displayDoneMessage(state, { message }) {
+      state.doneMessage = message;
     },
     clearMessage(state) {
       state.errorMessage = '';
@@ -39,7 +39,6 @@ export default {
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
-      state.doneMessage = 'カテゴリーを削除しました';
     },
     setCategoryDetail(state, { categoryId, categoryName }) {
       state.editCategory.id = categoryId;
@@ -51,7 +50,6 @@ export default {
     doneUpdateCategory(state) {
       state.editCategory.id = null;
       state.editCategory.name = '';
-      state.doneMessage = 'カテゴリーを更新しました。';
     },
   },
 
@@ -77,7 +75,7 @@ export default {
           params,
         }).then(() => {
           commit('toggleLoading');
-          commit('donePostCategory');
+          commit('displayDoneMessage', { message: 'カテゴリーを追加しました。' });
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
@@ -98,6 +96,7 @@ export default {
           url: `/category/${categoryId}`,
         }).then(() => {
           commit('doneDeleteCategory');
+          commit('displayDoneMessage', { message: 'カテゴリーを削除しました。' });
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
@@ -130,7 +129,7 @@ export default {
           params,
         }).then(() => {
           commit('toggleLoading');
-          commit('doneUpdateCategory');
+          commit('displayDoneMessage', { message: 'カテゴリーを更新しました。' });
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -9,6 +9,10 @@ export default {
     loading: false,
     deleteCategoryId: null,
     deleteCategoryName: '',
+    editCategory: {
+      id: null,
+      name: '',
+    },
   },
 
   mutations: {
@@ -36,6 +40,18 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
       state.doneMessage = 'カテゴリーを削除しました';
+    },
+    setCategoryDetail(state, { categoryId, categoryName }) {
+      state.editCategory.id = categoryId;
+      state.editCategory.name = categoryName;
+    },
+    updateEditValue(state, payload) {
+      state.editCategory.name = payload;
+    },
+    doneUpdateCategory(state) {
+      state.editCategory.id = null;
+      state.editCategory.name = '';
+      state.doneMessage = 'カテゴリーを更新しました。';
     },
   },
 
@@ -82,6 +98,39 @@ export default {
           url: `/category/${categoryId}`,
         }).then(() => {
           commit('doneDeleteCategory');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
+      });
+    },
+    getCategoryDetail({ commit, rootGetters }, categoryId) {
+      axios(rootGetters['auth/token'])({
+        methods: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(({ data }) => {
+        const categoryName = data.category.name;
+        commit('setCategoryDetail', { categoryId, categoryName });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    updateEditValue({ commit }, editCategoryName) {
+      commit('updateEditValue', editCategoryName);
+    },
+    updateCategory({ commit, rootGetters, state }) {
+      commit('clearMessage');
+      commit('toggleLoading');
+      const params = new URLSearchParams();
+      params.append('name', state.editCategory.name);
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'PUT',
+          url: `/category/${state.editCategory.id}`,
+          params,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('doneUpdateCategory');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -47,7 +47,7 @@ export default {
     updateEditValue(state, payload) {
       state.editCategory.name = payload;
     },
-    doneUpdateCategory(state) {
+    clearEditCategory(state) {
       state.editCategory.id = null;
       state.editCategory.name = '';
     },
@@ -133,6 +133,9 @@ export default {
       }).finally(() => {
         commit('toggleLoading');
       });
+    },
+    clearEditCategory({ commit }) {
+      commit('clearEditCategory');
     },
   },
 };


### PR DESCRIPTION
- チケットのリンク
[https://gizumo.backlog.com/view/GIZFE-416](url)

- 作業内容
カテゴリー更新機能の実装

- 動作確認
inputの初期値にidに応じたカテゴリ名が表示されている。
更新ボタンを押したら処理が完了した旨のメッセージが表示される。
カテゴリー一覧へ戻るのリンクをクリックしたらカテゴリ管理画面へ遷移し、変更後のカテゴリが表示されている。
カテゴリー一覧へ戻ると、更新されたメッセージが消える。
