### PR TITLE
削除済記事一覧画面実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -18,6 +18,8 @@ import ArticleList from '@Pages/Articles/List';
 import ArticleDetail from '@Pages/Articles/Detail';
 import ArticleEdit from '@Pages/Articles/Edit';
 import ArticlePost from '@Pages/Articles/Post';
+import ArticleTrashed from '@Pages/Articles/Trashed';
+
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile';
@@ -115,6 +117,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -32,6 +32,7 @@ export default {
     perPage: 30,
     currentPage: null,
     totalPage: null,
+    trashedArticles: [],
   },
   getters: {
     transformedArticles(state) {
@@ -51,6 +52,9 @@ export default {
     deleteArticleId: state => state.deleteArticleId,
   },
   mutations: {
+    setTrashedArticles(state, payload) {
+      state.trashedArticles = payload;
+    },
     currentPageDisplay(state, payload) {
       state.articleList = payload;
     },
@@ -311,6 +315,17 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    getTrashedArticles({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then((res) => {
+        const payload = res.data.articles;
+        commit('setTrashedArticles', payload);
+      }).catch((err) => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };

--- a/src/js/components/molecules/ArticleList/index.vue
+++ b/src/js/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__trashed"
+    >
+      削除済記事一覧
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -151,6 +163,9 @@ export default {
       .fade-enter-active, .fade-leave-active {
         transition: opacity .5s;
       }
+    }
+    &__trashed {
+      margin-left: 20px;
     }
     .fade-enter, .fade-leave-to {
       opacity: 0;

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -16,9 +16,9 @@
     <table class="trashed-table">
       <thead class="trashed-table__head">
         <tr>
-          <th v-for="(thead, index) in theads" :key="index">
+          <th v-for="(array, index) in $options.titleArray" :key="index">
             <app-text tag="span" theme-color bold>
-              {{ thead }}
+              {{ array }}
             </app-text>
           </th>
         </tr>
@@ -48,23 +48,20 @@ import {
 } from '@Components/atoms';
 
 export default {
+  titleArray: ['タイトル', '本文', '作成日'],
   components: {
     appHeading: Heading,
     appRouterLink: RouterLink,
     appText: Text,
   },
   props: {
-    theads: {
-      type: Array,
-      default: () => [],
-    },
     access: {
       type: Object,
       default: () => ({}),
     },
     trashedArticles: {
       type: Array,
-      default: () => [],
+      required: true,
     },
   },
   computed: {

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -13,7 +13,9 @@
     >
       全ての記事一覧へ戻る
     </app-router-link>
-    <p v-if="!$options.titleArray.length" class="emptyMessage">削除済記事一覧はありません</p>
+    <p v-if="arrayLength === 0" class="emptyMessage">
+      削除済記事一覧はありません
+    </p>
     <table class="trashed-table">
       <thead class="trashed-table__head">
         <tr>
@@ -71,6 +73,9 @@ export default {
     },
     formatDate() {
       return date => date.substring(0, 10);
+    },
+    arrayLength() {
+      return this.trashedArticles.length;
     },
   },
 };

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -1,0 +1,126 @@
+<template lang="html">
+  <div>
+    <section class="article-trashed">
+      <app-heading :level="1">削除済記事一覧</app-heading>
+    </section>
+    <app-router-link
+      to="/articles?page=1"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-lists"
+    >
+      全ての記事一覧へ戻る
+    </app-router-link>
+    <table class="trashed-table">
+      <thead class="trashed-table__head">
+        <tr>
+          <th v-for="(thead, index) in theads" :key="index">
+            <app-text tag="span" theme-color bold>
+              {{ thead }}
+            </app-text>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="trashed-table__body">
+        <tr v-for="article in trashedArticles" :key="article.id">
+          <td class="trashed-table__title">
+            <app-text tag="span" small>{{ formatText(article.title) }}</app-text>
+          </td>
+          <td class="trashed-table__content">
+            <app-text tag="span" small>{{ formatText(article.content) }}</app-text>
+          </td>
+          <td class="trashed-table__create">
+            <app-text tag="span" small>{{ formatDate(article.created_at) }}</app-text>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import {
+  Heading,
+  RouterLink,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+    appText: Text,
+  },
+  props: {
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    trashedArticles: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    formatText() {
+      return text => (text.length >= 30 ? `${text.substring(0, 30)}...` : text);
+    },
+    formatDate() {
+      return date => date.substring(0, 10);
+    },
+  },
+};
+</script>
+<style lang="postcss" scoped>
+.article-lists {
+  margin-top: 10px;
+}
+.trashed-table {
+  width: 100%;
+  margin-top: 40px;
+  text-align: left;
+  background-color: #fff;
+  tr {
+    border-bottom: 1px solid var(--separatorColor);
+  }
+  &__head {
+    th {
+      padding: 5px 10px;
+      vertical-align: middle;
+    }
+  }
+  &__body {
+    td {
+      padding: 10px;
+      vertical-align: middle;
+      &.is-disabled {
+        color: var(--disabledColor);
+        font-size: 12px;
+      }
+    }
+    .fade-enter-active, .fade-leave-active {
+      transition: opacity .5s;
+    }
+    .fade-enter, .fade-leave-to {
+      opacity: 0;
+    }
+  }
+  &__title {
+    width: 40%;
+  }
+  &__content {
+    width: 50%;
+  }
+  &__create {
+    width: 8%;
+  }
+}
+</style>

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -1,8 +1,6 @@
 <template lang="html">
-  <div>
-    <section class="article-trashed">
-      <app-heading :level="1">削除済記事一覧</app-heading>
-    </section>
+  <div class="article-trashed">
+    <app-heading :level="1">削除済記事一覧</app-heading>
     <app-router-link
       to="/articles?page=1"
       key-color

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -69,7 +69,7 @@ export default {
   },
   computed: {
     formatText() {
-      return text => (text.length >= 30 ? `${text.substring(0, 30)}...` : text);
+      return text => (text.length >= 31 ? `${text.substring(0, 30)}...` : text);
     },
     formatDate() {
       return date => date.substring(0, 10);

--- a/src/js/components/molecules/ArticleTrashed/index.vue
+++ b/src/js/components/molecules/ArticleTrashed/index.vue
@@ -13,6 +13,7 @@
     >
       全ての記事一覧へ戻る
     </app-router-link>
+    <p v-if="!$options.titleArray.length" class="emptyMessage">削除済記事一覧はありません</p>
     <table class="trashed-table">
       <thead class="trashed-table__head">
         <tr>
@@ -117,5 +118,9 @@ export default {
   &__create {
     width: 8%;
   }
+}
+.emptyMessage {
+  text-align: center;
+  font-size: 16px;
 }
 </style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -14,6 +14,7 @@ import CategoryList from './CategoryList';
 import ArticleEdit from './ArticleEdit';
 import ArticlePost from './ArticlePost';
 import ArticleDetail from './ArticleDetail';
+import ArticleTrashed from './ArticleTrashed';
 import DeleteModal from './Modal';
 import Notice from './Notice';
 import CategoryEdit from './CategoryEdit';
@@ -38,4 +39,5 @@ export {
   PageNation,
   DeleteModal,
   Notice,
+  ArticleTrashed,
 };

--- a/src/js/pages/Articles/Trashed.vue
+++ b/src/js/pages/Articles/Trashed.vue
@@ -1,6 +1,5 @@
 <template lang="html">
   <app-article-trashed
-    :theads="theads"
     :trashed-articles="trashedArticles"
   />
 </template>
@@ -11,11 +10,6 @@ import { ArticleTrashed } from '@Components/molecules';
 export default {
   components: {
     appArticleTrashed: ArticleTrashed,
-  },
-  data() {
-    return {
-      theads: ['タイトル', '本文', '作成日'],
-    };
   },
   computed: {
     trashedArticles() {

--- a/src/js/pages/Articles/Trashed.vue
+++ b/src/js/pages/Articles/Trashed.vue
@@ -1,10 +1,8 @@
 <template lang="html">
-  <section>
-    <app-article-trashed
-      :theads="theads"
-      :trashed-articles="trashedArticles"
-    />
-  </section>
+  <app-article-trashed
+    :theads="theads"
+    :trashed-articles="trashedArticles"
+  />
 </template>
 
 <script>

--- a/src/js/pages/Articles/Trashed.vue
+++ b/src/js/pages/Articles/Trashed.vue
@@ -1,0 +1,36 @@
+<template lang="html">
+  <section>
+    <app-article-trashed
+      :theads="theads"
+      :trashed-articles="trashedArticles"
+    />
+  </section>
+</template>
+
+<script>
+import { ArticleTrashed } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashed: ArticleTrashed,
+  },
+  data() {
+    return {
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    trashedArticles() {
+      return this.$store.state.articles.trashedArticles;
+    },
+  },
+  created() {
+    this.getTrashedArticles();
+  },
+  methods: {
+    getTrashedArticles() {
+      this.$store.dispatch('articles/getTrashedArticles');
+    },
+  },
+};
+</script>


### PR DESCRIPTION
[チケットのリンク](https://gizumo.backlog.com/view/GIZFE-485#comment-200664167)

作業内容：削除済記事一覧の画面実装

動作確認

- 削除済記事一覧が表示されているか
- 指定されている文字数で表示されているか
- 指定されている文字数よりも多い場合ドットが表示されているか
- 記事一覧へ戻るボタン押下時に記事一覧へ戻るか