### PR TITLE
カテゴリ一新規作成機能実装

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -57,7 +57,11 @@ export default {
       this.$store.dispatch('categories/postCategory', {
         name: this.$store.state.categories.category,
       }).then(() => {
-        this.$router.go({ path: this.$router.currentRoute.path, force: true });
+        this.$store.dispatch('categories/getAllCategories');
+        this.$router.push({
+          path: '/categories',
+          query: { redirect: '/categories' },
+        });
       });
     },
     updateValue($event) {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -3,6 +3,7 @@
     <app-category-post
       class="category-post"
       :access="access"
+      :category="category"
       :error-message="errorMessage"
       @update-value="updateValue"
       @clear-message="clearMessage"
@@ -37,6 +38,9 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    category() {
+      return this.$store.state.categories.category;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
@@ -47,7 +51,8 @@ export default {
   methods: {
     handleSubmit() {
     },
-    updateValue() {
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event.target.value);
     },
     clearMessage() {
     },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,6 +2,7 @@
   <div class="wrapper">
     <app-category-post
       class="category-post"
+      :disabled="loading ? true : false"
       :access="access"
       :category="category"
       :done-message="doneMessage"
@@ -33,6 +34,9 @@ export default {
     };
   },
   computed: {
+    loading() {
+      return this.$store.state.categories.loading;
+    },
     categoryList() {
       return this.$store.state.categories.categoryList;
     },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -50,6 +50,15 @@ export default {
   },
   methods: {
     handleSubmit() {
+      this.$store.dispatch('categories/postCategory', {
+        name: this.$store.state.categories.category,
+      }).then(() => {
+        console.log('submit');
+        this.$router.push({
+          path: '/categories',
+          query: { redirect: '/categories/post' },
+        });
+      });
     },
     updateValue($event) {
       this.$store.dispatch('categories/updateValue', $event.target.value);

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -56,7 +56,6 @@ export default {
         console.log('submit');
         this.$router.push({
           path: '/categories',
-          query: { redirect: '/categories/post' },
         });
       });
     },
@@ -64,6 +63,7 @@ export default {
       this.$store.dispatch('categories/updateValue', $event.target.value);
     },
     clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -4,6 +4,7 @@
       class="category-post"
       :access="access"
       :category="category"
+      :done-message="doneMessage"
       :error-message="errorMessage"
       @update-value="updateValue"
       @clear-message="clearMessage"
@@ -40,6 +41,9 @@ export default {
     },
     category() {
       return this.$store.state.categories.category;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,7 +2,7 @@
   <div class="wrapper">
     <app-category-post
       class="category-post"
-      :disabled="loading ? true : false"
+      :disabled="loading"
       :access="access"
       :category="category"
       :done-message="doneMessage"

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -31,6 +31,7 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      category: '',
     };
   },
   computed: {
@@ -42,9 +43,6 @@ export default {
     },
     access() {
       return this.$store.getters['auth/access'];
-    },
-    category() {
-      return this.$store.state.categories.category;
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
@@ -59,13 +57,14 @@ export default {
   methods: {
     handleSubmit() {
       this.$store.dispatch('categories/postCategory', {
-        name: this.$store.state.categories.category,
+        name: this.category,
       }).then(() => {
+        this.category = '';
         this.$store.dispatch('categories/getAllCategories');
       });
     },
     updateValue($event) {
-      this.$store.dispatch('categories/updateValue', $event.target.value);
+      this.category = $event.target.value;
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -4,6 +4,9 @@
       class="category-post"
       :access="access"
       :error-message="errorMessage"
+      @update-value="updateValue"
+      @clear-message="clearMessage"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       class="category-list"
@@ -40,6 +43,14 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    handleSubmit() {
+    },
+    updateValue() {
+    },
+    clearMessage() {
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -56,12 +56,14 @@ export default {
   },
   methods: {
     handleSubmit() {
-      this.$store.dispatch('categories/postCategory', {
-        name: this.category,
-      }).then(() => {
-        this.category = '';
-        this.$store.dispatch('categories/getAllCategories');
-      });
+      if (!this.$store.loading) {
+        this.$store.dispatch('categories/postCategory', {
+          name: this.category,
+        }).then(() => {
+          this.category = '';
+          this.$store.dispatch('categories/getAllCategories');
+        });
+      }
     },
     updateValue($event) {
       this.category = $event.target.value;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -53,10 +53,7 @@ export default {
       this.$store.dispatch('categories/postCategory', {
         name: this.$store.state.categories.category,
       }).then(() => {
-        console.log('submit');
-        this.$router.push({
-          path: '/categories',
-        });
+        this.$router.go({ path: this.$router.currentRoute.path, force: true });
       });
     },
     updateValue($event) {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -58,10 +58,6 @@ export default {
         name: this.$store.state.categories.category,
       }).then(() => {
         this.$store.dispatch('categories/getAllCategories');
-        this.$router.push({
-          path: '/categories',
-          query: { redirect: '/categories' },
-        });
       });
     },
     updateValue($event) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,8 +19,7 @@ export default {
     },
     clearMessage(state) {
       state.errorMessage = '';
-      console.log('clearMessage');
-    }
+    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -46,7 +45,6 @@ export default {
           url: '/category',
           data: name,
         }).then(() => {
-          console.log('resolve');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,7 +5,6 @@ export default {
   state: {
     loading: false,
     categoryList: [],
-    category: '',
     doneMessage: '',
     errorMessage: '',
   },
@@ -20,9 +19,6 @@ export default {
     doneGetAllCategories(state, categories) {
       state.categoryList = categories;
       state.loading = false;
-    },
-    updateValue(state, category) {
-      state.category = category;
     },
     clearMessage(state) {
       state.doneMessage = '';
@@ -42,9 +38,6 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
-    },
-    updateValue({ commit }, category) {
-      commit('updateValue', category);
     },
     clearMessage({ commit }) {
       commit('clearMessage');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -9,7 +9,7 @@ export default {
     errorMessage: '',
   },
   mutations: {
-    applyRequest(state) {
+    toggleLoading(state) {
       state.loading = true;
     },
     failRequest(state, { message }) {
@@ -30,6 +30,7 @@ export default {
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
+      commit('toggleLoading');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/category',
@@ -43,8 +44,7 @@ export default {
       commit('clearMessage');
     },
     postCategory({ commit, rootGetters }, name) {
-      commit('applyRequest');
-
+      commit('toggleLoading');
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'POST',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,6 +5,7 @@ export default {
   state: {
     categoryList: [],
     category: '',
+    doneMessage: '',
     errorMessage: '',
   },
   mutations: {
@@ -18,7 +19,11 @@ export default {
       state.category = category;
     },
     clearMessage(state) {
+      state.doneMessage = '';
       state.errorMessage = '';
+    },
+    displayDoneMessage(state) {
+      state.doneMessage = '成功しました';
     },
   },
   actions: {
@@ -45,6 +50,7 @@ export default {
           url: '/category',
           data: name,
         }).then(() => {
+          commit('displayDoneMessage');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -42,6 +42,7 @@ export default {
     },
     postCategory({ commit, rootGetters }, name) {
       return new Promise(resolve => {
+        commit('toggleLoading');
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
@@ -54,7 +55,6 @@ export default {
           commit('failRequest', { message: err.message });
           commit('toggleLoading');
         });
-        commit('toggleLoading');
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -17,6 +17,10 @@ export default {
     updateValue(state, category) {
       state.category = category;
     },
+    clearMessage(state) {
+      state.errorMessage = '';
+      console.log('clearMessage');
+    }
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -32,6 +36,9 @@ export default {
     updateValue({ commit }, category) {
       commit('updateValue', category);
     },
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
     postCategory({ commit, rootGetters }, name) {
       return new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
@@ -42,7 +49,7 @@ export default {
           console.log('resolve');
           resolve();
         }).catch(err => {
-          console.log('reject');
+          commit('failRequest', { message: err.message });
           reject();
         });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -28,23 +28,19 @@ export default {
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
-      commit('toggleLoading');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/category',
       }).then(res => {
         commit('doneGetAllCategories', res.data.categories.reverse());
-        commit('toggleLoading');
       }).catch(err => {
         commit('failRequest', { message: err.message });
-        commit('toggleLoading');
       });
     },
     clearMessage({ commit }) {
       commit('clearMessage');
     },
     postCategory({ commit, rootGetters }, name) {
-      commit('toggleLoading');
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'POST',
@@ -58,6 +54,7 @@ export default {
           commit('failRequest', { message: err.message });
           commit('toggleLoading');
         });
+        commit('toggleLoading');
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -52,7 +52,7 @@ export default {
     postCategory({ commit, rootGetters }, name) {
       commit('applyRequest');
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
@@ -62,7 +62,6 @@ export default {
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
-          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -32,14 +32,19 @@ export default {
     updateValue({ commit }, category) {
       commit('updateValue', category);
     },
-    postCategory({ commit, rootGetters }) {
-      axios(rootGetters['auth/token'])({
-        method: 'POST',
-        url: '/category',
-      }).then(res => {
-        commit('donePostCategories', res.data.categories.reverse());
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
+    postCategory({ commit, rootGetters }, name) {
+      return new Promise((resolve, reject) => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data: name,
+        }).then(() => {
+          console.log('resolve');
+          resolve();
+        }).catch(err => {
+          console.log('reject');
+          reject();
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,6 +4,7 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
+    category: '',
     errorMessage: '',
   },
   mutations: {
@@ -13,6 +14,9 @@ export default {
     doneGetAllCategories(state, categories) {
       state.categoryList = categories;
     },
+    updateValue(state, category) {
+      state.category = category;
+    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -21,6 +25,19 @@ export default {
         url: '/category',
       }).then(res => {
         commit('doneGetAllCategories', res.data.categories.reverse());
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    updateValue({ commit }, category) {
+      commit('updateValue', category);
+    },
+    postCategory({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+      }).then(res => {
+        commit('donePostCategories', res.data.categories.reverse());
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,17 +3,23 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    loading: false,
     categoryList: [],
     category: '',
     doneMessage: '',
     errorMessage: '',
   },
   mutations: {
+    applyRequest(state) {
+      state.loading = true;
+    },
     failRequest(state, { message }) {
       state.errorMessage = message;
+      state.loading = false;
     },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories;
+      state.loading = false;
     },
     updateValue(state, category) {
       state.category = category;
@@ -44,6 +50,8 @@ export default {
       commit('clearMessage');
     },
     postCategory({ commit, rootGetters }, name) {
+      commit('applyRequest');
+
       return new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
           method: 'POST',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,15 +10,13 @@ export default {
   },
   mutations: {
     toggleLoading(state) {
-      state.loading = true;
+      state.loading = !state.loading;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
-      state.loading = false;
     },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories;
-      state.loading = false;
     },
     clearMessage(state) {
       state.doneMessage = '';
@@ -36,8 +34,10 @@ export default {
         url: '/category',
       }).then(res => {
         commit('doneGetAllCategories', res.data.categories.reverse());
+        commit('toggleLoading');
       }).catch(err => {
         commit('failRequest', { message: err.message });
+        commit('toggleLoading');
       });
     },
     clearMessage({ commit }) {
@@ -52,9 +52,11 @@ export default {
           data: name,
         }).then(() => {
           commit('displayDoneMessage');
+          commit('toggleLoading');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
+          commit('toggleLoading');
         });
       });
     },


### PR DESCRIPTION
### 内容
カテゴリー新規作成処理の実装
[課題へのリンク](https://gizumo.backlog.com/view/GIZFE-508)

- 作成ボタン押下時にカテゴリー作成API呼び出し処理の追加
- APIから返されるエラーメッセージ・成功メッセージ表示処理の追加
- カテゴリー作成時、カテゴリー取得API呼び出し処理追加

### テスト項目
[テスト項目一覧へのリンク](https://gizumo.backlog.com/view/GIZFE-510)