### PR TITLE
カテゴリー削除機能実装

### DIFF
--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -17,6 +17,9 @@
         :theads="theads"
         :categories="categoriesList"
         :access="access"
+        :delete-category-name="deleteCategoryName"
+        @open-modal="openModal"
+        @handle-click="handleClick"
       />
     </div>
   </div>
@@ -24,16 +27,19 @@
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
       categoryName: '',
+      deleteCategoryName: '',
     };
   },
   computed: {
@@ -67,6 +73,16 @@ export default {
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/confirmDeleteCategory', categoryId);
+      this.toggleModal();
+      this.deleteCategoryName = categoryName;
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
+      this.$store.dispatch('categories/getAllCategories');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -9,9 +9,6 @@ export default {
     loading: false,
     deleteCategoryId: null,
   },
-  getters: {
-    deleteCategoryId: state => state.deleteCategoryId,
-  },
   mutations: {
     doneGetAllCategories(state, { categories }) {
       state.categoryList = categories;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,10 @@ export default {
     doneMessage: '',
     errorMessage: '',
     loading: false,
+    deleteCategoryId: null,
+  },
+  getters: {
+    deleteCategoryId: state => state.deleteCategoryId,
   },
   mutations: {
     doneGetAllCategories(state, { categories }) {
@@ -27,6 +31,12 @@ export default {
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    confirmDeleteCategory(state, { categoryId }) {
+      state.deleteCategoryId = categoryId;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
     },
   },
   actions: {
@@ -65,6 +75,24 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    confirmDeleteCategory({ commit }, categoryId) {
+      commit('confirmDeleteCategory', { categoryId });
+    },
+    deleteCategory({ commit, rootGetters }) {
+      commit('clearMessage');
+      const data = new URLSearchParams();
+      data.append('id', rootGetters['categories/deleteCategoryId']);
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        data,
+      }).then(() => {
+        commit('doneDeleteCategory');
+        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -35,9 +35,6 @@ export default {
     confirmDeleteCategory(state, { categoryId }) {
       state.deleteCategoryId = categoryId;
     },
-    doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
-    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -79,19 +76,18 @@ export default {
     confirmDeleteCategory({ commit }, categoryId) {
       commit('confirmDeleteCategory', { categoryId });
     },
-    deleteCategory({ commit, rootGetters }) {
+    deleteCategory({ commit, rootGetters, state }) {
       commit('clearMessage');
-      const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/deleteCategoryId']);
-      axios(rootGetters['auth/token'])({
-        method: 'DELETE',
-        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
-        data,
-      }).then(() => {
-        commit('doneDeleteCategory');
-        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${state.deleteCategoryId}`,
+        }).then(() => {
+          commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
       });
     },
   },


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-566

## やったこと
- 削除ボタンを押したらモーダルを出現させる
- モーダルには当該カテゴリー名が表示され、モーダル内の削除を押すとモーダルが消える
- 削除が完了すると、メッセージが表示され、一覧が更新される

## やらないこと
- なし

## テスト
https://gizumo.backlog.com/view/GIZFE-568#comment-222360475

## 特にレビューをお願いしたい箇所
最後に更新した一覧を表示させる方法は、getAllCategoriesアクションで良いのでしょうか？
