### PR TITLE
feat: ページネーション機能実装

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -81,6 +81,9 @@
         削除
       </app-button>
     </app-modal>
+    <app-page-nation
+      @handle-page-button-click="pushPageId"
+    />
   </div>
 </template>
 
@@ -92,6 +95,7 @@ import {
   Button,
   Text,
 } from '@Components/atoms';
+import PageNation from '@Components/molecules/PageNation/index.vue';
 
 export default {
   components: {
@@ -100,6 +104,7 @@ export default {
     appRouterLink: RouterLink,
     appButton: Button,
     appText: Text,
+    appPageNation: PageNation,
   },
   props: {
     className: {
@@ -139,6 +144,12 @@ export default {
     openModal(articleId) {
       if (!this.access.delete) return;
       this.$emit('open-modal', articleId);
+    },
+    pushPageId(pageId) {
+      this.$router.push({
+        path: '/articles',
+        query: { page: pageId },
+      }, () => {});
     },
   },
 };

--- a/src/components/molecules/HomeArticle/index.vue
+++ b/src/components/molecules/HomeArticle/index.vue
@@ -22,7 +22,7 @@
 
     <div class="home-article__button">
       <app-router-link
-        to="/articles"
+        to="/articles?page=1"
         round
         bg-theme-color
         white

--- a/src/components/molecules/PageNation/index.vue
+++ b/src/components/molecules/PageNation/index.vue
@@ -55,7 +55,7 @@ export default {
         return result;
       }
       if (this.totalPages - 2 <= this.currentPage) {
-        const result = range.slice(this.totalPages - 5);
+        const result = range.slice(-5);
         return result;
       }
       const result = range.slice(this.currentPage - 3, this.currentPage + 2);

--- a/src/components/molecules/PageNation/index.vue
+++ b/src/components/molecules/PageNation/index.vue
@@ -46,10 +46,10 @@ export default {
       return this.$store.state.articles.pageData.totalPages;
     },
     pageRange() {
-      const range = [...Array(this.totalPages).keys()].map(i => i + 1);
       if (this.totalPages === null) {
         return false;
       }
+      const range = [...Array(this.totalPages).keys()].map(i => i + 1);
       if (this.currentPage <= 3) {
         const result = range.slice(0, 5);
         return result;

--- a/src/components/molecules/PageNation/index.vue
+++ b/src/components/molecules/PageNation/index.vue
@@ -1,0 +1,87 @@
+<template>
+  <ul class="page-nation-lists">
+    <template v-if="4 <= currentPage">
+      <li class="page-nation-list">
+        <app-button @click="$emit('handle-page-button-click', 1)">
+          1
+        </app-button>
+      </li>
+      <li class="page-nation-list page-nation-list-dots">…</li>
+    </template>
+    <li
+      v-for="page in pageRange"
+      :key="page"
+      class="page-nation-list"
+    >
+      <app-button
+        :disabled="currentPage === page"
+        @click="$emit('handle-page-button-click', page)"
+      >
+        {{ page }}
+      </app-button>
+    </li>
+    <template v-if="currentPage <= totalPages - 3">
+      <li class="page-nation-list page-nation-list-dots">…</li>
+      <li class="page-nation-list">
+        <app-button @click="$emit('handle-page-button-click', totalPages)">
+          {{ totalPages }}
+        </app-button>
+      </li>
+    </template>
+  </ul>
+</template>
+
+<script>
+import { Button } from '@Components/atoms';
+
+export default {
+  components: {
+    appButton: Button,
+  },
+  computed: {
+    currentPage() {
+      return this.$store.state.articles.pageData.currentPage;
+    },
+    totalPages() {
+      return this.$store.state.articles.pageData.totalPages;
+    },
+    pageRange() {
+      if (this.totalPages === null) {
+        return false;
+      }
+      const range = [...Array(this.totalPages).keys()].map(i => i + 1);
+      if (this.currentPage <= 3) {
+        const result = range.slice(0, 5);
+        return result;
+      }
+      if (this.totalPages - 2 <= this.currentPage) {
+        const result = range.slice(this.totalPages - 5);
+        return result;
+      }
+      const result = range.slice(this.currentPage - 3, this.currentPage + 2);
+      return result;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.page-nation {
+  &-lists {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 32px;
+  }
+  &-list {
+    margin-left: 16px;
+    &:first-child {
+      margin-left: 0;
+    }
+    &-dots{
+      font-size: 20px;
+      color: #c0c6c9;
+    }
+  }
+}
+</style>

--- a/src/components/molecules/PageNation/index.vue
+++ b/src/components/molecules/PageNation/index.vue
@@ -51,15 +51,12 @@ export default {
       }
       const range = [...Array(this.totalPages).keys()].map(i => i + 1);
       if (this.currentPage <= 3) {
-        const result = range.slice(0, 5);
-        return result;
+        return range.slice(0, 5);
       }
       if (this.totalPages - 2 <= this.currentPage) {
-        const result = range.slice(-5);
-        return result;
+        return range.slice(-5);
       }
-      const result = range.slice(this.currentPage - 3, this.currentPage + 2);
-      return result;
+      return range.slice(this.currentPage - 3, this.currentPage + 2);
     },
   },
 };

--- a/src/components/molecules/PageNation/index.vue
+++ b/src/components/molecules/PageNation/index.vue
@@ -46,10 +46,10 @@ export default {
       return this.$store.state.articles.pageData.totalPages;
     },
     pageRange() {
+      const range = [...Array(this.totalPages).keys()].map(i => i + 1);
       if (this.totalPages === null) {
         return false;
       }
-      const range = [...Array(this.totalPages).keys()].map(i => i + 1);
       if (this.currentPage <= 3) {
         const result = range.slice(0, 5);
         return result;

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -16,6 +16,7 @@ import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
+import PageNation from './PageNation/index.vue';
 
 export {
   SigninForm,
@@ -36,4 +37,5 @@ export {
   ArticleDetail,
   DeleteModal,
   Notice,
+  PageNation,
 };

--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -22,7 +22,7 @@ export default {
   },
   mixins: [Mixins],
   beforeRouteUpdate(to, from, next) {
-    this.fetchArticles(Number(to.query.page));
+    this.fetchArticles(to.query.page);
     next();
   },
   data() {
@@ -42,7 +42,7 @@ export default {
     },
   },
   created() {
-    this.fetchArticles(Number(this.$route.query.page));
+    this.fetchArticles(this.$route.query.page);
   },
   methods: {
     openModal(articleId) {

--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -22,7 +22,7 @@ export default {
   },
   mixins: [Mixins],
   beforeRouteUpdate(to, from, next) {
-    this.fetchArticles();
+    this.fetchArticles(Number(to.query.page));
     next();
   },
   data() {
@@ -42,7 +42,7 @@ export default {
     },
   },
   created() {
-    this.fetchArticles();
+    this.fetchArticles(Number(this.$route.query.page));
   },
   methods: {
     openModal(articleId) {
@@ -64,24 +64,11 @@ export default {
             // console.log(err);
           });
       } else {
-        this.$store.dispatch('articles/getAllArticles');
+        this.$store.dispatch('articles/getArticlesData');
       }
     },
-    fetchArticles() {
-      if (this.$route.query.category) {
-        const { category } = this.$route.query;
-        this.title = category;
-        this.$store.dispatch('articles/filteredArticles', category)
-          .then(() => {
-            if (this.$store.state.articles.articleList.length === 0) {
-              this.$router.push({ path: '/notfound' });
-            }
-          }).catch(() => {
-            // console.log(err);
-          });
-      } else {
-        this.$store.dispatch('articles/getAllArticles');
-      }
+    fetchArticles(pageId) {
+      this.$store.dispatch('articles/getArticlesData', pageId);
     },
   },
 };

--- a/src/components/pages/Home/index.vue
+++ b/src/components/pages/Home/index.vue
@@ -19,7 +19,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('articles/getAllArticles');
+    this.$store.dispatch('articles/getArticlesData');
   },
 };
 </script>

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -12,7 +12,7 @@ export default [
   {
     id: 3,
     name: '記事',
-    path: '/articles',
+    path: '/articles?page=1',
   },
   {
     id: 4,

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -28,6 +28,10 @@ export default {
     loading: false,
     doneMessage: '',
     errorMessage: '',
+    pageData: {
+      currentPage: null,
+      totalPages: null,
+    },
   },
   getters: {
     transformedArticles(state) {
@@ -83,15 +87,14 @@ export default {
       );
       state.articleList = [...filteredArticles];
     },
-    doneGetAllArticles(state, payload) {
-      state.articleList = [...payload.articles];
+    doneGetArticlesData(state, payload) {
+      state.articleList = payload;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
     selectedArticleCategory(state, payload) {
       state.targetArticle.category = {
-
         ...state.targetArticle.category,
         ...payload.category,
       };
@@ -115,20 +118,22 @@ export default {
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
     },
+    getPageNumber(state, { current_page: currentPage, last_page: totalPages }) {
+      state.pageData.currentPage = currentPage;
+      state.pageData.totalPages = totalPages;
+    },
   },
   actions: {
     initPostArticle({ commit }) {
       commit('initPostArticle');
     },
-    getAllArticles({ commit, rootGetters }) {
+    getArticlesData({ commit, rootGetters }, pageId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
-        url: '/article',
-      }).then(res => {
-        const payload = {
-          articles: res.data.articles,
-        };
-        commit('doneGetAllArticles', payload);
+        url: `/article?page=${pageId}`,
+      }).then(({ data }) => {
+        commit('getPageNumber', data.meta);
+        commit('doneGetArticlesData', data.articles);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -132,7 +132,7 @@ export default {
         method: 'GET',
         url: `/article?page=${pageId}`,
       }).then(({ data }) => {
-        commit('getPageNumber', data.meta);
+        commit('setPageNumber', data.meta);
         commit('doneGetArticlesData', data.articles);
       }).catch(err => {
         commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -118,7 +118,7 @@ export default {
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
     },
-    getPageNumber(state, { current_page: currentPage, last_page: totalPages }) {
+    setPageNumber(state, { current_page: currentPage, last_page: totalPages }) {
       state.pageData.currentPage = currentPage;
       state.pageData.totalPages = totalPages;
     },

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -127,7 +127,7 @@ export default {
     initPostArticle({ commit }) {
       commit('initPostArticle');
     },
-    getArticlesData({ commit, rootGetters }, pageId) {
+    getArticlesData({ commit, rootGetters }, pageId = 1) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/article?page=${pageId}`,


### PR DESCRIPTION
# チケットのリンク
[GIZFE-460](https://gizumo.backlog.com/view/GIZFE-460)

# やったこと
- 記事一覧画面にページネーション機能の実装。
- 関数の処理内容が、名前と違うので、適した名前に変更。

# 動作確認
[テストケース](https://gizumo.backlog.com/view/GIZFE-462)
- ページ数ボタンを押すと該当のページに移動すること
- リロードしても、ページが移動しないこと
- 現在表示しているページのボタンには、disabledで非活性処理されている
- 1ページ目と、最後のページが常に表示されている。
- ドットが不必要な場合は描画されない。
- URLのクエリが該当のものになっている。
