### PR TITLE
カテゴリー新規作成機能実装

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -59,6 +59,7 @@ export default {
       this.targetCategory = event.target.value;
     },
     handleSubmit() {
+      if (this.isLoading) return;
       this.$store.dispatch('categories/createCategory', this.targetCategory).then(() => {
         this.$store.dispatch('categories/allCategories');
       });

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,9 +2,14 @@
   <div class="category">
     <app-category-post
       class="category-post"
-      :category="category"
       :access="access"
+      :done-message="doneMessage"
       :error-message="errorMessage"
+      :category="category"
+      :disabled="disabled"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
+      @clear-message="clearMessage"
     />
     <app-category-list
       class="category-list"
@@ -30,7 +35,10 @@ export default {
   },
   computed: {
     category() {
-      return this.$store.state.category;
+      return this.$store.state.categories.targetCategories;
+    },
+    disabled() {
+      return this.$store.state.categories.isLoading;
     },
     categories() {
       return this.$store.state.categories.categories;
@@ -38,12 +46,28 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
   },
   created() {
     this.$store.dispatch('categories/allCategories');
+  },
+  methods: {
+    updateValue($event) {
+      this.$store.dispatch('categories/addTargetCategories', $event.target.value);
+    },
+    handleSubmit() {
+      this.$store.dispatch('categories/createCategory').then(() => {
+        this.$store.dispatch('categories/allCategories');
+      });
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -3,10 +3,10 @@
     <app-category-post
       class="category-post"
       :access="access"
+      :category="targetCategory"
       :done-message="doneMessage"
       :error-message="errorMessage"
-      :category="category"
-      :disabled="disabled"
+      :disabled="isLoading"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
       @clear-message="clearMessage"
@@ -31,13 +31,11 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      targetCategory: '',
     };
   },
   computed: {
-    category() {
-      return this.$store.state.categories.targetCategories;
-    },
-    disabled() {
+    isLoading() {
       return this.$store.state.categories.isLoading;
     },
     categories() {
@@ -57,11 +55,11 @@ export default {
     this.$store.dispatch('categories/allCategories');
   },
   methods: {
-    updateValue($event) {
-      this.$store.dispatch('categories/addTargetCategories', $event.target.value);
+    updateValue(event) {
+      this.targetCategory = event.target.value;
     },
     handleSubmit() {
-      this.$store.dispatch('categories/createCategory').then(() => {
+      this.$store.dispatch('categories/createCategory', this.targetCategory).then(() => {
         this.$store.dispatch('categories/allCategories');
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,19 +3,34 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    category: {
-      id: null,
-      name: '',
-    },
     categories: [],
+    targetCategories: '',
     errorMessage: '',
+    doneMessage: '',
+    isLoading: false,
+  },
+  getters: {
+    targetCategories: state => state.targetCategories,
   },
   mutations: {
     allCategories(state, payload) {
       state.categories = payload;
     },
+    addTargetCategories(state, name) {
+      state.targetCategories = name;
+    },
+    toggleLoading(state) {
+      state.isLoading = !state.isLoading;
+    },
+    doneMessage(state) {
+      state.doneMessage = 'カテゴリー名を登録しました';
+    },
     errorRequest(state, message) {
       state.errorMessage = message;
+    },
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
     },
   },
   actions: {
@@ -30,6 +45,32 @@ export default {
         const errroMesssage = err.message;
         commit('errorRequest', errroMesssage);
       });
+    },
+    addTargetCategories({ commit }, name) {
+      commit('addTargetCategories', name);
+    },
+    createCategory({ commit, rootGetters }) {
+      return new Promise(resolve => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', rootGetters['categories/targetCategories']);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('doneMessage');
+          resolve();
+        }).catch(err => {
+          commit('toggleLoading');
+          commit('errorRequest', { message: err.message });
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,28 +4,21 @@ export default {
   namespaced: true,
   state: {
     categories: [],
-    targetCategories: '',
     errorMessage: '',
     doneMessage: '',
     isLoading: false,
-  },
-  getters: {
-    targetCategories: state => state.targetCategories,
   },
   mutations: {
     allCategories(state, payload) {
       state.categories = payload;
     },
-    addTargetCategories(state, name) {
-      state.targetCategories = name;
-    },
     toggleLoading(state) {
       state.isLoading = !state.isLoading;
     },
-    doneMessage(state) {
-      state.doneMessage = 'カテゴリー名を登録しました';
+    doneMessage(state, { message }) {
+      state.doneMessage = message;
     },
-    errorRequest(state, message) {
+    errorMessage(state, message) {
       state.errorMessage = message;
     },
     clearMessage(state) {
@@ -43,29 +36,26 @@ export default {
         commit('allCategories', categoryList);
       }).catch(err => {
         const errroMesssage = err.message;
-        commit('errorRequest', errroMesssage);
+        commit('errorMessage', errroMesssage);
       });
     },
-    addTargetCategories({ commit }, name) {
-      commit('addTargetCategories', name);
-    },
-    createCategory({ commit, rootGetters }) {
+    createCategory({ commit, rootGetters }, targetCategory) {
       return new Promise(resolve => {
         commit('clearMessage');
         commit('toggleLoading');
-        const data = new URLSearchParams();
-        data.append('name', rootGetters['categories/targetCategories']);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
-          data,
+          data: {
+            name: targetCategory,
+          },
         }).then(() => {
           commit('toggleLoading');
-          commit('doneMessage');
+          commit('doneMessage', { message: 'カテゴリー名を登録しました' });
           resolve();
         }).catch(err => {
           commit('toggleLoading');
-          commit('errorRequest', { message: err.message });
+          commit('errorMessage', err.message);
         });
       });
     },


### PR DESCRIPTION
[チケットはこちら](https://gizumo.backlog.com/view/GIZFE-517#comment-205354307)
### 作業内容
- 作成ボタンがクリックされたら、新規作成APIを実行する
- 成功時、一覧画面が更新されメッセージを表示する
- 追加されたカテゴリーはカテゴリー一覧の一番上に表示される

### 動作確認
- カテゴリー入力欄に文字が入力できること
- カテゴリー入力欄が空で作成ボタンを押した時、エラーメッセージが表示されること
- カテゴリー入力欄にカテゴリー名入力後、作成ボタン押して新規カテゴリーが作成されること
- カテゴリー入力欄にカテゴリー名入力後、作成ボタン押して作成完了メッセージが表示されること
