### PR TITLE
1-3 カテゴリ一削除機能実装

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,6 +16,7 @@
       :theads="theads"
       :categories="categories"
       :access="access"
+      @open-modal="openModal"
     />
   </div>
 </template>
@@ -56,6 +57,10 @@ export default {
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
+    openModal(categoryId) {
+      this.$store.dispatch('categories/confirmDeleteCategory', categoryId);
+      this.toggleModal();
+    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -17,6 +17,7 @@
       :categories="categories"
       :access="access"
       @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
@@ -71,6 +72,10 @@ export default {
       this.$store.dispatch('categories/createCategory', this.targetName).then(() => {
         this.$store.dispatch('categories/getAllCategories');
       });
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,6 +16,7 @@
       :theads="theads"
       :categories="categories"
       :access="access"
+      :delete-category-name="deleteCategoryName"
       @open-modal="openModal"
       @handle-click="handleClick"
     />
@@ -53,13 +54,16 @@ export default {
     disabled() {
       return this.$store.state.categories.loading;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
-    openModal(categoryId) {
-      this.$store.dispatch('categories/confirmDeleteCategory', categoryId);
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/openDeleteModal', { categoryId, categoryName });
       this.toggleModal();
     },
     clearMessage() {
@@ -74,7 +78,9 @@ export default {
       });
     },
     handleClick() {
-      this.$store.dispatch('categories/deleteCategory');
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
       this.toggleModal();
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,7 +7,7 @@ export default {
       id: null,
       name: '',
     },
-    deleteCategoryId: '',
+    deleteCategoryId: null,
     deleteCategoryName: '',
     categoryList: [],
     errorMessage: '',
@@ -40,7 +40,7 @@ export default {
       state.deleteCategoryName = categoryName;
     },
     doneDeleteCategory(state) {
-      state.deleteCategoryId = '';
+      state.deleteCategoryId = null;
     },
   },
   actions: {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -35,8 +35,9 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
-    confirmDeleteCategory(state, { categoryId }) {
+    openDeleteModal(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
     },
     doneDeleteCategory(state) {
       state.deleteCategoryId = '';
@@ -77,23 +78,26 @@ export default {
         });
       });
     },
-    confirmDeleteCategory({ commit }, categoryId) {
-      commit('confirmDeleteCategory', { categoryId });
+    openDeleteModal({ commit }, { categoryId, categoryName }) {
+      commit('openDeleteModal', { categoryId, categoryName });
     },
     deleteCategory({ commit, rootGetters }) {
       commit('clearMessage');
-      const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/deleteCategoryId']);
-      axios(rootGetters['auth/token'])({
-        method: 'DELETE',
-        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
-        data,
-      }).then(response => {
-        if (response.data.code === 0) throw new Error(response.data.message);
-        commit('doneDeleteCategory');
-        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
+      return new Promise(resolve => {
+        const data = new URLSearchParams();
+        data.append('id', rootGetters['categories/deleteCategoryId']);
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          data,
+        }).then(response => {
+          if (response.data.code === 0) throw new Error(response.data.message);
+          commit('doneDeleteCategory');
+          commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -41,6 +41,7 @@ export default {
     },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
     },
   },
   actions: {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,7 @@ export default {
       id: null,
       name: '',
     },
+    deleteCategoryId: '',
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
@@ -28,6 +29,9 @@ export default {
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    confirmDeleteCategory(state, { categoryId }) {
+      state.deleteCategoryId = categoryId;
     },
   },
   actions: {
@@ -64,6 +68,9 @@ export default {
           commit('failRequest', { message: err.response.data.message });
         });
       });
+    },
+    confirmDeleteCategory({ commit }, categoryId) {
+      commit('confirmDeleteCategory', { categoryId });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -82,14 +82,14 @@ export default {
     openDeleteModal({ commit }, { categoryId, categoryName }) {
       commit('openDeleteModal', { categoryId, categoryName });
     },
-    deleteCategory({ commit, rootGetters }) {
+    deleteCategory({ commit, rootGetters, state }) {
       commit('clearMessage');
       return new Promise(resolve => {
         const data = new URLSearchParams();
-        data.append('id', rootGetters['categories/deleteCategoryId']);
+        data.append('id', state.deleteCategoryId);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          url: `/category/${state.deleteCategoryId}`,
           data,
         }).then(response => {
           if (response.data.code === 0) throw new Error(response.data.message);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,10 +8,15 @@ export default {
       name: '',
     },
     deleteCategoryId: '',
+    deleteCategoryName: '',
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
     loading: false,
+  },
+  getters: {
+    deleteCategoryId: state => state.deleteCategoryId,
+    deleteCategoryName: state => state.deleteCategoryName,
   },
   mutations: {
     clearMessage(state) {
@@ -32,6 +37,9 @@ export default {
     },
     confirmDeleteCategory(state, { categoryId }) {
       state.deleteCategoryId = categoryId;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = '';
     },
   },
   actions: {
@@ -71,6 +79,22 @@ export default {
     },
     confirmDeleteCategory({ commit }, categoryId) {
       commit('confirmDeleteCategory', { categoryId });
+    },
+    deleteCategory({ commit, rootGetters }) {
+      commit('clearMessage');
+      const data = new URLSearchParams();
+      data.append('id', rootGetters['categories/deleteCategoryId']);
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        data,
+      }).then(response => {
+        if (response.data.code === 0) throw new Error(response.data.message);
+        commit('doneDeleteCategory');
+        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };


### PR DESCRIPTION
GIZFE-451 1-3 カテゴリ一削除機能実装
https://gizumo.backlog.com/view/GIZFE-451

作業内容
-削除ボタンを押したら、削除確認用のモーダルを出現させる
-削除確認用のモーダルには、削除対象のカテゴリ名を表示する
-削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIを実行する
-API通信が成功したら一覧が更新され、メッセージを表示する
