### PR TITLE
カテゴリ一新規作成機能作成

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,6 +5,8 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
+    disabled: false,
+    doneMessage: '',
     errorMessage: '',
   },
   mutations: {
@@ -14,6 +16,16 @@ export default {
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
+    toggleDisabled(state) {
+      state.disabled = !state.disabled;
+    },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
+    displayDoneMessage(state, payload) {
+      state.doneMessage = payload.message;
+    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -22,12 +34,35 @@ export default {
         url: '/category',
       }).then((res) => {
         const payload = {
-          categories: res.data.categories,
+          categories: res.data.categories.reverse(),
         };
         commit('doneGetAllCategories', payload);
       }).catch((err) => {
         commit('failRequest', { message: err.message });
       });
+    },
+    postCategories({ commit, rootGetters }, targetCategory) {
+      return new Promise((resolve) => {
+        commit('toggleDisabled');
+        commit('clearMessage');
+        const data = new URLSearchParams();
+        data.append('name', targetCategory);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleDisabled');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          resolve();
+        }).catch((err) => {
+          commit('toggleDisabled');
+          commit('failRequest', { message: err.message });
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @updateValue="$emit('udpateValue', $event)"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -3,13 +3,20 @@
     <app-category-post
       class="category-post"
       :access="access"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      :disabled="disabled"
+      :category="targetCategory"
+      @handleSubmit="handleSubmit"
+      @updateValue="uptargetCategory"
+      @clearMessage="clearMessage"
     />
     <app-category-list
       class="category-list"
       :categories="CategoriesList"
       :access="access"
-    />
-  </div>
+      />
+    </div>
 </template>
 
 <script>
@@ -20,6 +27,11 @@ export default {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  data() {
+    return {
+      targetCategory: '',
+    };
+  },
   computed: {
     CategoriesList() {
       return this.$store.state.categories.categoryList;
@@ -27,9 +39,35 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    category() {
+      return this.$store.state.categories.targetCategory;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategories', this.targetCategory).then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    uptargetCategory(event) {
+      this.targetCategory = event.target.value;
+    },
   },
 };
 </script>

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -15,8 +15,8 @@
       class="category-list"
       :categories="CategoriesList"
       :access="access"
-      />
-    </div>
+    />
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
# GIZFE-418
### チケットのリンク
https://github.com/gizumo-inc/gizumo_wiki_lesson/tree/feature/GIZFE-418

### 作業内容
- カテゴリ一新規作成機能作成

### 動作確認
- 作成ボタンがクリックされたら、新規作成APIを実行し、一覧画面が更新されメッセージを表示する
- カテゴリー一覧が降順で表示されていること


