### PR TITLE
カテゴリ一削除機能実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -183,8 +183,8 @@ export default {
 .category-list__modal {
   text-align: center;
   &__name {
-    margin-top: 16px;
-    font-size: 16px;
+    margin-top: 25px;
+    font-size: 25px;
     color: $theme-color;
   }
   &__button {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -14,27 +14,37 @@
     <app-category-list
       class="category-list"
       :categories="categoriesList"
+      :delete-category-name="deleteCategoryName"
+      :theads="theads"
       :access="access"
+      @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       targetCategory: '',
+      theads: ['カテゴリー名'],
     };
   },
   computed: {
     categoriesList() {
       return this.$store.state.categories.categoryList;
+    },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
     },
     disabled() {
       return this.$store.state.categories.disabled;
@@ -64,6 +74,18 @@ export default {
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/confirmDeleteCategories', {
+        categoryId, categoryName,
+      });
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategories').then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+      this.toggleModal();
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -57,14 +57,14 @@ export default {
     confirmDeleteCategories({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategories', { categoryId, categoryName });
     },
-    deleteCategories({ commit, rootGetters }) {
+    deleteCategories({ commit, rootGetters, state }) {
       return new Promise(resolve => {
         commit('clearMessage');
         const data = new URLSearchParams();
-        data.append('id', rootGetters['categories/deleteCategoryId']);
+        data.append('id', state.deleteCategoryId);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          url: `/category/${state.deleteCategoryId}`,
           data,
         }).then(() => {
           commit('doneDeleteCategory');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,12 @@ export default {
     disabled: false,
     errorMessage: '',
     doneMessage: '',
+    deleteCategoryId: null,
+    deleteCategoryName: '',
+  },
+  getters: {
+    deleteCategoryId: state => state.deleteCategoryId,
+    deleteCategoryName: state => state.deleteCategoryName,
   },
   mutations: {
     doneGetCategories(state, payload) {
@@ -14,6 +20,14 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
+    },
+    confirmDeleteCategories(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
     },
     toggleDisabled(state) {
       state.disabled = !state.disabled;
@@ -38,6 +52,27 @@ export default {
         commit('doneGetCategories', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    confirmDeleteCategories({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategories', { categoryId, categoryName });
+    },
+    deleteCategories({ commit, rootGetters }) {
+      return new Promise(resolve => {
+        commit('clearMessage');
+        const data = new URLSearchParams();
+        data.append('id', rootGetters['categories/deleteCategoryId']);
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          data,
+        }).then(() => {
+          commit('doneDeleteCategory');
+          commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
       });
     },
     postCategories({ commit, rootGetters }, targetCategory) {


### PR DESCRIPTION
### チケットリンク
https://gizumo.backlog.com/view/GIZFE-482
### 内容
- カテゴリー一覧の削除ボタンを押したら、削除APIが実行される
### 動作確認
- 削除ボタンを押したら、削除確認用のモーダルが出現する
- 削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行
- 削除確認用のモーダル内部の削除ボタンをクリックした後モーダルが閉じる
- 成功したら一覧が更新され、メッセージを表示