### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -88,7 +88,7 @@ export default {
   computed: {
     buttonText() {
       if (!this.access.edit) return '更新権限がありません';
-      return this.loading ? '更新中...' : '更新';
+      return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -18,7 +18,7 @@
       type="text"
       placeholder="カテゴリー名を入力してください。"
       white-bg
-      data-vv-as="カテゴリー"
+      data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="categoryName"
       @update-value="$emit('edited-category', $event)"

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -8,25 +8,23 @@
         key-color
         hover-opacity
         to="/categories"
+        class="category-management-edit__back"
       >
         カテゴリー一覧へ戻る
       </app-router-link>
-
-      <div class="category-edit-form">
-        <app-input
-          v-validate="'required'"
-          name="title"
-          type="text"
-          placeholder="カテゴリー名を入力してください。"
-          white-bg
-          data-vv-as="カテゴリー"
-          :error-messages="errors.collect('title')"
-          :value="categoryName"
-          @update-value="$emit('edited-category', $event)"
-        />
-      </div>
+      <app-input
+        v-validate="'required'"
+        name="title"
+        type="text"
+        placeholder="カテゴリー名を入力してください。"
+        white-bg
+        data-vv-as="カテゴリー"
+        :error-messages="errors.collect('title')"
+        :value="categoryName"
+        @update-value="$emit('edited-category', $event)"
+      />
       <app-button
-        class="category-edit-submit"
+        class="category-management-edit__submit"
         button-type="submit"
         round
         :disabled="disabled || !access.create"
@@ -34,10 +32,10 @@
       >
         {{ buttonText }}
       </app-button>
-      <div v-if="errorMessage" class="category-management-post__notice">
+      <div v-if="errorMessage" class="category-management-edit__notice">
         <app-text bg-error>{{ errorMessage }}</app-text>
       </div>
-      <div v-if="doneMessage" class="category-management-post__notice">
+      <div v-if="doneMessage" class="category-management-edit__notice">
         <app-text bg-success>{{ doneMessage }}</app-text>
       </div>
     </section>
@@ -99,4 +97,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.category-management-edit {
+  &__submit {
+    margin-top: 16px;
+  }
+  &__back {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
 </style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -60,7 +60,7 @@ export default {
     },
     categoryName: {
       type: String,
-      default: '',
+      required: true,
     },
     errorMessage: {
       type: String,

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,45 +1,46 @@
 <template>
   <div class="category-edit">
-    <div v-if="doneMessage" class="category-edit__notice--update">
-      <app-text bg-success>{{ doneMessage }}</app-text>
-    </div>
-    <div class="category-edit__columns">
-      <section class="category-edit-editor">
-        <app-heading :level="1">カテゴリー管理</app-heading>
-        <app-router-link
-          block
-          underline
-          key-color
-          hover-opacity
-          to="/categories"
-        >
-          カテゴリー一覧へ戻る
-        </app-router-link>
+    <section class="category-edit-editor">
+      <app-heading :level="1">カテゴリー管理</app-heading>
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        to="/categories"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
 
-        <div class="category-edit-form">
-          <app-input
-            v-validate="'required'"
-            name="title"
-            type="text"
-            placeholder="カテゴリー名を入力してください。"
-            white-bg
-            data-vv-as="カテゴリー"
-            :error-messages="errors.collect('title')"
-            :value="categoryName"
-            @update-value="$emit('edited-category', $event)"
-          />
-        </div>
-        <app-button
-          class="category-edit-submit"
-          button-type="submit"
-          round
-          :disabled="disabled || !access.create"
-          @click="$emit('handle-submit', $event)"
-        >
-          {{ buttonText }}
-        </app-button>
-      </section>
-    </div>
+      <div class="category-edit-form">
+        <app-input
+          v-validate="'required'"
+          name="title"
+          type="text"
+          placeholder="カテゴリー名を入力してください。"
+          white-bg
+          data-vv-as="カテゴリー"
+          :error-messages="errors.collect('title')"
+          :value="categoryName"
+          @update-value="$emit('edited-category', $event)"
+        />
+      </div>
+      <app-button
+        class="category-edit-submit"
+        button-type="submit"
+        round
+        :disabled="disabled || !access.create"
+        @click="$emit('handle-submit', $event)"
+      >
+        {{ buttonText }}
+      </app-button>
+      <div v-if="errorMessage" class="category-management-post__notice">
+        <app-text bg-error>{{ errorMessage }}</app-text>
+      </div>
+      <div v-if="doneMessage" class="category-management-post__notice">
+        <app-text bg-success>{{ doneMessage }}</app-text>
+      </div>
+    </section>
   </div>
 </template>
 
@@ -70,6 +71,14 @@ export default {
       default: 0,
     },
     categoryName: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
       type: String,
       default: '',
     },

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -62,10 +62,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    categoryId: {
-      type: Number,
-      default: 0,
-    },
     categoryName: {
       type: String,
       default: '',

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -34,7 +34,7 @@
           button-type="submit"
           round
           :disabled="disabled || !access.create"
-          @click="handleSubmit"
+          @click="$emit('handle-submit', $event)"
         >
           {{ buttonText }}
         </app-button>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -54,10 +54,6 @@ export default {
     appRouterLink: RouterLink,
   },
   props: {
-    loading: {
-      type: Boolean,
-      default: false,
-    },
     access: {
       type: Object,
       default: () => ({}),

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -5,44 +5,28 @@
     </div>
     <div class="article-edit__columns">
       <section class="article-edit-editor">
-        <app-heading :level="1">記事の更新</app-heading>
-        <app-heading
-          class="article-edit-editor-title"
-          :level="2"
+        <app-heading :level="1">カテゴリー管理</app-heading>
+        <app-router-link
+          block
+          underline
+          key-color
+          hover-opacity
+          to="/categories"
         >
-          カテゴリーの選択
-        </app-heading>
+          カテゴリー一覧へ戻る
+        </app-router-link>
 
-        <app-heading
-          class="article-edit-editor-title"
-          :level="2"
-        >
-          タイトル・本文の更新
-        </app-heading>
         <div class="article-edit-form">
           <app-input
             v-validate="'required'"
             name="title"
             type="text"
-            placeholder="記事のタイトルを入力してください。"
+            placeholder="カテゴリー名を入力してください。"
             white-bg
-            data-vv-as="記事のタイトル"
+            data-vv-as="カテゴリー"
             :error-messages="errors.collect('title')"
             :value="articleTitle"
-            @update-value="$emit('edited-title', $event)"
-          />
-        </div>
-
-        <div class="article-edit-form">
-          <app-textarea
-            v-validate="'required'"
-            name="content"
-            placeholder="記事の本文をマークダウン記法で入力してください。"
-            white-bg
-            data-vv-as="記事の本文"
-            :error-messages="errors.collect('content')"
-            :value="articleContent"
-            @update-value="$emit('edited-content', $event)"
+            @update-value="$emit('edited-category', $event)"
           />
         </div>
         <app-button
@@ -55,33 +39,38 @@
           {{ buttonText }}
         </app-button>
       </section>
-
-      <article class="article-edit-preview">
-        <app-markdown-preview
-          :markdown-content="markdownContent"
-        />
-      </article>
     </div>
   </div>
 </template>
 
 <script>
 import {
-  Heading, MarkdownPreview, Textarea, Input, Button, Text,
+  Heading, Input, Button, Text, RouterLink,
 } from '@Components/atoms';
 
 export default {
   components: {
     appHeading: Heading,
-    appTextarea: Textarea,
-    appMarkdownPreview: MarkdownPreview,
     appInput: Input,
     appButton: Button,
     appText: Text,
+    appRouterLink: RouterLink,
   },
   props: {
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
+    },
   },
   methods: {
   },

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -33,7 +33,7 @@
           class="category-edit-submit"
           button-type="submit"
           round
-          :disabled="!disabled"
+          :disabled="disabled || !access.create"
           @click="handleSubmit"
         >
           {{ buttonText }}
@@ -72,6 +72,10 @@ export default {
     categoryName: {
       type: String,
       default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="article-edit">
+    <div v-if="doneMessage" class="article-edit__notice--update">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+    <div class="article-edit__columns">
+      <section class="article-edit-editor">
+        <app-heading :level="1">記事の更新</app-heading>
+        <app-heading
+          class="article-edit-editor-title"
+          :level="2"
+        >
+          カテゴリーの選択
+        </app-heading>
+
+        <app-heading
+          class="article-edit-editor-title"
+          :level="2"
+        >
+          タイトル・本文の更新
+        </app-heading>
+        <div class="article-edit-form">
+          <app-input
+            v-validate="'required'"
+            name="title"
+            type="text"
+            placeholder="記事のタイトルを入力してください。"
+            white-bg
+            data-vv-as="記事のタイトル"
+            :error-messages="errors.collect('title')"
+            :value="articleTitle"
+            @update-value="$emit('edited-title', $event)"
+          />
+        </div>
+
+        <div class="article-edit-form">
+          <app-textarea
+            v-validate="'required'"
+            name="content"
+            placeholder="記事の本文をマークダウン記法で入力してください。"
+            white-bg
+            data-vv-as="記事の本文"
+            :error-messages="errors.collect('content')"
+            :value="articleContent"
+            @update-value="$emit('edited-content', $event)"
+          />
+        </div>
+        <app-button
+          class="article-edit-submit"
+          button-type="submit"
+          round
+          :disabled="!disabled"
+          @click="handleSubmit"
+        >
+          {{ buttonText }}
+        </app-button>
+      </section>
+
+      <article class="article-edit-preview">
+        <app-markdown-preview
+          :markdown-content="markdownContent"
+        />
+      </article>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  Heading, MarkdownPreview, Textarea, Input, Button, Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appTextarea: Textarea,
+    appMarkdownPreview: MarkdownPreview,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+  },
+  props: {
+  },
+  computed: {
+  },
+  methods: {
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -27,7 +27,7 @@
       class="category-management-edit__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.create"
+      :disabled="disabled || !access.edit"
     >
       {{ buttonText }}
     </app-button>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,45 +1,43 @@
 <template>
-  <div class="category-edit">
-    <section class="category-edit-editor">
-      <app-heading :level="1">カテゴリー管理</app-heading>
-      <app-router-link
-        block
-        underline
-        key-color
-        hover-opacity
-        to="/categories"
-        class="category-management-edit__back"
-      >
-        カテゴリー一覧へ戻る
-      </app-router-link>
-      <app-input
-        v-validate="'required'"
-        name="category"
-        type="text"
-        placeholder="カテゴリー名を入力してください。"
-        white-bg
-        data-vv-as="カテゴリー"
-        :error-messages="errors.collect('category')"
-        :value="categoryName"
-        @update-value="$emit('edited-category', $event)"
-      />
-      <app-button
-        class="category-management-edit__submit"
-        button-type="submit"
-        round
-        :disabled="disabled || !access.create"
-        @click="$emit('handle-submit', $event)"
-      >
-        {{ buttonText }}
-      </app-button>
-      <div v-if="errorMessage" class="category-management-edit__notice">
-        <app-text bg-error>{{ errorMessage }}</app-text>
-      </div>
-      <div v-if="doneMessage" class="category-management-edit__notice">
-        <app-text bg-success>{{ doneMessage }}</app-text>
-      </div>
-    </section>
-  </div>
+  <form class="category-management-edit" @submit.prevent="editCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      block
+      underline
+      key-color
+      hover-opacity
+      to="/categories"
+      class="category-management-edit__back"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      class="category-management-edit__input"
+      name="category"
+      type="text"
+      placeholder="カテゴリー名を入力してください。"
+      white-bg
+      data-vv-as="カテゴリー"
+      :error-messages="errors.collect('category')"
+      :value="categoryName"
+      @update-value="$emit('edited-category', $event)"
+    />
+    <app-button
+      class="category-management-edit__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.create"
+    >
+      {{ buttonText }}
+    </app-button>
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
 </template>
 
 <script>
@@ -92,6 +90,13 @@ export default {
     },
   },
   methods: {
+    editCategory() {
+      if (!this.access.create) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
   },
 };
 </script>
@@ -102,6 +107,9 @@ export default {
     margin-top: 16px;
   }
   &__back {
+    margin-top: 16px;
+  }
+  &__input {
     margin-top: 16px;
   }
   &__notice {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -14,12 +14,12 @@
       </app-router-link>
       <app-input
         v-validate="'required'"
-        name="title"
+        name="category"
         type="text"
         placeholder="カテゴリー名を入力してください。"
         white-bg
         data-vv-as="カテゴリー"
-        :error-messages="errors.collect('title')"
+        :error-messages="errors.collect('category')"
         :value="categoryName"
         @update-value="$emit('edited-category', $event)"
       />

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="article-edit">
-    <div v-if="doneMessage" class="article-edit__notice--update">
+  <div class="category-edit">
+    <div v-if="doneMessage" class="category-edit__notice--update">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
-    <div class="article-edit__columns">
-      <section class="article-edit-editor">
+    <div class="category-edit__columns">
+      <section class="category-edit-editor">
         <app-heading :level="1">カテゴリー管理</app-heading>
         <app-router-link
           block
@@ -16,7 +16,7 @@
           カテゴリー一覧へ戻る
         </app-router-link>
 
-        <div class="article-edit-form">
+        <div class="category-edit-form">
           <app-input
             v-validate="'required'"
             name="title"
@@ -25,12 +25,12 @@
             white-bg
             data-vv-as="カテゴリー"
             :error-messages="errors.collect('title')"
-            :value="articleTitle"
+            :value="categoryName"
             @update-value="$emit('edited-category', $event)"
           />
         </div>
         <app-button
-          class="article-edit-submit"
+          class="category-edit-submit"
           button-type="submit"
           round
           :disabled="!disabled"
@@ -64,6 +64,14 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
+    },
+    categoryId: {
+      type: Number,
+      default: 0,
+    },
+    categoryName: {
+      type: String,
+      default: '',
     },
   },
   computed: {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -87,7 +87,7 @@ export default {
   },
   methods: {
     editCategory() {
-      if (!this.access.create) return;
+      if (!this.access.edit) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('handle-submit');

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,3 @@
+<template>
+  <router-view />
+</template>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -46,10 +46,7 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/updateCategory', {
-        id: this.$store.state.categories.category.id,
-        name: this.$store.state.categories.category.name,
-      });
+      this.$store.dispatch('categories/updateCategory');
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -36,9 +36,7 @@ export default {
   },
   created() {
     this.clearMessage();
-    this.$store.dispatch('categories/getCategory', {
-      id: this.$route.params.id,
-    });
+    this.$store.dispatch('categories/getCategory', this.$route.params.id);
   },
   beforeDestroy() {
     this.$store.dispatch('categories/initializeCategory');

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -36,6 +36,7 @@ export default {
     },
   },
   created() {
+    this.$store.dispatch('categories/clearMessage');
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategory', {
       id,
@@ -49,6 +50,7 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
+      this.$store.dispatch('categories/clearMessage');
       const { id } = this.$route.params;
       this.$store.dispatch('categories/updateCategory', {
         id,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -40,6 +40,24 @@ export default {
       this.categoryName = $event.target.value;
     },
     handleSubmit() {
+      if (this.loading) return;
+      const { id } = this.$route.params;
+      this.$store.dispatch('categories/updateCategory', {
+        id,
+        name: this.categoryName,
+      });
+    },
+    editUser() {
+      this.$store.dispatch('users/editUser', {
+        id: this.user.id,
+        /* eslint-disable-next-line no-irregular-whitespace */
+        full_name: this.user.fullName.replace(/(　)+/, ' ').trim(),
+        /* eslint-disable-next-line no-irregular-whitespace */
+        account_name: this.user.accountName.replace(/( |　)+/, '').trim(),
+        /* eslint-disable-next-line no-irregular-whitespace */
+        email: this.user.email.replace(/( |　)+/, '').trim(),
+        role_id: this.roleList.find(role => role.value === this.user.role).id,
+      });
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -3,6 +3,8 @@
     :access="access"
     :category-name="categoryName"
     :disabled="loading"
+    :done-message="doneMessage"
+    :error-message="errorMessage"
     @edited-category="editedCategory"
     @handle-submit="handleSubmit"
   />
@@ -26,6 +28,12 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
   },
   created() {
     const { id } = this.$route.params;
@@ -45,18 +53,6 @@ export default {
       this.$store.dispatch('categories/updateCategory', {
         id,
         name: this.categoryName,
-      });
-    },
-    editUser() {
-      this.$store.dispatch('users/editUser', {
-        id: this.user.id,
-        /* eslint-disable-next-line no-irregular-whitespace */
-        full_name: this.user.fullName.replace(/(　)+/, ' ').trim(),
-        /* eslint-disable-next-line no-irregular-whitespace */
-        account_name: this.user.accountName.replace(/( |　)+/, '').trim(),
-        /* eslint-disable-next-line no-irregular-whitespace */
-        email: this.user.email.replace(/( |　)+/, '').trim(),
-        role_id: this.roleList.find(role => role.value === this.user.role).id,
       });
     },
   },

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -34,15 +34,12 @@ export default {
     }).then(() => {
       this.categoryName = this.$store.state.categories.category.name;
     });
-    console.log(this.$route.params);
   },
   methods: {
     editedCategory($event) {
       this.categoryName = $event.target.value;
-      console.log(this.categoryName);
     },
     handleSubmit() {
-      console.log('submit');
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,5 +1,7 @@
 <template>
-  <app-category-edit />
+  <app-category-edit
+    :access="access"
+  />
 </template>
 <script>
 import { CategoryEdit } from '@Components/molecules';
@@ -7,6 +9,11 @@ import { CategoryEdit } from '@Components/molecules';
 export default {
   components: {
     appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,7 +1,7 @@
 <template>
   <app-category-edit
     :access="access"
-    :category="category"
+    :category-name="categoryName"
     @edited-category="editedCategory"
     @handle-submit="handleSubmit"
   />
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      category: '',
+      categoryName: '',
     };
   },
   computed: {
@@ -27,7 +27,8 @@ export default {
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategory', {
       id,
-      category: this.category,
+    }).then(() => {
+      this.categoryName = this.$store.state.categories.category.name;
     });
   },
   methods: {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -40,6 +40,9 @@ export default {
       id: this.$route.params.id,
     });
   },
+  beforeDestroy() {
+    this.$store.dispatch('categories/initializeCategory');
+  },
   methods: {
     editedCategory($event) {
       this.$store.dispatch('categories/editedCategory', $event.target.value);

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,6 +1,9 @@
 <template>
   <app-category-edit
     :access="access"
+    :category="category"
+    @edited-category="editedCategory"
+    @handle-submit="handleSubmit"
   />
 </template>
 <script>
@@ -10,9 +13,29 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
+  data() {
+    return {
+      category: '',
+    };
+  },
   computed: {
     access() {
       return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategory', {
+      id,
+      category: this.category,
+    });
+  },
+  methods: {
+    editedCategory($event) {
+
+    },
+    handleSubmit() {
+
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,3 +1,12 @@
 <template>
-  <router-view />
+  <app-category-edit />
 </template>
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -36,9 +36,8 @@ export default {
   },
   created() {
     this.clearMessage();
-    const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategory', {
-      id,
+      id: this.$route.params.id,
     });
   },
   methods: {
@@ -47,9 +46,8 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      const { id } = this.$route.params;
       this.$store.dispatch('categories/updateCategory', {
-        id,
+        id: this.$store.state.categories.category.id,
         name: this.$store.state.categories.category.name,
       });
     },

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -16,11 +16,6 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
-  data() {
-    return {
-      categoryName: '',
-    };
-  },
   computed: {
     access() {
       return this.$store.getters['auth/access'];
@@ -34,19 +29,20 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    categoryName() {
+      return this.$store.state.categories.category.name;
+    },
   },
   created() {
     this.$store.dispatch('categories/clearMessage');
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategory', {
       id,
-    }).then(() => {
-      this.categoryName = this.$store.state.categories.category.name;
     });
   },
   methods: {
     editedCategory($event) {
-      this.categoryName = $event.target.value;
+      this.$store.dispatch('categories/editedCategory', $event.target.value);
     },
     handleSubmit() {
       if (this.loading) return;
@@ -54,7 +50,7 @@ export default {
       const { id } = this.$route.params;
       this.$store.dispatch('categories/updateCategory', {
         id,
-        name: this.categoryName,
+        name: this.$store.state.categories.category.name,
       });
     },
   },

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -2,6 +2,7 @@
   <app-category-edit
     :access="access"
     :category-name="categoryName"
+    :disabled="loading"
     @edited-category="editedCategory"
     @handle-submit="handleSubmit"
   />
@@ -22,6 +23,9 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
   },
   created() {
     const { id } = this.$route.params;
@@ -30,13 +34,15 @@ export default {
     }).then(() => {
       this.categoryName = this.$store.state.categories.category.name;
     });
+    console.log(this.$route.params);
   },
   methods: {
     editedCategory($event) {
-
+      this.categoryName = $event.target.value;
+      console.log(this.categoryName);
     },
     handleSubmit() {
-
+      console.log('submit');
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -7,6 +7,7 @@
     :error-message="errorMessage"
     @edited-category="editedCategory"
     @handle-submit="handleSubmit"
+    @clear-message="clearMessage"
   />
 </template>
 <script>
@@ -34,7 +35,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/clearMessage');
+    this.clearMessage();
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategory', {
       id,
@@ -46,12 +47,14 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/clearMessage');
       const { id } = this.$route.params;
       this.$store.dispatch('categories/updateCategory', {
         id,
         name: this.$store.state.categories.category.name,
       });
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -91,11 +91,10 @@ export default {
     },
     handleClick() {
       this.clearMessage();
-      this.$store.dispatch('categories/deleteCategory', {
-        id: this.deleteCategoryId,
-      }).then(() => {
-        this.$store.dispatch('categories/getAllCategories');
-      });
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
       this.toggleModal();
     },
   },

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/List.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'categoryList',
           path: '',
           component: CategoryList,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -88,7 +88,6 @@ export default {
     },
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
-      console.log(this.state.categories.category.id);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${this.state.categories.category.id}`,

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -93,12 +93,12 @@ export default {
     initializeCategory({ commit }) {
       commit('initializeCategory');
     },
-    updateCategory({ commit, rootGetters }) {
+    updateCategory({ commit, rootGetters, state }) {
       commit('toggleLoading');
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${this.state.categories.category.id}`,
-        data: this.state.categories.category,
+        url: `/category/${state.category.id}`,
+        data: state.category,
       }).then(() => {
         commit('displayDoneMessage', { message: 'カテゴリー名を変更しました' });
         commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -9,6 +9,7 @@ export default {
     deleteCategoryName: '',
     doneMessage: '',
     errorMessage: '',
+    category: [],
   },
   mutations: {
     toggleLoading(state) {
@@ -19,6 +20,9 @@ export default {
     },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories;
+    },
+    doneGetCategory(state, category) {
+      state.category = category;
     },
     confirmDeleteCategory(state, { id, name }) {
       state.deleteCategoryId = id;
@@ -43,14 +47,12 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    getCategory({ commit, rootGetters }, { id, category }) {
+    getCategory({ commit, rootGetters }, { id }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${id}`,
       }).then(res => {
-        category = res.data.category.name;
-        console.log(category);
-        console.log(res);
+        commit('doneGetCategory', res.data.category);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -77,6 +77,17 @@ export default {
         });
       });
     },
+    updateCategory({ commit, rootGetters }, category) {
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${category.id}`,
+        data: category,
+      }).then(() => {
+
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
     confirmDeleteCategory({ commit }, { id, name }) {
       commit('confirmDeleteCategory', { id, name });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -78,14 +78,17 @@ export default {
       });
     },
     updateCategory({ commit, rootGetters }, category) {
+      commit('toggleLoading');
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${category.id}`,
         data: category,
       }).then(() => {
-
+        commit('displayDoneMessage', { message: 'カテゴリー名を変更しました' });
+        commit('toggleLoading');
       }).catch(err => {
         commit('failRequest', { message: err.message });
+        commit('toggleLoading');
       });
     },
     confirmDeleteCategory({ commit }, { id, name }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -14,6 +14,9 @@ export default {
       name: '',
     },
   },
+  getters: {
+    category: state => state.category,
+  },
   mutations: {
     toggleLoading(state) {
       state.loading = !state.loading;
@@ -86,12 +89,12 @@ export default {
     editedCategory({ commit }, name) {
       commit('editedCategory', name);
     },
-    updateCategory({ commit, rootGetters }, category) {
+    updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${category.id}`,
-        data: category,
+        url: `/category/${rootGetters['categories/category'].id}`,
+        data: rootGetters['categories/category'],
       }).then(() => {
         commit('displayDoneMessage', { message: 'カテゴリー名を変更しました' });
         commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -30,6 +30,10 @@ export default {
     editedCategory(state, name) {
       state.category.name = name;
     },
+    initializeCategory(state) {
+      state.category.name = '';
+      state.category.id = null;
+    },
     confirmDeleteCategory(state, { id, name }) {
       state.deleteCategoryId = id;
       state.deleteCategoryName = name;
@@ -85,6 +89,9 @@ export default {
     },
     editedCategory({ commit }, name) {
       commit('editedCategory', name);
+    },
+    initializeCategory({ commit }) {
+      commit('initializeCategory');
     },
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -9,7 +9,10 @@ export default {
     deleteCategoryName: '',
     doneMessage: '',
     errorMessage: '',
-    category: [],
+    category: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     toggleLoading(state) {
@@ -23,6 +26,9 @@ export default {
     },
     doneGetCategory(state, category) {
       state.category = category;
+    },
+    editedCategory(state, name) {
+      state.category.name = name;
     },
     confirmDeleteCategory(state, { id, name }) {
       state.deleteCategoryId = id;
@@ -76,6 +82,9 @@ export default {
           commit('toggleLoading');
         });
       });
+    },
+    editedCategory({ commit }, name) {
+      commit('editedCategory', name);
     },
     updateCategory({ commit, rootGetters }, category) {
       commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -43,6 +43,18 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
+    getCategory({ commit, rootGetters }, { id, category }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then(res => {
+        category = res.data.category.name;
+        console.log(category);
+        console.log(res);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
     clearMessage({ commit }) {
       commit('clearMessage');
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -57,7 +57,7 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    getCategory({ commit, rootGetters }, { id }) {
+    getCategory({ commit, rootGetters }, id) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${id}`,
@@ -110,7 +110,7 @@ export default {
     confirmDeleteCategory({ commit }, { id, name }) {
       commit('confirmDeleteCategory', { id, name });
     },
-    deleteCategory({ commit, rootGetters }, { id }) {
+    deleteCategory({ commit, rootGetters }, id) {
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -14,9 +14,6 @@ export default {
       name: '',
     },
   },
-  getters: {
-    category: state => state.category,
-  },
   mutations: {
     toggleLoading(state) {
       state.loading = !state.loading;
@@ -91,10 +88,11 @@ export default {
     },
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
+      console.log(this.state.categories.category.id);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${rootGetters['categories/category'].id}`,
-        data: rootGetters['categories/category'],
+        url: `/category/${this.state.categories.category.id}`,
+        data: this.state.categories.category,
       }).then(() => {
         commit('displayDoneMessage', { message: 'カテゴリー名を変更しました' });
         commit('toggleLoading');


### PR DESCRIPTION
[チケット GIZFE-514](https://gizumo.backlog.com/view/GIZFE-514)

### 内容
カテゴリー更新画面作成

- IDに対応したカテゴリーのカテゴリー更新画面に遷移する
- APIでカテゴリー名の変更が行える
- API通信成功・失敗時エラーメッセージを表示する
- カテゴリー一覧画面へ戻るリンクがある

### テストケース
[テストケース GIZFE-516](https://gizumo.backlog.com/view/GIZFE-516)

