### PR TITLE
削除済記事一覧画面実装

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -164,9 +164,6 @@ export default {
   .article-list {
     &__articles {
       margin-top: 16px;
-      .fade-enter-active, .fade-leave-active {
-        transition: opacity .5s;
-      }
     }
     .fade-enter, .fade-leave-to {
       opacity: 0;

--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__create-link-trashed"
+    >
+      削除済記事一覧へ移動する
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -164,6 +176,9 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+      &-trashed {
+        margin-left: 16px;
+      }
     }
     &__links {
       *:not(first-child) {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="article-trashed">
-    <app-heading :level="1">{{ articleTitle }}</app-heading>
+    <app-heading :level="1">削除済記事一覧</app-heading>
     <app-router-link
       to="/articles"
       key-color
@@ -83,17 +83,10 @@ export default {
   props: {
     targetArray: {
       type: Array,
-      default: () => [],
-    },
-    title: {
-      type: String,
-      default: '削除済記事',
+      required: true,
     },
   },
   computed: {
-    articleTitle() {
-      return `${this.title}一覧`;
-    },
     articleListTitle() {
       return title => {
         if (title.length > 30) {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -87,7 +87,7 @@ export default {
     },
     title: {
       type: String,
-      default: 'すべて',
+      default: '削除済記事',
     },
   },
   computed: {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -61,7 +61,7 @@
         <app-text
           class="article-trashed__date"
         >
-          {{ article.created_at }}
+          {{ articleDate(article.created_at) }}
         </app-text>
       </app-list-item>
     </transition-group>
@@ -137,9 +137,9 @@ export default {
     },
   },
   methods: {
-    openModal(articleId) {
-      if (!this.access.delete) return;
-      this.$emit('open-modal', articleId);
+    articleDate(date) {
+      const ymdDate = new Date(date).toLocaleDateString();
+      return ymdDate.replaceAll('/', '-');
     },
   },
 };

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -135,23 +135,27 @@ export default {
     buttonText() {
       return this.access.delete ? '削除' : '削除権限がありません';
     },
-  },
-  methods: {
-    articleListTitle(title) {
-      if (title.length > 30) {
-        return `${title.substr(0, 30)}...`;
-      }
-      return title;
+    articleListTitle() {
+      return title => {
+        if (title.length > 30) {
+          return `${title.substr(0, 30)}...`;
+        }
+        return title;
+      };
     },
-    articleListContent(content) {
-      if (content.length > 30) {
-        return `${content.substr(0, 30)}...`;
-      }
-      return content;
+    articleListContent() {
+      return content => {
+        if (content.length > 30) {
+          return `${content.substr(0, 30)}...`;
+        }
+        return content;
+      };
     },
-    articleListDate(date) {
-      const ymdDate = new Date(date).toLocaleDateString();
-      return ymdDate.replaceAll('/', '-');
+    articleListDate() {
+      return date => {
+        const ymdDate = new Date(date).toLocaleDateString();
+        return ymdDate.replaceAll('/', '-');
+      };
     },
   },
 };

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -51,17 +51,17 @@
         <app-text
           class="article-trashed__title"
         >
-          {{ article.title }}
+          {{ articleListTitle(article.title) }}
         </app-text>
         <app-text
           class="article-trashed__content"
         >
-          {{ article.content }}
+          {{ articleListContent(article.content) }}
         </app-text>
         <app-text
           class="article-trashed__date"
         >
-          {{ articleDate(article.created_at) }}
+          {{ articleListDate(article.created_at) }}
         </app-text>
       </app-list-item>
     </transition-group>
@@ -137,7 +137,19 @@ export default {
     },
   },
   methods: {
-    articleDate(date) {
+    articleListTitle(title) {
+      if (title.length > 30) {
+        return `${title.substr(0, 30)}...`;
+      }
+      return title;
+    },
+    articleListContent(content) {
+      if (content.length > 30) {
+        return `${content.substr(0, 30)}...`;
+      }
+      return content;
+    },
+    articleListDate(date) {
       const ymdDate = new Date(date).toLocaleDateString();
       return ymdDate.replaceAll('/', '-');
     },

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -111,8 +111,11 @@ export default {
       };
     },
     articleListDate() {
+      const options = {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+      };
       return date => {
-        const ymdDate = new Date(date).toLocaleDateString();
+        const ymdDate = new Date(date).toLocaleDateString('ja-JP', options);
         return ymdDate.replaceAll('/', '-');
       };
     },

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="article-trashed">
-    <div v-if="doneMessage" class="article-trashed__notice--create">
-      <app-text bg-success>{{ doneMessage }}</app-text>
-    </div>
     <app-heading :level="1">{{ articleTitle }}</app-heading>
     <app-router-link
       to="/articles"
@@ -65,19 +62,6 @@
         </app-text>
       </app-list-item>
     </transition-group>
-    <app-modal>
-      <app-text
-        ex-large
-      >
-        本当に削除しますか?
-      </app-text>
-      <app-button
-        bg-danger
-        @click="$emit('handle-click')"
-      >
-        削除
-      </app-button>
-    </app-modal>
   </div>
 </template>
 
@@ -86,7 +70,6 @@ import {
   Heading,
   ListItem,
   RouterLink,
-  Button,
   Text,
 } from '@Components/atoms';
 
@@ -95,45 +78,21 @@ export default {
     appHeading: Heading,
     appListItem: ListItem,
     appRouterLink: RouterLink,
-    appButton: Button,
     appText: Text,
   },
   props: {
-    className: {
-      type: String,
-      default: '',
-    },
     targetArray: {
       type: Array,
       default: () => [],
-    },
-    targetMeta: {
-      type: Object,
-      default: () => {},
-    },
-    borderGray: {
-      type: Boolean,
-      default: false,
     },
     title: {
       type: String,
       default: 'すべて',
     },
-    doneMessage: {
-      type: String,
-      default: '',
-    },
-    access: {
-      type: Object,
-      default: () => ({}),
-    },
   },
   computed: {
     articleTitle() {
       return `${this.title}一覧`;
-    },
-    buttonText() {
-      return this.access.delete ? '削除' : '削除権限がありません';
     },
     articleListTitle() {
       return title => {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,0 +1,170 @@
+<template>
+  <div class="article-trashed">
+    <div v-if="doneMessage" class="article-trashed__notice--create">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+    <app-heading :level="1">{{ articleTitle }}</app-heading>
+    <app-router-link
+      to="/articles"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-trashed__create-link"
+    >
+      全ての記事一覧へ戻る
+    </app-router-link>
+    <div class="article-trashed__list-header">
+      <app-text>
+        タイトル
+      </app-text>
+      <app-text>
+        本文
+      </app-text>
+      <app-text>
+        作成日
+      </app-text>
+    </div>
+    <transition-group
+      class="article-trashed__articles"
+      name="fade"
+      tag="ul"
+    >
+      <app-list-item
+        v-for="article in targetArray"
+        :key="article.id"
+        flex
+        beetween
+        align-items
+        bg-white
+        large
+        border-bottom-gray
+      >
+        <app-text
+          class="article-trashed__title"
+        >
+          {{ article.title }}
+        </app-text>
+        <app-text
+          class="article-trashed__title"
+        >
+          内容
+        </app-text>
+        <app-text
+          class="article-trashed__title"
+        >
+          作成日
+        </app-text>
+      </app-list-item>
+    </transition-group>
+    <app-modal>
+      <app-text
+        ex-large
+      >
+        本当に削除しますか?
+      </app-text>
+      <app-button
+        bg-danger
+        @click="$emit('handle-click')"
+      >
+        削除
+      </app-button>
+    </app-modal>
+  </div>
+</template>
+
+<script>
+import {
+  Heading,
+  ListItem,
+  RouterLink,
+  Button,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appListItem: ListItem,
+    appRouterLink: RouterLink,
+    appButton: Button,
+    appText: Text,
+  },
+  props: {
+    className: {
+      type: String,
+      default: '',
+    },
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+    targetMeta: {
+      type: Object,
+      default: () => {},
+    },
+    borderGray: {
+      type: Boolean,
+      default: false,
+    },
+    title: {
+      type: String,
+      default: 'すべて',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    articleTitle() {
+      return `${this.title}一覧`;
+    },
+    buttonText() {
+      return this.access.delete ? '削除' : '削除権限がありません';
+    },
+  },
+  methods: {
+    openModal(articleId) {
+      if (!this.access.delete) return;
+      this.$emit('open-modal', articleId);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  .article-trashed {
+    &__articles {
+      .fade-enter-active, .fade-leave-active {
+        transition: opacity .5s;
+      }
+    }
+    &__list-header {
+      display: flex;
+    }
+    .fade-enter, .fade-leave-to {
+      opacity: 0;
+    }
+    &__title {
+      width: 60%;
+    }
+    &__create-link {
+      margin-top: 16px;
+    }
+    &__links {
+      *:not(first-child) {
+        margin-left: 16px;
+      }
+    }
+    &__notice--create {
+      margin-bottom: 16px;
+    }
+  }
+</style>

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -17,13 +17,19 @@
       全ての記事一覧へ戻る
     </app-router-link>
     <div class="article-trashed__list-header">
-      <app-text>
+      <app-text
+        class="article-trashed__title"
+      >
         タイトル
       </app-text>
-      <app-text>
+      <app-text
+        class="article-trashed__content"
+      >
         本文
       </app-text>
-      <app-text>
+      <app-text
+        class="article-trashed__date"
+      >
         作成日
       </app-text>
     </div>
@@ -48,14 +54,14 @@
           {{ article.title }}
         </app-text>
         <app-text
-          class="article-trashed__title"
+          class="article-trashed__content"
         >
-          内容
+          {{ article.content }}
         </app-text>
         <app-text
-          class="article-trashed__title"
+          class="article-trashed__date"
         >
-          作成日
+          {{ article.created_at }}
         </app-text>
       </app-list-item>
     </transition-group>
@@ -147,21 +153,25 @@ export default {
       }
     }
     &__list-header {
+      color: $theme-color;
+      font-weight: $bold;
+      margin-top: 16px;
+      padding: 10px;
       display: flex;
+      justify-content: space-between;
+      border-bottom: solid 1px $separator-color;
     }
     .fade-enter, .fade-leave-to {
       opacity: 0;
     }
     &__title {
-      width: 60%;
+      width: 40%;
     }
-    &__create-link {
-      margin-top: 16px;
+    &__content {
+      width: 50%;
     }
-    &__links {
-      *:not(first-child) {
-        margin-left: 16px;
-      }
+    &__date {
+      width: 10%;
     }
     &__notice--create {
       margin-bottom: 16px;

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -18,17 +18,17 @@
     </app-router-link>
     <div class="article-trashed__list-header">
       <app-text
-        class="article-trashed__title"
+        class="article-trashed__title article-trashed__list-header-item"
       >
         タイトル
       </app-text>
       <app-text
-        class="article-trashed__content"
+        class="article-trashed__content article-trashed__list-header-item"
       >
         本文
       </app-text>
       <app-text
-        class="article-trashed__date"
+        class="article-trashed__date article-trashed__list-header-item"
       >
         作成日
       </app-text>
@@ -176,6 +176,9 @@ export default {
       display: flex;
       justify-content: space-between;
       border-bottom: solid 1px $separator-color;
+      &-item {
+        margin-left: 10px;
+      }
     }
     .fade-enter, .fade-leave-to {
       opacity: 0;

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -173,6 +173,9 @@ export default {
     &__date {
       width: 10%;
     }
+    &__create-link {
+      margin-top: 16px;
+    }
     &__notice--create {
       margin-bottom: 16px;
     }

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -97,7 +97,7 @@ export default {
     articleListTitle() {
       return title => {
         if (title.length > 30) {
-          return `${title.substr(0, 30)}...`;
+          return `${title.substring(0, 30)}...`;
         }
         return title;
       };
@@ -105,7 +105,7 @@ export default {
     articleListContent() {
       return content => {
         if (content.length > 30) {
-          return `${content.substr(0, 30)}...`;
+          return `${content.substring(0, 30)}...`;
         }
         return content;
       };

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -118,11 +118,6 @@ export default {
 
 <style lang="scss" scoped>
   .article-trashed {
-    &__articles {
-      .fade-enter-active, .fade-leave-active {
-        transition: opacity .5s;
-      }
-    }
     &__list-header {
       color: $theme-color;
       font-weight: $bold;

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -14,6 +14,7 @@ import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
+import ArticleTrashed from './ArticleTrashed/index.vue';
 import Pagination from './Pagination/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
@@ -35,6 +36,7 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrashed,
   Pagination,
   DeleteModal,
   Notice,

--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -53,8 +53,9 @@ export default {
   created() {
     if (!this.$route.query.page) {
       this.$router.push({ query: { page: 1 } });
+    } else {
+      this.fetchArticles();
     }
-    this.fetchArticles();
   },
   methods: {
     openModal(articleId) {

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -68,7 +68,6 @@ export default {
     },
     fetchTrashed() {
       this.$store.dispatch('articles/getTrashed');
-      console.log(this.$store.state.articles.articleList);
     },
     paginationClick(pageNum) {
       this.pageNum = pageNum;

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="articles">
-    <app-article-list
+    <app-article-trashed
       :title="title"
       :target-array="articlesList"
       :done-message="doneMessage"
@@ -9,21 +9,16 @@
       @open-modal="openModal"
       @handle-click="handleClick"
     />
-    <app-pagination
-      :target-meta="articlesMeta"
-      @pagination-click="paginationClick"
-    />
   </div>
 </template>
 
 <script>
-import { ArticleList, Pagination } from '@Components/molecules';
+import { ArticleTrashed } from '@Components/molecules';
 import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
-    appArticleList: ArticleList,
-    appPagination: Pagination,
+    appArticleTrashed: ArticleTrashed,
   },
   mixins: [Mixins],
   beforeRouteUpdate(to, from, next) {
@@ -32,7 +27,7 @@ export default {
   },
   data() {
     return {
-      title: 'すべて',
+      title: '削除済記事',
       pageNum: null,
     };
   },

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -3,75 +3,33 @@
     <app-article-trashed
       :title="title"
       :target-array="articlesList"
-      :done-message="doneMessage"
-      :access="access"
-      border-gray
-      @handle-click="handleClick"
     />
   </div>
 </template>
 
 <script>
 import { ArticleTrashed } from '@Components/molecules';
-import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appArticleTrashed: ArticleTrashed,
   },
-  mixins: [Mixins],
-  beforeRouteUpdate(to, from, next) {
-    this.fetchArticles();
-    next();
-  },
   data() {
     return {
       title: '削除済記事',
-      pageNum: null,
     };
   },
   computed: {
     articlesList() {
       return this.$store.state.articles.articleList;
     },
-    articlesMeta() {
-      return this.$store.state.articles.articleMeta;
-    },
-    doneMessage() {
-      return this.$store.state.articles.doneMessage;
-    },
-    access() {
-      return this.$store.getters['auth/access'];
-    },
   },
   created() {
     this.fetchTrashed();
   },
   methods: {
-    handleClick() {
-      this.$store.dispatch('articles/deleteArticle');
-      this.toggleModal();
-      if (this.$route.query.category) {
-        const { category } = this.$route.query;
-        this.title = category;
-        this.$store.dispatch('articles/filteredArticles', category)
-          .then(() => {
-            if (this.$store.state.articles.articleList.length === 0) {
-              this.$router.push({ path: '/notfound' });
-            }
-          }).catch(() => {
-            // console.log(err);
-          });
-      } else {
-        this.$store.dispatch('articles/getAllArticles', this.$route.query.page);
-      }
-    },
     fetchTrashed() {
       this.$store.dispatch('articles/getTrashed');
-    },
-    paginationClick(pageNum) {
-      this.pageNum = pageNum;
-      this.$router.push({ query: { page: pageNum } });
     },
   },
 };

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -6,7 +6,6 @@
       :done-message="doneMessage"
       :access="access"
       border-gray
-      @open-modal="openModal"
       @handle-click="handleClick"
     />
   </div>
@@ -46,16 +45,9 @@ export default {
     },
   },
   created() {
-    if (!this.$route.query.page) {
-      this.$router.push({ query: { page: 1 } });
-    }
-    this.fetchArticles();
+    this.fetchTrashed();
   },
   methods: {
-    openModal(articleId) {
-      this.$store.dispatch('articles/confirmDeleteArticle', articleId);
-      this.toggleModal();
-    },
     handleClick() {
       this.$store.dispatch('articles/deleteArticle');
       this.toggleModal();
@@ -74,26 +66,9 @@ export default {
         this.$store.dispatch('articles/getAllArticles', this.$route.query.page);
       }
     },
-    fetchArticles() {
-      if (this.$route.query.category) {
-        const { category } = this.$route.query;
-        this.title = category;
-        this.$store.dispatch('articles/filteredArticles', category)
-          .then(() => {
-            if (this.$store.state.articles.articleList.length === 0) {
-              this.$router.push({ path: '/notfound' });
-            }
-          }).catch(() => {
-            // console.log(err);
-          });
-      } else if (this.pageNum) {
-        this.$store.dispatch('articles/getAllArticles', this.pageNum);
-      } else {
-        this.$store.dispatch(
-          'articles/getAllArticles',
-          (this.$route.query.page ? this.$route.query.page : 1),
-        );
-      }
+    fetchTrashed() {
+      this.$store.dispatch('articles/getTrashed');
+      console.log(this.$store.state.articles.articleList);
     },
     paginationClick(pageNum) {
       this.pageNum = pageNum;

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="articles">
+    <app-article-list
+      :title="title"
+      :target-array="articlesList"
+      :done-message="doneMessage"
+      :access="access"
+      border-gray
+      @open-modal="openModal"
+      @handle-click="handleClick"
+    />
+    <app-pagination
+      :target-meta="articlesMeta"
+      @pagination-click="paginationClick"
+    />
+  </div>
+</template>
+
+<script>
+import { ArticleList, Pagination } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appArticleList: ArticleList,
+    appPagination: Pagination,
+  },
+  mixins: [Mixins],
+  beforeRouteUpdate(to, from, next) {
+    this.fetchArticles();
+    next();
+  },
+  data() {
+    return {
+      title: 'すべて',
+      pageNum: null,
+    };
+  },
+  computed: {
+    articlesList() {
+      return this.$store.state.articles.articleList;
+    },
+    articlesMeta() {
+      return this.$store.state.articles.articleMeta;
+    },
+    doneMessage() {
+      return this.$store.state.articles.doneMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    if (!this.$route.query.page) {
+      this.$router.push({ query: { page: 1 } });
+    }
+    this.fetchArticles();
+  },
+  methods: {
+    openModal(articleId) {
+      this.$store.dispatch('articles/confirmDeleteArticle', articleId);
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('articles/deleteArticle');
+      this.toggleModal();
+      if (this.$route.query.category) {
+        const { category } = this.$route.query;
+        this.title = category;
+        this.$store.dispatch('articles/filteredArticles', category)
+          .then(() => {
+            if (this.$store.state.articles.articleList.length === 0) {
+              this.$router.push({ path: '/notfound' });
+            }
+          }).catch(() => {
+            // console.log(err);
+          });
+      } else {
+        this.$store.dispatch('articles/getAllArticles', this.$route.query.page);
+      }
+    },
+    fetchArticles() {
+      if (this.$route.query.category) {
+        const { category } = this.$route.query;
+        this.title = category;
+        this.$store.dispatch('articles/filteredArticles', category)
+          .then(() => {
+            if (this.$store.state.articles.articleList.length === 0) {
+              this.$router.push({ path: '/notfound' });
+            }
+          }).catch(() => {
+            // console.log(err);
+          });
+      } else if (this.pageNum) {
+        this.$store.dispatch('articles/getAllArticles', this.pageNum);
+      } else {
+        this.$store.dispatch(
+          'articles/getAllArticles',
+          (this.$route.query.page ? this.$route.query.page : 1),
+        );
+      }
+    },
+    paginationClick(pageNum) {
+      this.pageNum = pageNum;
+      this.$router.push({ query: { page: pageNum } });
+    },
+  },
+};
+</script>

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="articles">
     <app-article-trashed
-      :title="title"
       :target-array="articlesList"
     />
   </div>
@@ -13,11 +12,6 @@ import { ArticleTrashed } from '@Components/molecules';
 export default {
   components: {
     appArticleTrashed: ArticleTrashed,
-  },
-  data() {
-    return {
-      title: '削除済記事',
-    };
   },
   computed: {
     articlesList() {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -15,6 +15,7 @@ import CategoryEdit from '@Pages/Categories/Edit.vue';
 // 記事
 import Articles from '@Pages/Articles/index.vue';
 import ArticleList from '@Pages/Articles/List.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
@@ -110,6 +111,11 @@ const router = new VueRouter({
               next();
             }
           },
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articlePost',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -172,7 +172,7 @@ export default {
       });
     },
     getTrashed({ commit, rootGetters }) {
-      return new Promise((resolve, reject) => {
+      new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
           method: 'GET',
           url: '/article/trashed',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -91,6 +91,10 @@ export default {
       state.articleList = [...payload.articles];
       state.articleMeta = { ...payload.meta };
     },
+    doneGetTrashed(state, payload) {
+      console.log(payload);
+      state.articleList = [...payload.articles];
+    },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
@@ -168,20 +172,13 @@ export default {
         });
       });
     },
-    getArticleTrashed({ commit, rootGetters }) {
+    getTrashed({ commit, rootGetters }) {
       return new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
           method: 'GET',
           url: '/article/trashed',
         }).then(res => {
-          const payload = {
-            article: {
-              id: res.data.title,
-              title: res.data.content,
-              created_at: res.data.created_at,
-            },
-          };
-          commit('doneGetArticle', payload);
+          commit('doneGetTrashed', res.data.articles);
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -168,6 +168,27 @@ export default {
         });
       });
     },
+    getArticleTrashed({ commit, rootGetters }) {
+      return new Promise((resolve, reject) => {
+        axios(rootGetters['auth/token'])({
+          method: 'GET',
+          url: '/article/trashed',
+        }).then(res => {
+          const payload = {
+            article: {
+              id: res.data.title,
+              title: res.data.content,
+              created_at: res.data.created_at,
+            },
+          };
+          commit('doneGetArticle', payload);
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+          reject();
+        });
+      });
+    },
     editedTitle({ commit }, title) {
       commit({
         type: 'editedTitle',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -172,17 +172,13 @@ export default {
       });
     },
     getTrashed({ commit, rootGetters }) {
-      new Promise((resolve, reject) => {
-        axios(rootGetters['auth/token'])({
-          method: 'GET',
-          url: '/article/trashed',
-        }).then(res => {
-          commit('doneGetTrashed', res.data.articles);
-          resolve();
-        }).catch(err => {
-          commit('failRequest', { message: err.message });
-          reject();
-        });
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(res => {
+        commit('doneGetTrashed', res.data.articles);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
     editedTitle({ commit }, title) {

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -91,9 +91,8 @@ export default {
       state.articleList = [...payload.articles];
       state.articleMeta = { ...payload.meta };
     },
-    doneGetTrashed(state, payload) {
-      console.log(payload);
-      state.articleList = [...payload.articles];
+    doneGetTrashed(state, articles) {
+      state.articleList = [...articles];
     },
     failRequest(state, { message }) {
       state.errorMessage = message;


### PR DESCRIPTION
### 課題
[課題リンク](https://gizumo.backlog.com/view/GIZFE-537)

### テスト
[テストリンク](https://gizumo.backlog.com/view/GIZFE-539)

### 実装内容
- 記事一覧画面ベースの新規コンポーネント作成
- 削除済記事一覧取得API呼び出し処理作成
- 30文字制限処理作成
- 日付データ変換処理作成