### PR TITLE
カテゴリ一更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -91,7 +91,7 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('update-categories');
+        if (valid) this.$emit('update-category');
       });
     },
   },

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,119 @@
+<template>
+  <section class="category-edit">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="category-edit__back">
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        :to="`/categories`"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+
+    <form class="category-edit__form" @submit.prevent="updateCategories">
+      <div class="category-edit__input">
+        <app-input
+          v-validate="'required'"
+          name="categoryName"
+          type="text"
+          placeholder="カテゴリー名"
+          data-vv-as="カテゴリー名"
+          :error-messages="errors.collect('categoryName')"
+          :value="categoryName"
+          @update-value="$emit('edited-name', $event)"
+        />
+      </div>
+
+      <div class="category-edit__submit">
+        <app-button
+          button-type="submit"
+          :disabled="disabled || !access.edit"
+          round
+        >
+          {{ buttonText }}
+        </app-button>
+      </div>
+
+      <div v-if="errorMessage" class="category-edit__notice">
+        <app-text bg-error>{{ errorMessage }}</app-text>
+      </div>
+
+      <div v-if="doneMessage" class="category-edit__notice">
+        <app-text bg-success>{{ doneMessage }}</app-text>
+      </div>
+    </form>
+  </section>
+</template>
+
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    categoryName: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.create) return '作成権限がありません';
+      return this.disabled ? '作成中...' : '作成';
+    },
+  },
+  methods: {
+    updateCategories() {
+      if (!this.access.edit) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('update-categories');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-edit {
+  &__back {
+    margin-top: 16px;
+  }
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,41 +1,38 @@
 <template>
   <section class="category-edit">
     <app-heading :level="1">カテゴリー管理</app-heading>
-    <div class="category-edit__back">
-      <app-router-link
-        block
-        underline
-        key-color
-        hover-opacity
-        :to="`/categories`"
+    <app-router-link
+      class="category-edit__back"
+      block
+      underline
+      key-color
+      hover-opacity
+      :to="`/categories`"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+
+    <form class="category-edit__form" @submit.prevent="updateCategory">
+      <app-input
+        v-validate="'required'"
+        class="category-edit__input"
+        name="categoryName"
+        type="text"
+        placeholder="カテゴリー名"
+        data-vv-as="カテゴリー名"
+        :error-messages="errors.collect('categoryName')"
+        :value="categoryName"
+        @update-value="$emit('edited-name', $event)"
+      />
+
+      <app-button
+        class="category-edit__submit"
+        button-type="submit"
+        :disabled="disabled || !access.edit"
+        round
       >
-        カテゴリー一覧へ戻る
-      </app-router-link>
-    </div>
-
-    <form class="category-edit__form" @submit.prevent="updateCategories">
-      <div class="category-edit__input">
-        <app-input
-          v-validate="'required'"
-          name="categoryName"
-          type="text"
-          placeholder="カテゴリー名"
-          data-vv-as="カテゴリー名"
-          :error-messages="errors.collect('categoryName')"
-          :value="categoryName"
-          @update-value="$emit('edited-name', $event)"
-        />
-      </div>
-
-      <div class="category-edit__submit">
-        <app-button
-          button-type="submit"
-          :disabled="disabled || !access.edit"
-          round
-        >
-          {{ buttonText }}
-        </app-button>
-      </div>
+        {{ buttonText }}
+      </app-button>
 
       <div v-if="errorMessage" class="category-edit__notice">
         <app-text bg-error>{{ errorMessage }}</app-text>
@@ -85,12 +82,12 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '作成権限がありません';
-      return this.disabled ? '作成中...' : '作成';
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {
-    updateCategories() {
+    updateCategory() {
       if (!this.access.edit) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -12,7 +12,7 @@
       カテゴリー一覧へ戻る
     </app-router-link>
 
-    <form class="category-edit__form" @submit.prevent="updateCategory">
+    <form @submit.prevent="updateCategory">
       <app-input
         v-validate="'required'"
         class="category-edit__input"
@@ -82,7 +82,7 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '更新権限がありません';
+      if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
     },
   },

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -8,6 +8,7 @@ import UserCreate from './UserCreate/index.vue';
 import UserTable from './UserTable/index.vue';
 import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
@@ -27,6 +28,7 @@ export {
   UserTable,
   UserDetail,
   UserList,
+  CategoryEdit,
   CategoryPost,
   CategoryList,
   ArticleEdit,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,15 +1,13 @@
 <template>
-  <div>
-    <app-category-edit
-      :category-name="categoryName"
-      :error-message="errorMessage"
-      :done-message="doneMessage"
-      :disabled="disabled"
-      :access="access"
-      @edited-name="editedName"
-      @update-categories="updateCategories"
-    />
-  </div>
+  <app-category-edit
+    :category-name="categoryName"
+    :error-message="errorMessage"
+    :done-message="doneMessage"
+    :disabled="disabled"
+    :access="access"
+    @edited-name="editedName"
+    @update-categories="updateCategory"
+  />
 </template>
 
 <script>
@@ -44,9 +42,9 @@ export default {
     editedName($event) {
       this.$store.dispatch('categories/editedName', $event.target.value);
     },
-    updateCategories() {
+    updateCategory() {
       if (this.disabled) return;
-      this.$store.dispatch('categories/updateCategories');
+      this.$store.dispatch('categories/updateCategory');
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <app-category-edit
+      :category-name="categoryName"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      :disabled="disabled"
+      :access="access"
+      @edited-name="editedName"
+      @update-categories="updateCategories"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    categoryName() {
+      const { name } = this.$store.state.categories.targetCategory;
+      return name;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategories', this.$route.params.id);
+  },
+  methods: {
+    editedName($event) {
+      this.$store.dispatch('categories/editedName', $event.target.value);
+    },
+    updateCategories() {
+      if (this.disabled) return;
+      this.$store.dispatch('categories/updateCategories');
+    },
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -6,7 +6,8 @@
     :disabled="disabled"
     :access="access"
     @edited-name="editedName"
-    @update-categories="updateCategory"
+    @update-category="updateCategory"
+    @clear-message="clearMessage"
   />
 </template>
 
@@ -36,6 +37,7 @@ export default {
     },
   },
   created() {
+    this.$store.dispatch('categories/initCategory');
     this.$store.dispatch('categories/getCategories', this.$route.params.id);
   },
   methods: {
@@ -45,6 +47,9 @@ export default {
     updateCategory() {
       if (this.disabled) return;
       this.$store.dispatch('categories/updateCategory');
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -3,7 +3,7 @@
     :category-name="categoryName"
     :error-message="errorMessage"
     :done-message="doneMessage"
-    :disabled="disabled"
+    :disabled="isLoading"
     :access="access"
     @edited-name="editedName"
     @update-category="updateCategory"
@@ -23,7 +23,7 @@ export default {
       const { name } = this.$store.state.categories.targetCategory;
       return name;
     },
-    disabled() {
+    isLoading() {
       return this.$store.state.categories.disabled;
     },
     errorMessage() {
@@ -45,7 +45,7 @@ export default {
       this.$store.dispatch('categories/editedName', $event.target.value);
     },
     updateCategory() {
-      if (this.disabled) return;
+      if (this.isLoading) return;
       this.$store.dispatch('categories/updateCategory');
     },
     clearMessage() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -5,7 +5,7 @@
       :category="targetCategory"
       :error-message="errorMessage"
       :done-message="doneMessage"
-      :disabled="disabled"
+      :disabled="isLoading"
       :access="access"
       @handle-submit="handleSubmit"
       @update-value="uptargetCategory"
@@ -46,7 +46,7 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
-    disabled() {
+    isLoading() {
       return this.$store.state.categories.disabled;
     },
     errorMessage() {
@@ -64,7 +64,7 @@ export default {
   },
   methods: {
     handleSubmit() {
-      if (this.disabled) return;
+      if (this.isLoading) return;
       this.$store.dispatch('categories/postCategories', this.targetCategory).then(() => {
         this.$store.dispatch('categories/getAllCategories');
       });

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -60,6 +60,7 @@ export default {
     },
   },
   created() {
+    this.$store.dispatch('categories/clearMessage');
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -17,6 +17,7 @@ import ArticlePost from '@Pages/Articles/Post.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoriesList from '@Pages/Categories/List.vue';
+import CategoriesEdit from '@Pages/Categories/Edit.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'categoriesList',
           path: '',
           component: CategoriesList,
+        },
+        {
+          name: 'categoriesEdit',
+          path: ':id',
+          component: CategoriesEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,19 +19,34 @@ export default {
     deleteCategoryName: state => state.deleteCategoryName,
   },
   mutations: {
+    initCategory(state) {
+      state.targetCategory = {
+        id: null,
+        name: '',
+      };
+    },
+    doneGetCategories(state, payload) {
+      state.targetCategory = { ...payload };
+    },
+    editedName(state, payload) {
+      state.targetCategory = { ...state.targetCategory, name: payload.name };
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
-    doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
-      state.deleteCategoryName = '';
+    updateCategory(state, { targetCategory }) {
+      state.targetCategory = { ...state.targetCategory, ...targetCategory };
     },
     confirmDeleteCategories(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
     },
     toggleDisabled(state) {
       state.disabled = !state.disabled;
@@ -43,17 +58,11 @@ export default {
     displayDoneMessage(state, payload) {
       state.doneMessage = payload.message;
     },
-    editedName(state, payload) {
-      state.targetCategory = { ...state.targetCategory, name: payload.name };
-    },
-    updateCategory(state, { targetCategory }) {
-      state.targetCategory = { ...state.targetCategory, ...targetCategory };
-    },
-    doneGetCategories(state, payload) {
-      state.targetCategory = { ...payload };
-    },
   },
   actions: {
+    initCategory({ commit }) {
+      commit('initCategory');
+    },
     getAllCategories({ commit, rootGetters }) {
       commit('clearMessage');
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -46,7 +46,7 @@ export default {
     editedName(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
-    updateCategories(state, { targetCategory }) {
+    updateCategory(state, { targetCategory }) {
       state.targetCategory = { ...state.targetCategory, ...targetCategory };
     },
     doneGetCategories(state, payload) {
@@ -74,7 +74,6 @@ export default {
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then(res => {
-        // NOTE: エラー時はresponse.data.codeが0で返ってくる。
         if (res.data.code === 0) throw new Error(res.data.message);
         const payload = {
           id: res.data.category.id,
@@ -91,7 +90,7 @@ export default {
         name,
       });
     },
-    updateCategories({ commit, rootGetters, state }) {
+    updateCategory({ commit, rootGetters, state }) {
       return new Promise(resolve => {
         commit('clearMessage');
         commit('toggleDisabled');
@@ -109,7 +108,7 @@ export default {
               name: res.data.category.name,
             },
           };
-          commit('updateCategories', payload);
+          commit('updateCategory', payload);
           commit('toggleDisabled');
           commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
           resolve();

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -64,7 +64,6 @@ export default {
       commit('initCategory');
     },
     getAllCategories({ commit, rootGetters }) {
-      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/category',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -116,8 +116,8 @@ export default {
       commit('confirmDeleteCategories', { categoryId, categoryName });
     },
     deleteCategories({ commit, rootGetters, state }) {
-      commit('clearMessage');
       return new Promise(resolve => {
+        commit('clearMessage');
         const data = new URLSearchParams();
         data.append('id', state.deleteCategoryId);
         axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -29,7 +29,7 @@ export default {
       state.targetCategory = { ...payload };
     },
     editedName(state, payload) {
-      state.targetCategory = { ...state.targetCategory, name: payload.name };
+      state.targetCategory.name = payload;
     },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
@@ -94,45 +94,31 @@ export default {
       });
     },
     editedName({ commit }, name) {
-      commit({
-        type: 'editedName',
-        name,
-      });
+      commit('editedName', name);
     },
     updateCategory({ commit, rootGetters, state }) {
-      return new Promise(resolve => {
-        commit('clearMessage');
+      commit('clearMessage');
+      commit('toggleDisabled');
+      const data = new URLSearchParams();
+      data.append('name', state.targetCategory.name);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.targetCategory.id}`,
+        data,
+      }).then(() => {
         commit('toggleDisabled');
-        const data = new URLSearchParams();
-        data.append('id', state.targetCategory.id);
-        data.append('name', state.targetCategory.name);
-        axios(rootGetters['auth/token'])({
-          method: 'PUT',
-          url: `/category/${state.targetCategory.id}`,
-          data,
-        }).then(res => {
-          const payload = {
-            targetCategory: {
-              id: res.data.category.id,
-              name: res.data.category.name,
-            },
-          };
-          commit('updateCategory', payload);
-          commit('toggleDisabled');
-          commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
-          resolve();
-        }).catch(err => {
-          commit('toggleDisabled');
-          commit('failRequest', { message: err.message });
-        });
+        commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
+      }).catch(err => {
+        commit('toggleDisabled');
+        commit('failRequest', { message: err.message });
       });
     },
     confirmDeleteCategories({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategories', { categoryId, categoryName });
     },
     deleteCategories({ commit, rootGetters, state }) {
+      commit('clearMessage');
       return new Promise(resolve => {
-        commit('clearMessage');
         const data = new URLSearchParams();
         data.append('id', state.deleteCategoryId);
         axios(rootGetters['auth/token'])({


### PR DESCRIPTION
### チケットリンク
https://gizumo.backlog.com/view/GIZFE-505
### 内容
- カテゴリを編集するための画面をデザインから作成
- カテゴリ更新機能を実装する
### 動作確認
- カテゴリー管理画面の「更新」をクリックすると、カテゴリー編集画面へ遷移
- カテゴリー編集画面の「カテゴリー一覧へ戻る」をクリックすると、カテゴリー管理画面へ遷移
- 更新ボタンをクリックするとAPI通信が実行され、カテゴリーが入力欄の内容に更新される
- API通信が成功、失敗した場合はメッセージが表示される
