### PR TITLE
カテゴリー削除機能実装　命名修正

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,35 +2,46 @@
   <div class="category">
     <app-category-post
       class="category-post"
-      :category="category"
       :access="access"
+      :category="targetCategory"
+      :done-message="doneMessage"
       :error-message="errorMessage"
+      :disabled="isLoading"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
+      @clear-message="clearMessage"
     />
     <app-category-list
       class="category-list"
       :categories="categories"
+      :delete-category-name="deleteCategoryName"
       :theads="theads"
       :access="access"
+      @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
+      targetCategory: '',
     };
   },
   computed: {
-    category() {
-      return this.$store.state.category;
+    isLoading() {
+      return this.$store.state.categories.isLoading;
     },
     categories() {
       return this.$store.state.categories.categories;
@@ -38,12 +49,45 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
+    },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
     },
   },
   created() {
     this.$store.dispatch('categories/allCategories');
+  },
+  methods: {
+    updateValue(event) {
+      this.targetCategory = event.target.value;
+    },
+    handleSubmit() {
+      if (this.isLoading) return;
+      this.$store.dispatch('categories/createCategory', this.targetCategory).then(() => {
+        this.$store.dispatch('categories/allCategories');
+      });
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/modalDeleteCategory', {
+        categoryId,
+        categoryName,
+      });
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/allCategories');
+      });
+      this.toggleModal();
+    },
   },
 };
 </script>


### PR DESCRIPTION
[チケットはこちら](https://gizumo.backlog.com/view/GIZFE-525)

### 作業内容
- 削除ボタンを押したら、削除確認用のモーダルが出現する
- 削除確認用のモーダルには、削除対象のカテゴリ名が表示される
- 削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行される
- 成功したら一覧が更新され、メッセージを表示する

### 動作確認
- カテゴリー一覧ページの削除ボタンを押したら、削除確認用のモーダルが出現すること
- カテゴリー一覧ページの削除ボタンを押した際に表示される削除確認用のモーダルには、削除対象のカテゴリ名が表示される こと
- カテゴリー一覧ページの削除ボタンを押した際に表示される削除確認用のモーダル内部の削除ボタンをクリックした場合削除 APIが実行され、指定カテゴリーが削除されること
- カテゴリー削除に成功したらカテゴリ一覧が更新され、完了メッセージを表示されること
- カテゴリー削除に成功したらカテゴリ一覧が更新され、カテゴリー一覧の順番が変更されずに表示されること
- カテゴリー削除ボタンを押した際にAPI通信が失敗した場合、エラーメッセージが表示されること