### PR TITLE
カテゴリ一管理画面実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="category-list">
-    <table class="category-list__table">
+    <table
+      v-if="categories.length"
+      class="category-list__table"
+    >
       <thead class="category-list__table__head">
         <tr>
           <th
@@ -54,6 +57,12 @@
         </tr>
       </transition-group>
     </table>
+    <p
+      v-else
+      class="category-list-none"
+    >
+      カテゴリーがありません
+    </p>
     <app-modal>
       <div class="category-list__modal">
         <app-text
@@ -163,8 +172,14 @@ export default {
       }
     }
   }
+  &-none {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 25px;
+    height: 100vh;
+  }
 }
-
 .category-list__modal {
   text-align: center;
   &__name {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="category">
+    <app-category-post
+      class="category-post"
+      :access="access"
+    />
+    <app-category-list
+      class="category-list"
+      :categories="CategoriesList"
+      :access="access"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryList, CategoryPost } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryList: CategoryList,
+    appCategoryPost: CategoryPost,
+  },
+  computed: {
+    CategoriesList() {
+      return this.$store.state.categories.categoryList;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category {
+  display: flex;
+  height: 100%;
+  &-post {
+    padding-right: 2%;
+    width: 40%;
+    border-right: 1px solid #ccc;
+  }
+  &-list {
+    margin-left: 2%;
+    width: 60%;
+    overflow-y: scroll;
+    background-color: #fff;
+  }
+}
+</style>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -6,7 +6,7 @@
     />
     <app-category-list
       class="category-list"
-      :categories="CategoriesList"
+      :categories="categoriesList"
       :access="access"
     />
   </div>
@@ -21,7 +21,7 @@ export default {
     appCategoryPost: CategoryPost,
   },
   computed: {
-    CategoriesList() {
+    categoriesList() {
       return this.$store.state.categories.categoryList;
     },
     access() {

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -5,6 +5,11 @@ export default [
     path: '/',
   },
   {
+    id: 2,
+    name: 'カテゴリー',
+    path: '/categories',
+  },
+  {
     id: 3,
     name: '記事',
     path: '/articles',

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -14,6 +14,10 @@ import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
 
+// カテゴリー
+import Categories from '@Pages/Categories/index.vue';
+import CategoriesList from '@Pages/Categories/List.vue';
+
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
 
@@ -66,6 +70,17 @@ const router = new VueRouter({
       name: 'profile',
       path: '/profile',
       component: Profile,
+    },
+    {
+      path: '/categories',
+      component: Categories,
+      children: [
+        {
+          name: 'categoriesList',
+          path: '',
+          component: CategoriesList,
+        },
+      ],
     },
     {
       path: '/articles',

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import {
-  auth, articles, users,
+  auth, articles, users, categories,
 } from './modules';
 
 Vue.use(Vuex);
@@ -11,5 +11,6 @@ export default new Vuex.Store({
     auth,
     articles,
     users,
+    categories,
   },
 });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -1,0 +1,32 @@
+import axios from '@Helpers/axiosDefault';
+
+export default {
+  namespaced: true,
+  state: {
+    categoryList: [],
+    errorMessage: '',
+  },
+  mutations: {
+    doneGetCategories(state, payload) {
+      state.categoryList = [...payload.categories];
+    },
+    failRequest(state, { message }) {
+      state.errorMessage = message;
+    },
+  },
+  actions: {
+    getAllCategories({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then(res => {
+        const payload = {
+          categories: res.data.categories.reverse(),
+        };
+        commit('doneGetCategories', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+  },
+};

--- a/src/js/_store/modules/index.js
+++ b/src/js/_store/modules/index.js
@@ -1,9 +1,11 @@
 import articles from './articles';
 import auth from './auth';
 import users from './users';
+import categories from './categories';
 
 export {
   articles,
   auth,
   users,
+  categories,
 };


### PR DESCRIPTION
## チケットリンク
https://gizumo.backlog.com/view/GIZFE-457

## 内容
- カテゴリーを管理するための画面作成
- サイドバーにカテゴリーを追加
- API通信をして、カテゴリ一覧情報を取得する

## 動作確認
- サイドバーの「カテゴリー」をクリックするとカテゴリー一覧ページに遷移
- APIから取得したカテゴリ一覧が画面右側に降順で表示される
- カテゴリーの数が0個の場合は、適切なメッセージを表示
