### PR TITLE
1-2 カテゴリ一新規作成機能実装

### DIFF
--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -70,6 +70,9 @@ export default {
     },
   },
   methods: {
+    updateValue($event) {
+      this.$emit('update-value', $event.target);
+    },
     addCategory() {
       if (!this.access.create) return;
       this.$emit('clear-message');

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -6,6 +6,7 @@
       :error-message="errorMessage"
       :done-message="doneMessage"
       :access="access"
+      :disabled="disabled"
       @clear-message="clearMessage"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
@@ -46,6 +47,9 @@ export default {
     },
     access() {
       return this.$store.getters['auth/access'];
+    },
+    disabled() {
+      return this.$store.state.categories.loading;
     },
   },
   created() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,10 +2,13 @@
   <div class="categories">
     <app-category-post
       class="category-post"
-      :category="category"
+      :category="targetName"
       :error-message="errorMessage"
       :done-message="doneMessage"
       :access="access"
+      @clear-message="clearMessage"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       class="category-list"
@@ -28,12 +31,10 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      targetName: '',
     };
   },
   computed: {
-    category() {
-      return this.$store.state.category;
-    },
     errorMessage() {
       return this.$store.state.errorMessage;
     },
@@ -49,6 +50,17 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue(event) {
+      this.targetName = event.target.value;
+    },
+    handleSubmit() {
+      this.$store.dispatch('categories/createCategory', this.targetName);
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -74,6 +74,7 @@ export default {
     padding-right: 30px;
   }
   .category-list {
+    width: 100%;
     border-left: 5px solid $separator-color;
   }
 </style>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -36,10 +36,10 @@ export default {
   },
   computed: {
     errorMessage() {
-      return this.$store.state.errorMessage;
+      return this.$store.state.categories.errorMessage;
     },
     doneMessage() {
-      return this.$store.state.doneMessage;
+      return this.$store.state.categories.doneMessage;
     },
     categories() {
       return this.$store.state.categories.categoryList;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -63,8 +63,9 @@ export default {
       this.targetName = event.target.value;
     },
     handleSubmit() {
-      this.$store.dispatch('categories/createCategory', this.targetName);
-      this.$store.dispatch('categories/getAllCategories');
+      this.$store.dispatch('categories/createCategory', this.targetName).then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -60,6 +60,7 @@ export default {
     },
     handleSubmit() {
       this.$store.dispatch('categories/createCategory', this.targetName);
+      this.$store.dispatch('categories/getAllCategories');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -17,9 +17,6 @@ export default {
       state.errorMessage = '';
       state.doneMessage = '';
     },
-    applyRequest(state) {
-      state.loading = true;
-    },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
     },
@@ -28,6 +25,9 @@ export default {
     },
     displayDoneMessage(state, payload) {
       state.doneMessage = payload.message;
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
     },
   },
   actions: {
@@ -45,7 +45,7 @@ export default {
       });
     },
     createCategory({ commit, rootGetters }, category) {
-      commit('applyRequest');
+      commit('toggleLoading');
 
       return new Promise(resolve => {
         const data = new URLSearchParams();
@@ -56,9 +56,11 @@ export default {
           data,
         }).then(response => {
           if (response.data.code === 0) throw new Error(response.data.message);
+          commit('toggleLoading');
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
           resolve();
         }).catch(err => {
+          commit('toggleLoading');
           commit('failRequest', { message: err.response.data.message });
         });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,9 +20,6 @@ export default {
     applyRequest(state) {
       state.loading = true;
     },
-    updateValue(state, { name, value }) {
-      state.category = { ...state.category, [name]: value };
-    },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
     },
@@ -39,9 +36,6 @@ export default {
   actions: {
     clearMessage({ commit }) {
       commit('clearMessage');
-    },
-    updateValue({ commit }) {
-      commit('updateValue');
     },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -60,7 +60,7 @@ export default {
         }).then(response => {
           if (response.data.code === 0) throw new Error(response.data.message);
           commit('doneCreateCategory', response.data.category);
-          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' }); 
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.response.data.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -32,6 +32,9 @@ export default {
     doneCreateCategory(state, category) {
       state.categoryList.unshift(category);
     },
+    displayDoneMessage(state, payload) {
+      state.doneMessage = payload.message;
+    },
   },
   actions: {
     clearMessage({ commit }) {
@@ -64,6 +67,7 @@ export default {
           // NOTE: エラー時はresponse.data.codeが0で返ってくる。
           if (response.data.code === 0) throw new Error(response.data.message);
           commit('doneCreateCategory', response.data.category);
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' }); 
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.response.data.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,7 +20,7 @@ export default {
     applyRequest(state) {
       state.loading = true;
     },
-    updateValue(state, { name, value }){
+    updateValue(state, { name, value }) {
       state.category = { ...state.category, [name]: value };
     },
     doneGetAllCategories(state, categories) {
@@ -64,7 +64,6 @@ export default {
           url: '/category',
           data,
         }).then(response => {
-          // NOTE: エラー時はresponse.data.codeが0で返ってくる。
           if (response.data.code === 0) throw new Error(response.data.message);
           commit('doneCreateCategory', response.data.category);
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' }); 

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -26,9 +26,6 @@ export default {
     failRequest(state, payload) {
       state.errorMessage = payload.message;
     },
-    doneCreateCategory(state, category) {
-      state.categoryList.unshift(category);
-    },
     displayDoneMessage(state, payload) {
       state.doneMessage = payload.message;
     },
@@ -59,7 +56,6 @@ export default {
           data,
         }).then(response => {
           if (response.data.code === 0) throw new Error(response.data.message);
-          commit('doneCreateCategory', response.data.category);
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
           resolve();
         }).catch(err => {


### PR DESCRIPTION
GIZFE-445 1-2 カテゴリ一新規作成機能実装　
https://gizumo.backlog.com/view/GIZFE-445

作業内容
・作成ボタンがクリックされたら、新規作成APIを実行する
・成功時、一覧画面が更新されメッセージを表示する
・追加されたカテゴリーはカテゴリー一覧の一番上に表示される