### PR TITLE
1-4 カテゴリ一更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -66,10 +66,6 @@ export default {
   },
 
   props: {
-    category: {
-      type: Object,
-      default: () => ({}),
-    },
     categoryName: {
       type: String,
       default: '',

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="category-edit">
     <app-heading :level="1">カテゴリー管理</app-heading>
-    <div class="category-list__back">
+    <div class="category-edit__back">
       <app-router-link
         block
         underline
@@ -26,17 +26,17 @@
         />
       </div>
 
-      <div class="category-edit__button">
+      <div class="category-edit__submit">
         <app-button
           button-type="submit"
-          block
+          round
           :disabled="loading || !access.edit"
         >
           {{ buttonText }}
         </app-button>
       </div>
 
-      <div v-if="errorMessage" class="category-management-post__notice">
+      <div v-if="errorMessage" class="category-edit__notice">
         <app-text bg-error>{{ errorMessage }}</app-text>
       </div>
       <div v-if="doneMessage" class="category-edit__notice">
@@ -111,3 +111,20 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.category-edit{
+  &__back {
+    margin-top: 16px;
+  }
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -30,6 +30,7 @@
         <app-button
           button-type="submit"
           block
+          :disabled="loading || !access.edit"
         >
           {{ buttonText }}
         </app-button>
@@ -88,19 +89,20 @@ export default {
       type: String,
       default: '',
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     buttonText() {
       if (!this.access.edit) return '更新権限がありません';
       return this.loading ? '更新中...' : '更新';
     },
-    disabled() {
-      return this.access.edit && !this.loading;
-    },
   },
   methods: {
     updateCategory() {
-      // if (!this.access.edit) return;
+      if (!this.access.edit) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('update-category');

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -34,6 +34,13 @@
           {{ buttonText }}
         </app-button>
       </div>
+
+      <div v-if="errorMessage" class="category-management-post__notice">
+        <app-text bg-error>{{ errorMessage }}</app-text>
+      </div>
+      <div v-if="doneMessage" class="category-edit__notice">
+        <app-text bg-success>{{ doneMessage }}</app-text>
+      </div>
     </form>
   </section>
 </template>
@@ -43,7 +50,7 @@ import {
   Button,
   Heading,
   Input,
-  // Text,
+  Text,
   RouterLink,
 } from '@Components/atoms';
 
@@ -52,7 +59,7 @@ export default {
     appButton: Button,
     appHeading: Heading,
     appInput: Input,
-    // appText: Text,
+    appText: Text,
     appRouterLink: RouterLink,
   },
 
@@ -73,6 +80,14 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     buttonText() {
@@ -85,7 +100,6 @@ export default {
   },
   methods: {
     updateCategory() {
-      console.log('df');
       // if (!this.access.edit) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,66 @@
+<template>
+  <section class="category-edit">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="category-list__back">
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        to="/categories"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+
+    <form class="category-edit__form">
+      <div class="category-edit__input">
+        <app-input
+          v-validate="'required'"
+          name="categoryName"
+          type="text"
+          placeholder="カテゴリー名"
+          data-vv-as=""
+          :value="categoryName"
+          @update-value="updateValue"
+        />
+      </div>
+
+      <div class="category-edit__button">
+        <app-button
+          button-type="submit"
+          block
+        >
+          {{ buttonText }}
+        </app-button>
+      </div>
+    </form>
+  </section>
+</template>
+
+<script>
+import {
+  Button,
+  Heading,
+  Input,
+  Text,
+  RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appButton: Button,
+    appHeading: Heading,
+    appInput: Input,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+
+  props: {
+    categoryName: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -13,7 +13,7 @@
       </app-router-link>
     </div>
 
-    <form class="category-edit__form">
+    <form class="category-edit__form" @submit.prevent="updateCategory">
       <div class="category-edit__input">
         <app-input
           v-validate="'required'"
@@ -22,7 +22,7 @@
           placeholder="カテゴリー名"
           data-vv-as=""
           :value="categoryName"
-          @update-value="updateValue"
+          @update-value="$emit('edited-name', $event)"
         />
       </div>
 
@@ -43,7 +43,7 @@ import {
   Button,
   Heading,
   Input,
-  Text,
+  // Text,
   RouterLink,
 } from '@Components/atoms';
 
@@ -52,14 +52,45 @@ export default {
     appButton: Button,
     appHeading: Heading,
     appInput: Input,
-    appText: Text,
+    // appText: Text,
     appRouterLink: RouterLink,
   },
 
   props: {
+    category: {
+      type: Object,
+      default: () => ({}),
+    },
+    categoryId: {
+      type: String,
+      default: '',
+    },
     categoryName: {
       type: String,
       default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+  },
+  methods: {
+    updateCategory() {
+      console.log('df');
+      // if (!this.access.edit) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('update-category');
+      });
     },
   },
 };

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -20,7 +20,8 @@
           name="categoryName"
           type="text"
           placeholder="カテゴリー名"
-          data-vv-as=""
+          data-vv-as="カテゴリー名"
+          :error-messages="errors.collect('categoryName')"
           :value="categoryName"
           @update-value="$emit('edited-name', $event)"
         />

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -70,10 +70,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    categoryId: {
-      type: String,
-      default: '',
-    },
     categoryName: {
       type: String,
       default: '',

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,6 +1,5 @@
 <template>
   <app-category-edit
-    :category-id="categoryId"
     :category-name="categoryName"
     :loading="loading"
     :access="access"
@@ -18,17 +17,7 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
-  data() {
-    return {
-      id: '',
-      name: '',
-    };
-  },
   computed: {
-    categoryId() {
-      const { id } = this.$route.params;
-      return id;
-    },
     categoryName() {
       const { name } = this.$store.state.categories.category;
       return name;

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,13 @@
+<template>
+  <app-category-edit />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -4,6 +4,8 @@
     :category-name="categoryName"
     :loading="loading"
     :access="access"
+    :error-message="errorMessage"
+    :done-message="doneMessage"
     @edited-name="editedName"
     @update-category="updateCategory"
   />
@@ -37,14 +39,23 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategory', this.$route.params.id);
   },
   methods: {
     editedName($event) {
       this.$store.dispatch('categories/editedName', $event.target.value);
     },
     updateCategory() {
+      if (this.loading) return;
       this.$store.dispatch('categories/updateCategory');
-      console.log('adf');
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,5 +1,12 @@
 <template>
-  <app-category-edit />
+  <app-category-edit
+    :category-id="categoryId"
+    :category-name="categoryName"
+    :loading="loading"
+    :access="access"
+    @edited-name="editedName"
+    @update-category="updateCategory"
+  />
 </template>
 
 <script>
@@ -8,6 +15,37 @@ import { CategoryEdit } from '@Components/molecules';
 export default {
   components: {
     appCategoryEdit: CategoryEdit,
+  },
+  data() {
+    return {
+      id: '',
+      name: '',
+    };
+  },
+  computed: {
+    categoryId() {
+      const { id } = this.$route.params;
+      return id;
+    },
+    categoryName() {
+      const { name } = this.$store.state.categories.category;
+      return name;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  methods: {
+    editedName($event) {
+      this.$store.dispatch('categories/editedName', $event.target.value);
+    },
+    updateCategory() {
+      this.$store.dispatch('categories/updateCategory');
+      console.log('adf');
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -59,6 +59,7 @@ export default {
     },
   },
   created() {
+    this.$store.dispatch('categories/clearMessage');
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/List.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'categoryList',
           path: '',
           component: CategoryList,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -43,6 +43,12 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
     },
+    updateCategory(state, { category }) {
+      state.category = { ...state.category, ...category };
+    },
+    editedName(state, payload) {
+      state.category = { ...state.category, name: payload.name };
+    },
   },
   actions: {
     clearMessage({ commit }) {
@@ -101,5 +107,33 @@ export default {
         });
       });
     },
+    editedName({ commit }, name) {
+      commit({
+        type: 'editedName',
+        name,
+      });
+    },
+    updateCategory({ commit, rootGetters, state }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('id', state.category.id);
+      data.append('name', state.category.name);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.category.id}`,
+        data,
+      }).then(res => {
+        console.log(res);
+        const payload = {
+          category: {
+            id: res.data.category.id,
+            name: res.data.category.name,
+          },
+        };
+        commit('updateCategory', payload);
+        commit('toggleLoading');
+      });
+    },
+
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -49,6 +49,10 @@ export default {
     editedName(state, payload) {
       state.category = { ...state.category, name: payload.name };
     },
+    doneGetCategory(state, payload) {
+      state.category.id = payload.id;
+      state.category.name = payload.name;
+    },
   },
   actions: {
     clearMessage({ commit }) {
@@ -62,6 +66,18 @@ export default {
         commit('doneGetAllCategories', res.data.categories);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    getCategory({ commit, rootGetters }, categoryId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(res => {
+        const payload = {
+          id: res.data.category.id,
+          name: res.data.category.name,
+        };
+        commit('doneGetCategory', payload);
       });
     },
     createCategory({ commit, rootGetters }, category) {
@@ -123,7 +139,6 @@ export default {
         url: `/category/${state.category.id}`,
         data,
       }).then(res => {
-        console.log(res);
         const payload = {
           category: {
             id: res.data.category.id,
@@ -132,6 +147,9 @@ export default {
         };
         commit('updateCategory', payload);
         commit('toggleLoading');
+        commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
 

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -133,6 +133,7 @@ export default {
       });
     },
     updateCategory({ commit, rootGetters, state }) {
+      commit('clearMessage');
       commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('id', state.category.id);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -69,6 +69,7 @@ export default {
       });
     },
     getCategory({ commit, rootGetters }, categoryId) {
+      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${categoryId}`,
@@ -78,6 +79,8 @@ export default {
           name: res.data.category.name,
         };
         commit('doneGetCategory', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
     createCategory({ commit, rootGetters }, category) {
@@ -149,6 +152,7 @@ export default {
         commit('toggleLoading');
         commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
       }).catch(err => {
+        commit('toggleLoading');
         commit('failRequest', { message: err.message });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -136,7 +136,6 @@ export default {
       commit('clearMessage');
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', state.category.id);
       data.append('name', state.category.name);
       axios(rootGetters['auth/token'])({
         method: 'PUT',


### PR DESCRIPTION
# GIZFE-469 1-4 カテゴリ一更新機能実装
https://gizumo.backlog.com/view/GIZFE-469

作業内容
- カテゴリー編集画面の作成
- カテゴリー更新APIの実行
- ページ遷移処理
- API通信後のメッセージの表示



