### PR TITLE
Feature/gizfe 525

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -76,7 +76,7 @@ export default {
       this.$store.dispatch('categories/clearMessage');
     },
     openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/modalDeleteCategory', {
+      this.$store.dispatch('categories/confirmDeleteCategory', {
         categoryId,
         categoryName,
       });

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,35 +2,46 @@
   <div class="category">
     <app-category-post
       class="category-post"
-      :category="category"
       :access="access"
+      :category="targetCategory"
+      :done-message="doneMessage"
       :error-message="errorMessage"
+      :disabled="isLoading"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
+      @clear-message="clearMessage"
     />
     <app-category-list
       class="category-list"
       :categories="categories"
+      :delete-category-name="deleteCategoryName"
       :theads="theads"
       :access="access"
+      @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
+      targetCategory: '',
     };
   },
   computed: {
-    category() {
-      return this.$store.state.category;
+    isLoading() {
+      return this.$store.state.categories.isLoading;
     },
     categories() {
       return this.$store.state.categories.categories;
@@ -38,12 +49,45 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
+    },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
     },
   },
   created() {
     this.$store.dispatch('categories/allCategories');
+  },
+  methods: {
+    updateValue(event) {
+      this.targetCategory = event.target.value;
+    },
+    handleSubmit() {
+      if (this.isLoading) return;
+      this.$store.dispatch('categories/createCategory', this.targetCategory).then(() => {
+        this.$store.dispatch('categories/allCategories');
+      });
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/modalDeleteCategory', {
+        categoryId,
+        categoryName,
+      });
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/allCategories');
+      });
+      this.toggleModal();
+    },
   },
 };
 </script>

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,7 +7,7 @@ export default {
     errorMessage: '',
     doneMessage: '',
     deleteCategoryId: null,
-    deleteCategoryName: '',
+    deleteCategoryName: '', 
     isLoading: false,
   },
   mutations: {
@@ -87,6 +87,29 @@ export default {
           commit('errorMessage', err.message);
         });
       });
+    },
+    createCategory({ commit, rootGetters }, targetCategory) {
+      return new Promise(resolve => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data: {
+            name: targetCategory,
+          },
+        }).then(() => {
+          commit('toggleLoading');
+          commit('doneMessage', { message: 'カテゴリー名を登録しました' });
+          resolve();
+        }).catch(err => {
+          commit('toggleLoading');
+          commit('errorMessage', err.message);
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,12 +74,9 @@ export default {
     deleteCategory({ commit, rootGetters, state }) {
       return new Promise(resolve => {
         commit('clearMessage');
-        const data = new URLSearchParams();
-        data.append('id', state.deleteCategoryId);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `/category/${state.deleteCategoryId}`,
-          data,
         }).then(() => {
           commit('doneMessage', { message: 'カテゴリーを削除しました' });
           resolve();

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -23,7 +23,7 @@ export default {
     errorMessage(state, message) {
       state.errorMessage = message;
     },
-    modalDeleteCategory(state, { categoryId, categoryName }) {
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
     },
@@ -68,8 +68,8 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
-    modalDeleteCategory({ commit }, { categoryId, categoryName }) {
-      commit('modalDeleteCategory', { categoryId, categoryName });
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
     },
     deleteCategory({ commit, rootGetters, state }) {
       return new Promise(resolve => {


### PR DESCRIPTION
[チケットはこちら](https://gizumo.backlog.com/view/GIZFE-525)

### 作業内容
- 削除ボタンを押したら、削除確認用のモーダルが出現する
- 削除確認用のモーダルには、削除対象のカテゴリ名が表示される
- 削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行される
- 成功したら一覧が更新され、メッセージを表示する

### 動作確認
- カテゴリー一覧ページの削除ボタンを押したら、削除確認用のモーダルが出現すること
- カテゴリー一覧ページの削除ボタンを押した際に表示される削除確認用のモーダルには、削除対象のカテゴリ名が表示されること
- カテゴリー一覧ページの削除ボタンを押した際に表示される削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行され、指定カテゴリーが削除されること
- カテゴリー削除に成功したらカテゴリ一覧が更新され、完了メッセージを表示されること
- カテゴリー削除に成功したらカテゴリ一覧が更新され、カテゴリー一覧の順番が変更されずに表示されること
- カテゴリー削除ボタンを押した際にAPI通信が失敗した場合、エラーメッセージが表示されること
