### PR TITLE
Feature/gizfe 534

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -54,7 +54,6 @@
               @click="openModal(category.id, category.name)"
             >
               削除
-              {{ buttonText }}
             </app-button>
           </td>
         </tr>

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -7,7 +7,6 @@
       type="text"
       placeholder="追加するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
-      :done-mesage="doneMessage"
       :error-messages="errors.collect('category')"
       :value="category"
       @update-value="$emit('update-value', $event)"

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -7,6 +7,7 @@
       type="text"
       placeholder="追加するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
+      :done-mesage="doneMessage"
       :error-messages="errors.collect('category')"
       :value="category"
       @update-value="$emit('update-value', $event)"
@@ -46,11 +47,11 @@ export default {
       type: String,
       default: '',
     },
-    errorMessage: {
+    doneMessage: {
       type: String,
       default: '',
     },
-    doneMessage: {
+    errorMessage: {
       type: String,
       default: '',
     },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -46,11 +46,11 @@ export default {
       type: String,
       default: '',
     },
-    doneMessage: {
+    errorMessage: {
       type: String,
       default: '',
     },
-    errorMessage: {
+    doneMessage: {
       type: String,
       default: '',
     },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -7,7 +7,7 @@
       :done-message="doneMessage"
       :error-message="errorMessage"
       :disabled="disabled"
-      @update-value="newCategory = $event.target.value"
+      @update-value="updateValue"
       @handle-submit="handleSubmit"
     />
     <app-category-list
@@ -54,7 +54,13 @@ export default {
   },
   methods: {
     handleSubmit() {
-      this.$store.dispatch('categories/postCategory', this.newCategory);
+      this.$store.dispatch('categories/postCategory', this.newCategory)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+    },
+    updateValue(updateValue) {
+      this.newCategory = updateValue.target.value;
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -6,6 +6,7 @@
       :category="newCategory"
       :done-message="doneMessage"
       :error-message="errorMessage"
+      :disabled="disabled"
       @update-value="newCategory = $event.target.value"
       @handle-submit="handleSubmit"
     />
@@ -40,6 +41,9 @@ export default {
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
+    },
+    disabled() {
+      return this.$store.state.categories.loading;
     },
     access() {
       return this.$store.getters['auth/access'];

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -3,6 +3,11 @@
     <app-category-post
       class="categories-post"
       :access="access"
+      :category="newCategory"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
+      @update-value="newCategory = $event.target.value"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       class="categories-list"
@@ -23,11 +28,18 @@ export default {
   data() {
     return {
       title: 'すべて',
+      newCategory: '',
     };
   },
   computed: {
     categoryList() {
       return this.$store.state.categories.categoryList;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -35,6 +47,11 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    handleSubmit() {
+      this.$store.dispatch('categories/postCategory', this.newCategory);
+    },
   },
 };
 </script>

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,6 +4,8 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
+    postCategories: '',
+    doneMessage: '',
     errorMessage: '',
   },
   mutations: {
@@ -14,7 +16,14 @@ export default {
       state.errorMessage = message;
     },
     clearMessage(state) {
+      state.doneMessage = '';
       state.errorMessage = '';
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
     },
   },
   actions: {
@@ -29,6 +38,28 @@ export default {
         commit('doneGetCategories', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    postCategory({ commit, rootGetters, dispatch }, newCategory) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', newCategory);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          resolve();
+          dispatch('getAllCategories');
+        }).catch(err => {
+          commit('toggleLoading');
+          commit('failRequest', { message: err.message });
+          reject();
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,8 +4,8 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
-    errorMessage: '',
     doneMessage: '',
+    errorMessage: '',
     loading: false,
   },
   mutations: {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,7 +4,6 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
-    postCategories: '',
     doneMessage: '',
     errorMessage: '',
     loading: false,
@@ -46,7 +45,6 @@ export default {
         commit('clearMessage');
         commit('toggleLoading');
         resolve();
-
         const data = new URLSearchParams();
         data.append('name', newCategory);
         axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -41,10 +41,12 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    postCategory({ commit, rootGetters, dispatch }, newCategory) {
+    postCategory({ commit, rootGetters }, newCategory) {
       return new Promise((resolve, reject) => {
         commit('clearMessage');
         commit('toggleLoading');
+        resolve();
+
         const data = new URLSearchParams();
         data.append('name', newCategory);
         axios(rootGetters['auth/token'])({
@@ -54,8 +56,6 @@ export default {
         }).then(() => {
           commit('toggleLoading');
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
-          resolve();
-          dispatch('getAllCategories');
         }).catch(err => {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,8 +4,8 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
-    doneMessage: '',
     errorMessage: '',
+    doneMessage: '',
     loading: false,
   },
   mutations: {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,7 @@ export default {
     postCategories: '',
     doneMessage: '',
     errorMessage: '',
+    loading: false,
   },
   mutations: {
     doneGetCategories(state, payload) {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-534

## 作業内容
カテゴリー新規作成機能の実装

## 動作確認
- サイドバーに「カテゴリー」項目を表示する。
- サイドバーに「カテゴリー」をクリックするとカテゴリー一覧ページを表示する。
- 取得したカテゴリ一覧が画面右側に降順で表示される。
- カテゴリーがない場合、「カテゴリーは何も登録されていません。」が表示される。
- 「作成」ボタンをクリック後、API通信中は「作成」ボタンが非活性になりダブルサブミットできないこと