### PR TITLE
カテゴリ一新規作成機能作成

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -54,6 +54,7 @@ export default {
   },
   methods: {
     handleSubmit() {
+      if (this.disabled) return;
       this.$store.dispatch('categories/postCategories', this.targetCategory).then(() => {
         this.$store.dispatch('categories/getAllCategories');
       });

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -54,7 +54,6 @@ export default {
   },
   methods: {
     handleSubmit() {
-      if (this.loading) return;
       this.$store.dispatch('categories/postCategories', this.targetCategory).then(() => {
         this.$store.dispatch('categories/getAllCategories');
       });

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,7 +2,14 @@
   <div class="category">
     <app-category-post
       class="category-post"
+      :category="targetCategory"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      :disabled="disabled"
       :access="access"
+      @handle-submit="handleSubmit"
+      @update-value="uptargetCategory"
+      @clear-message="clearMessage"
     />
     <app-category-list
       class="category-list"
@@ -20,9 +27,23 @@ export default {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  data() {
+    return {
+      targetCategory: '',
+    };
+  },
   computed: {
     categoriesList() {
       return this.$store.state.categories.categoryList;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -30,6 +51,20 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategories', this.targetCategory).then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+    },
+    uptargetCategory(event) {
+      this.targetCategory = event.target.value;
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
   },
 };
 </script>

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,7 +4,9 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
+    disabled: false,
     errorMessage: '',
+    doneMessage: '',
   },
   mutations: {
     doneGetCategories(state, payload) {
@@ -12,6 +14,16 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+    },
+    toggleDisabled(state) {
+      state.disabled = !state.disabled;
+    },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
+    displayDoneMessage(state, payload) {
+      state.doneMessage = payload.message;
     },
   },
   actions: {
@@ -27,6 +39,29 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
+    },
+    postCategories({ commit, rootGetters }, targetCategory) {
+      return new Promise(resolve => {
+        commit('clearMessage');
+        commit('toggleDisabled');
+        const data = new URLSearchParams();
+        data.append('name', targetCategory);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleDisabled');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          resolve();
+        }).catch(err => {
+          commit('toggleDisabled');
+          commit('failRequest', { message: err.message });
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };


### PR DESCRIPTION
### チケットリンク
https://gizumo.backlog.com/view/GIZFE-466
### 作業内容
- 作成ボタンがクリックされたら、新規作成APIを実行し、新しいカテゴリーを追加
### 動作確認
- カテゴリーを入力して作成ボタンクリックされたら、新しいカテゴリー作成
- 新しく作成されたカテゴリーが一覧の一番上に表示される
- 何も入力せずに作成ボタンを押すとエラーメッセージが表示
- 同じカテゴリー名を作成しようとすると422エラーが発生し、適切なエラーメッセージが表示
- 作成ボタンをクリック後、API通信中は「作成」ボタンが非活性になりダブルサブミットできないこと
