### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home';
 // カテゴリー
 import Categories from '@Pages/Categories';
 import CategoryManagement from '@Pages/Categories/CategoryManagement';
+import CategoryEdit from '@Pages/Categories/Edit';
 
 // 記事
 import Articles from '@Pages/Articles';
@@ -64,6 +65,11 @@ const router = new VueRouter({
           name: 'CategoryManagement',
           path: '',
           component: CategoryManagement,
+        },
+        {
+          name: 'CategoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -9,10 +9,16 @@ export default {
     disabled: false,
     deleteCategoryName: '',
     deleteCategoryId: null,
+    editCategoryName: '',
+    editCategoryId: null,
   },
 
 
   mutations: {
+    editCategory(state, payload) {
+      state.editCategoryName = payload.name;
+      state.editCategoryId = payload.id;
+    },
     setCategoryList(state, payload) {
       state.categoryList = payload.reverse();
     },
@@ -38,9 +44,18 @@ export default {
       this.state.deleteCategoryName = '';
       this.state.deleteCategoryId = null;
     },
+    updateValue(state, payload) {
+      state.editCategoryName = payload;
+    },
+    editDoneMessage(state) {
+      state.doneMessage = '更新に成功しました';
+    },
   },
 
   actions: {
+    updateValue({ commit }, event) {
+      commit('updateValue', event);
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -86,6 +101,34 @@ export default {
         }).catch((err) => {
           commit('failRequest', { message: err.message });
         });
+      });
+    },
+    getCategoryDetail({ commit, rootGetters }, categoryId) {
+      commit('clearMessage');
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(({ data }) => {
+        commit('editCategory', data.category);
+      }).catch((err) => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    updateCategory({ commit, rootGetters, state }) {
+      commit('toggleLoading');
+      commit('clearMessage');
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.editCategoryId}`,
+        data: {
+          name: state.editCategoryName,
+        },
+      }).then(() => {
+        commit('toggleLoading');
+        commit('editDoneMessage');
+      }).catch((err) => {
+        commit('toggleLoading');
+        commit('failRequest', { message: err.message });
       });
     },
     clearMessage({ commit }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -45,6 +45,10 @@ export default {
     updateValue(state, payload) {
       state.editCategoryName = payload;
     },
+    clearDeleteCategory(state) {
+      state.deleteCategoryName = '';
+      state.deleteCategoryId = null;
+    },
   },
 
   actions: {
@@ -91,6 +95,7 @@ export default {
           method: 'DELETE',
           url: `/category/${deleteCategoryId}`,
         }).then(() => {
+          commit('clearDeleteCategory');
           commit('doneMessage', { message: 'カテゴリーを削除しました' });
           resolve();
         }).catch((err) => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -15,6 +15,9 @@ export default {
 
 
   mutations: {
+    clearOldCategory(state) {
+      state.editCategoryName = '';
+    },
     editCategory(state, payload) {
       state.editCategoryName = payload.name;
       state.editCategoryId = payload.id;
@@ -125,6 +128,9 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    clearOldCategory({ commit }) {
+      commit('clearOldCategory');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -22,8 +22,8 @@ export default {
     setCategoryList(state, payload) {
       state.categoryList = payload.reverse();
     },
-    doneMessage(state) {
-      state.doneMessage = 'カテゴリーを追加しました';
+    doneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
@@ -39,16 +39,8 @@ export default {
       state.deleteCategoryName = categoryName;
       state.deleteCategoryId = categoryId;
     },
-    deleteDoneMessage(state) {
-      state.doneMessage = 'カテゴリーを削除しました。';
-      this.state.deleteCategoryName = '';
-      this.state.deleteCategoryId = null;
-    },
     updateValue(state, payload) {
       state.editCategoryName = payload;
-    },
-    editDoneMessage(state) {
-      state.doneMessage = '更新に成功しました';
     },
   },
 
@@ -96,7 +88,7 @@ export default {
           method: 'DELETE',
           url: `/category/${deleteCategoryId}`,
         }).then(() => {
-          commit('deleteDoneMessage');
+          commit('doneMessage', { message: 'カテゴリーを削除しました' });
           resolve();
         }).catch((err) => {
           commit('failRequest', { message: err.message });
@@ -125,7 +117,7 @@ export default {
         },
       }).then(() => {
         commit('toggleLoading');
-        commit('editDoneMessage');
+        commit('doneMessage', { message: 'カテゴリーを更新しました' });
       }).catch((err) => {
         commit('toggleLoading');
         commit('failRequest', { message: err.message });

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -25,7 +25,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.create"
+      :disabled="disabled || !access.edit"
     >
       {{ buttonText }}
     </app-button>
@@ -81,13 +81,13 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '更新権限がありません';
+      if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {
     updateCategory() {
-      if (!this.access.create) return;
+      if (!this.access.edit) return;
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('handleSubmit');
       });

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -7,7 +7,6 @@
       small
       hover-opacity
       to="/categories"
-      :value="targetCategory"
     >
       カテゴリー一覧へ戻る
     </app-router-link>

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,115 @@
+<template lang="html">
+  <form @submit.prevent="updateCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      class="return__category"
+      underline
+      small
+      hover-opacity
+      to="/categories"
+      :value="targetCategory"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      name="category"
+      placeholder="更新したいカテゴリー名を入力してください"
+      type="text"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="category"
+      @updateValue="$emit('updateValue', $event)"
+    />
+    <app-button
+      class="category-management-post__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.create"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-management-post__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-management-post__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    category: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    targetCategory: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    updateCategory() {
+      if (!this.access.create) return;
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('handleSubmit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+  .category-management-post {
+    &__input {
+      margin-top: 16px;
+    }
+    &__submit {
+      margin-top: 16px;
+    }
+    &__notice {
+      margin-top: 16px;
+    }
+  }
+  .return__category {
+    font-size: 2rem;
+    padding: 16px 0;
+  }
+</style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -15,6 +15,7 @@ import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
 import DeleteModal from './Modal';
 import Notice from './Notice';
+import CategoryEdit from './CategoryEdit';
 
 export {
   SigninForm,
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/js/pages/Categories/CategoryManagement.vue
+++ b/src/js/pages/Categories/CategoryManagement.vue
@@ -66,6 +66,7 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     updateValue(current) {

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -37,6 +37,7 @@ export default {
     },
   },
   created() {
+    this.$store.dispatch('categories/clearOldCategory');
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategoryDetail', id);
   },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -19,10 +19,6 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
-  data() {
-    return {
-    };
-  },
   computed: {
     disabled() {
       return this.$store.state.categories.disabled;
@@ -45,8 +41,8 @@ export default {
     this.$store.dispatch('categories/getCategoryDetail', id);
   },
   methods: {
-    updateValue(current) {
-      this.$store.dispatch('categories/updateValue', current.target.value);
+    updateValue(event) {
+      this.$store.dispatch('categories/updateValue', event.target.value);
     },
     handleSubmit() {
       if (this.disabled) return;

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,0 +1,57 @@
+<template lang="html">
+  <article class="category__content">
+    <app-category-edit
+      :disabled="disabled"
+      :access="access"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
+      :category="targetCategory"
+      @updateValue="updateValue"
+      @handleSubmit="handleSubmit"
+    />
+  </article>
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  data() {
+    return {
+    };
+  },
+  computed: {
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    targetCategory() {
+      return this.$store.state.categories.editCategoryName;
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategoryDetail', id);
+  },
+  methods: {
+    updateValue(current) {
+      this.$store.dispatch('categories/updateValue', current.target.value);
+    },
+    handleSubmit() {
+      if (this.disabled) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
+  },
+};
+</script>


### PR DESCRIPTION
チケットの[リンク](https://gizumo.backlog.com/view/GIZFE-417)

作業内容：カテゴリーの更新機能実装

動作確認
- 更新ボタンを押すと画面遷移する
- 画面遷移後、更新対象の文字がinputに初期値として表示されている
- 変更して更新ボタンを押した時に成功時メッセージが表示される
- 更新中はボタンが連打できない
- 一覧に戻ったときに成功字のメッセージが消えている