### PR TITLE
feat: カテゴリー更新機能実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home';
 // カテゴリー
 import Categories from '@Pages/Categories';
 import CategoryManage from '@Pages/Categories/Manage';
+import CategoryEdit from '@Pages/Categories/Edit';
 
 // 記事
 import Articles from '@Pages/Articles';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'categoryManage',
           path: '',
           component: CategoryManage,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -46,6 +46,10 @@ export default {
       state.editCategoryName = payload.data.category.name;
       state.editCategoryId = payload.data.category.id;
     },
+    clearCategory(state) {
+      state.editCategoryName = '';
+      state.editCategoryId = null;
+    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -125,6 +129,9 @@ export default {
           commit('failRequest', { message: err.message });
         });
       });
+    },
+    clearCategory({ commit }) {
+      commit('clearCategory');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -39,8 +39,8 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
     },
-    updateValue(state, $event) {
-      state.editCategoryName = $event.target.value;
+    updateValue(state, event) {
+      state.editCategoryName = event.target.value;
     },
     confirmEditCategory(state, payload) {
       state.editCategoryName = payload.data.category.name;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,6 +11,8 @@ export default {
     disabled: false,
     deleteCategoryId: null,
     deleteCategoryName: '',
+    editCategoryName: '',
+    editCategoryId: null,
   },
   mutations: {
     setAllCategories(state, payload) {
@@ -36,6 +38,13 @@ export default {
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
+    },
+    updateValue(state, $event) {
+      state.editCategoryName = $event.target.value;
+    },
+    confirmEditCategory(state, payload) {
+      state.editCategoryName = payload.data.category.name;
+      state.editCategoryId = payload.data.category.id;
     },
   },
   actions: {
@@ -83,6 +92,34 @@ export default {
         }).then(() => {
           commit('doneDeleteCategory');
           commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
+          resolve();
+        }).catch((err) => {
+          commit('failRequest', { message: err.message });
+        });
+      });
+    },
+    updateValue({ commit }, $event) {
+      commit('updateValue', $event);
+    },
+    setEditCategoryName({ commit, rootGetters }, id) {
+      commit('clearMessage');
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then((response) => {
+        commit('confirmEditCategory', response);
+      });
+    },
+    editCategory({ commit, rootGetters, state }) {
+      return new Promise((resolve) => {
+        axios(rootGetters['auth/token'])({
+          method: 'PUT',
+          url: `/category/${state.editCategoryId}`,
+          data: {
+            name: state.editCategoryName,
+          },
+        }).then(() => {
+          commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
           resolve();
         }).catch((err) => {
           commit('failRequest', { message: err.message });

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -85,13 +85,6 @@ export default {
     },
   },
   methods: {
-    addCategory() {
-      if (!this.access.create) return;
-      this.$emit('clearMessage');
-      this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('handleSubmit');
-      });
-    },
     editCategory(categoryId) {
       if (!this.access.edit) return;
       this.$emit('editCategory', categoryId);

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,117 @@
+<template lang="html">
+  <form @submit.prevent="editCategory(category.id)">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="backCategory">
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        to="/categories"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+    <app-input
+      v-validate="'required'"
+      name="category"
+      type="text"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="category"
+      @updateValue="$emit('updateValue', $event)"
+    />
+    <app-button
+      class="category-management-post__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.create"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-management-post__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-management-post__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+<script>
+import {
+  Heading,
+  Input,
+  Button,
+  Text,
+  RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    category: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    addCategory() {
+      if (!this.access.create) return;
+      this.$emit('clearMessage');
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('handleSubmit');
+      });
+    },
+    editCategory(categoryId) {
+      if (!this.access.edit) return;
+      this.$emit('editCategory', categoryId);
+    },
+  },
+};
+</script>
+<style lang="postcss" scoped>
+.category-management-post {
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+.backCategory {
+  margin-top: 20px;
+}
+</style>

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -25,7 +25,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.create"
+      :disabled="disabled || !access.edit"
     >
       {{ buttonText }}
     </app-button>
@@ -80,7 +80,7 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '更新権限がありません';
+      if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -87,7 +87,10 @@ export default {
   methods: {
     editCategory(categoryId) {
       if (!this.access.edit) return;
-      this.$emit('editCategory', categoryId);
+      this.$emit('clearMessage');
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('editCategory', categoryId);
+      });
     },
   },
 };

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -8,6 +8,7 @@ import UserCreate from './UserCreate';
 import UserTable from './UserTable';
 import UserDetail from './UserDetail';
 import UserList from './UserList';
+import CategoryEdit from './CategoryEdit';
 import CategoryPost from './CategoryPost';
 import CategoryList from './CategoryList';
 import ArticleEdit from './ArticleEdit';
@@ -27,6 +28,7 @@ export {
   UserTable,
   UserDetail,
   UserList,
+  CategoryEdit,
   CategoryPost,
   CategoryList,
   ArticleEdit,

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,0 +1,56 @@
+<template lang="html">
+  <app-category-edit
+    :disabled="toggleDisabled"
+    :access="access"
+    :done-message="doneMessage"
+    :error-message="errorMessage"
+    :category="editCategoryName"
+    @updateValue="updateValue"
+    @editCategory="editCategory"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    toggleDisabled() {
+      return this.$store.state.categories.disabled;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    editCategoryName() {
+      return this.$store.state.categories.editCategoryName;
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/setEditCategoryName', id);
+  },
+  methods: {
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event);
+    },
+    editCategory(categoryId) {
+      this.$store.dispatch('categories/editCategory', categoryId)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+    },
+  },
+};
+</script>
+
+<style>
+</style>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -7,6 +7,7 @@
     :category="editCategoryName"
     @updateValue="updateValue"
     @editCategory="editCategory"
+    @clearCategory="clearCategory"
   />
 </template>
 
@@ -37,6 +38,7 @@ export default {
   created() {
     const { id } = this.$route.params;
     this.$store.dispatch('categories/setEditCategoryName', id);
+    this.$store.dispatch('categories/clearCategory');
   },
   methods: {
     updateValue($event) {

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -7,7 +7,6 @@
     :category="editCategoryName"
     @updateValue="updateValue"
     @editCategory="editCategory"
-    @clearCategory="clearCategory"
   />
 </template>
 

--- a/src/js/pages/Categories/Manage.vue
+++ b/src/js/pages/Categories/Manage.vue
@@ -63,6 +63,7 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     updateValue($event) {


### PR DESCRIPTION
チケットのリンク
https://gizumo.backlog.com/view/GIZFE-419
作業内容（今回やったこと）
カテゴリー更新機能実装
動作確認
・カテゴリーリストの更新ボタンを押すとカテゴリー更新画面に移動する
・インプットタグに該当するカテゴリー名が入力されている
・カテゴリー更新画面の更新ボタンを押すと更新される
・メッセージが適切に切り替わる
・カテゴリー一覧へ戻るを押すとページが戻る