### PR TITLE
feat: 削除済み記事一覧機能実装

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__trashed-link"
+    >
+      削除済み記事一覧へ
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -171,6 +183,10 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+    }
+    &__trashed-link {
+      margin-top: 16px;
+      margin-left: 20px;
     }
     &__links {
       *:not(first-child) {

--- a/src/components/molecules/ArticleTrashedHead/index.vue
+++ b/src/components/molecules/ArticleTrashedHead/index.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="trashed-header">
+    <app-heading :level="1">削除済み記事一覧</app-heading>
+    <app-router-link
+      to="/articles?page=1"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="trashed-header-link"
+    >
+      すべての記事一覧へ戻る
+    </app-router-link>
+  </div>
+</template>
+
+<script>
+import { Heading, RouterLink } from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.trashed {
+  &-header {
+    &-link {
+      margin-top: 15px;
+    }
+  }
+}
+</style>

--- a/src/components/molecules/ArticleTrashedList/index.vue
+++ b/src/components/molecules/ArticleTrashedList/index.vue
@@ -1,0 +1,81 @@
+<template>
+  <table class="trashed-table">
+    <thead class="trashed-table-head">
+      <tr>
+        <th v-for="(thead, index) in theads" :key="index">
+          <app-text
+            tag="span"
+            theme-color
+            bold
+          >
+            {{ thead }}
+          </app-text>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="trashed-table-body">
+      <tr v-for="trashed in trashedList" :key="trashed.id">
+        <td>
+          <app-text tag="span">{{ cutText(trashed.title) }}</app-text>
+        </td>
+        <td>
+          <app-text tag="span">{{ cutText(trashed.content) }}</app-text>
+        </td>
+        <td>
+          <app-text tag="span">{{ formatDate(trashed.created_at) }}</app-text>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import { Text } from '@Components/atoms';
+
+export default {
+  components: {
+    appText: Text,
+  },
+  props: {
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+    trashedList: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    cutText() {
+      return text => (text.length >= 30 ? `${text.slice(0, 30)}...` : text);
+    },
+    formatDate() {
+      return data => data.slice(0, 10);
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.trashed{
+  &-table {
+    width: 100%;
+    margin-top: 16px;
+    & tr {
+      border-bottom: 1px solid #dcdcdc;
+    }
+    &-head {
+      & th {
+        padding: 5px 15px;
+        text-align: left;
+      }
+    }
+    &-body {
+      & td {
+        padding: 10px;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/molecules/ArticleTrashedList/index.vue
+++ b/src/components/molecules/ArticleTrashedList/index.vue
@@ -57,7 +57,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .trashed{
   &-table {
     width: 100%;

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -14,6 +14,8 @@ import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
+import ArticleTrashedHead from './ArticleTrashedHead/index.vue';
+import ArticleTrashedList from './ArticleTrashedList/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
 import PageNation from './PageNation/index.vue';
@@ -35,6 +37,8 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrashedHead,
+  ArticleTrashedList,
   DeleteModal,
   Notice,
   PageNation,

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="article_trashed">
+    <app-article-trashed-head />
+    <app-article-trashed-list
+      :theads="theads"
+      :trashed-list="trashedList"
+    />
+  </div>
+</template>
+
+<script>
+import { ArticleTrashedHead, ArticleTrashedList } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashedHead: ArticleTrashedHead,
+    appArticleTrashedList: ArticleTrashedList,
+  },
+  data() {
+    return {
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    trashedList() {
+      return this.$store.state.articles.trashedList;
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getTrashedArticles');
+  },
+};
+</script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -18,6 +18,7 @@ import ArticleList from '@Pages/Articles/List.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -115,6 +116,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -24,6 +24,7 @@ export default {
       },
     },
     articleList: [],
+    trashedList: [],
     deleteArticleId: null,
     loading: false,
     doneMessage: '',
@@ -121,6 +122,9 @@ export default {
     setPageNumber(state, { current_page: currentPage, last_page: totalPages }) {
       state.pageData.currentPage = currentPage;
       state.pageData.totalPages = totalPages;
+    },
+    doneGetTrashedArticles(state, payload) {
+      state.trashedList = payload;
     },
   },
   actions: {
@@ -288,6 +292,16 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    getTrashedArticles({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(({ data }) => {
+        commit('doneGetTrashedArticles', data.articles);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
[GIZFE-473](https://gizumo.backlog.com/view/GIZFE-473)

## 作業内容
削除済み記事一覧機能の実装

## 動作確認
- 削除済み記事一覧を表示するためのボタンを押したら、そのページに移動すること
- 削除済み記事の一覧が表示されること
- タイトルの表示文字上限は30文字で、31文字以上の場合は3点リーダーが表示されていること
- 本文の表示文字上限は30文字で、31文字以上の場合は3点リーダーが表示されていること
- 作成日はyyyy-mm-ddの形式で表示されていること
- 全ての記事一覧へ戻るボタンがクリックされたら、記事一覧画面の1ページ目に遷移すること