### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <form class="category-edit" @submit.prevent="editCategory">
+  <form class="category-edit" @submit.prevent="handleSubmit">
     <app-heading :level="1">カテゴリー管理</app-heading>
     <div class="category-edit__back">
       <app-router-link
@@ -15,12 +15,12 @@
     <div class="category-edit__form">
       <app-input
         v-validate="'required'"
-        name="categoryName"
+        name="category"
         type="text"
         placeholder="新しいカテゴリー名を入力してください。"
         white-bg
         data-vv-as="カテゴリー名"
-        :error-messages="errors.collect('categoryName')"
+        :error-messages="errors.collect('category')"
         :value="categoryName"
         @update-value="$emit('edited-category', $event)"
       />
@@ -30,15 +30,14 @@
       class="category-edit__submit"
       button-type="submit"
       round
-      :disabled="!disabled"
-      @click="handleSubmit"
+      :disabled="disabled || !access.edit"
     >
       {{ buttonText }}
     </app-button>
-    <div
-      v-if="doneMessage"
-      class="category-edit__notice--update"
-    >
+    <div v-if="errorMessage" class="category-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+    <div v-if="doneMessage" class="category-edit__notice">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
@@ -58,17 +57,9 @@ export default {
     appRouterLink: RouterLink,
   },
   props: {
-    categoryId: {
-      type: Number,
-      default: 0,
-    },
     categoryName: {
       type: String,
-      default: '',
-    },
-    loading: {
-      type: Boolean,
-      default: false,
+      default: 'true',
     },
     doneMessage: {
       type: String,
@@ -78,19 +69,25 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     buttonText() {
       if (!this.access.edit) return '更新権限がありません';
-      return this.loading ? '更新中...' : '更新';
-    },
-    disabled() {
-      return this.access.edit && !this.loading;
+      return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {
-    editCategory() {
+    handleSubmit() {
       if (!this.access.edit) return;
+      this.$emit('clear-message');
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('handle-submit');
       });
@@ -110,8 +107,8 @@ export default {
   &__submit {
     margin-top: 16px;
   }
-  &__notice--update {
-    margin-bottom: 16px;
+  &__notice {
+    margin-top: 16px;
   }
 }
 </style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -59,7 +59,7 @@ export default {
   props: {
     categoryName: {
       type: String,
-      default: 'true',
+      required: true,
     },
     doneMessage: {
       type: String,

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,117 @@
+<template>
+  <form class="category-edit" @submit.prevent="editCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="category-edit__back">
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        to="/categories"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+    <div class="category-edit__form">
+      <app-input
+        v-validate="'required'"
+        name="categoryName"
+        type="text"
+        placeholder="新しいカテゴリー名を入力してください。"
+        white-bg
+        data-vv-as="カテゴリー名"
+        :error-messages="errors.collect('categoryName')"
+        :value="categoryName"
+        @update-value="$emit('edited-category', $event)"
+      />
+    </div>
+
+    <app-button
+      class="category-edit__submit"
+      button-type="submit"
+      round
+      :disabled="!disabled"
+      @click="handleSubmit"
+    >
+      {{ buttonText }}
+    </app-button>
+    <div
+      v-if="doneMessage"
+      class="category-edit__notice--update"
+    >
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    categoryId: {
+      type: Number,
+      default: 0,
+    },
+    categoryName: {
+      type: String,
+      default: '',
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+  },
+  methods: {
+    editCategory() {
+      if (!this.access.edit) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-edit {
+  &__back {
+    margin-top: 20px;
+  }
+  &__form {
+    margin-top: 20px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice--update {
+    margin-bottom: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/UserCreate/index.vue
+++ b/src/components/molecules/UserCreate/index.vue
@@ -158,7 +158,7 @@ export default {
     margin-top: 20px;
   }
   &__button {
-    margin-top: 10px;
+    margin-top: 20px;
   }
 }
 </style>

--- a/src/components/molecules/UserCreate/index.vue
+++ b/src/components/molecules/UserCreate/index.vue
@@ -158,7 +158,7 @@ export default {
     margin-top: 20px;
   }
   &__button {
-    margin-top: 20px;
+    margin-top: 10px;
   }
 }
 </style>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -80,9 +80,11 @@ export default {
       this.deleteCategoryName = categoryName;
     },
     handleClick() {
-      this.$store.dispatch('categories/deleteCategory');
+      this.$store.dispatch('categories/deleteCategory')
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
       this.toggleModal();
-      this.$store.dispatch('categories/getAllCategories');
     },
   },
 };

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,84 @@
+<template>
+  <app-category-edit
+    :category-id="categoryId"
+    :category-name="categoryName"
+    :loading="loading"
+    :done-message="doneMessage"
+    :access="access"
+    @selected-article-category="selectedArticleCategory"
+    @edited-title="editedTitle"
+    @edited-content="editedContent"
+    @handle-submit="handleSubmit"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  data() {
+    return {
+      categoryName: '',
+      content: '',
+    };
+  },
+  computed: {
+    articleId() {
+      let { id } = this.$route.params;
+      id = parseInt(id, 10);
+      return id;
+    },
+    targetCategoryName() {
+      const { title } = this.$store.state.articles.targetArticle;
+      return title;
+    },
+    articleContent() {
+      const { content } = this.$store.state.articles.targetArticle;
+      return content;
+    },
+    markdownContent() {
+      return `# ${this.articleTitle}\n${this.articleContent}`;
+    },
+    currentCategoryName() {
+      const { name } = this.$store.state.articles.targetArticle.category;
+      return name;
+    },
+    categoryList() {
+      const { categoryList } = this.$store.state.categories;
+      return categoryList;
+    },
+    loading() {
+      return this.$store.state.articles.loading;
+    },
+    doneMessage() {
+      return this.$store.state.articles.doneMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('articles/getArticleDetail', parseInt(this.articleId, 10));
+  },
+  methods: {
+    editedTitle($event) {
+      this.$store.dispatch('articles/editedTitle', $event.target.value);
+    },
+    editedContent($event) {
+      this.$store.dispatch('articles/editedContent', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('articles/updateArticle');
+    },
+    selectedArticleCategory($event) {
+      const categoryName = $event.target.value;
+      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
+    },
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,14 +1,13 @@
 <template>
   <app-category-edit
-    :category-id="categoryId"
     :category-name="categoryName"
-    :loading="loading"
+    :disabled="loading"
     :done-message="doneMessage"
+    :error-message="errorMessage"
     :access="access"
-    @selected-article-category="selectedArticleCategory"
-    @edited-title="editedTitle"
-    @edited-content="editedContent"
+    @edited-category="editedCategory"
     @handle-submit="handleSubmit"
+    @clear-message="clearMessage"
   />
 </template>
 
@@ -19,65 +18,37 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
-  data() {
-    return {
-      categoryName: '',
-      content: '',
-    };
-  },
   computed: {
-    articleId() {
-      let { id } = this.$route.params;
-      id = parseInt(id, 10);
-      return id;
-    },
-    targetCategoryName() {
-      const { title } = this.$store.state.articles.targetArticle;
-      return title;
-    },
-    articleContent() {
-      const { content } = this.$store.state.articles.targetArticle;
-      return content;
-    },
-    markdownContent() {
-      return `# ${this.articleTitle}\n${this.articleContent}`;
-    },
-    currentCategoryName() {
-      const { name } = this.$store.state.articles.targetArticle.category;
-      return name;
-    },
-    categoryList() {
-      const { categoryList } = this.$store.state.categories;
-      return categoryList;
-    },
     loading() {
-      return this.$store.state.articles.loading;
+      return this.$store.state.categories.loading;
     },
     doneMessage() {
-      return this.$store.state.articles.doneMessage;
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
     },
     access() {
       return this.$store.getters['auth/access'];
     },
+    categoryName() {
+      return this.$store.state.categories.category.name;
+    },
   },
   created() {
-    this.$store.dispatch('categories/getAllCategories');
-    this.$store.dispatch('articles/getArticleDetail', parseInt(this.articleId, 10));
+    this.$store.dispatch('categories/clearMessage');
+    this.$store.dispatch('categories/getTargetCategory', this.$route.params.id);
   },
   methods: {
-    editedTitle($event) {
-      this.$store.dispatch('articles/editedTitle', $event.target.value);
-    },
-    editedContent($event) {
-      this.$store.dispatch('articles/editedContent', $event.target.value);
+    editedCategory($event) {
+      this.$store.dispatch('categories/editedCategory', $event.target.value);
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('articles/updateArticle');
+      this.$store.dispatch('categories/updateCategory');
     },
-    selectedArticleCategory($event) {
-      const categoryName = $event.target.value;
-      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
     },
   },
 };

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -20,6 +20,7 @@ import Profile from '@Pages/Profile/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import Category from '@Pages/Categories/Category.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // ユーザー
 import Users from '@Pages/Users/index.vue';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'category',
           path: '',
           component: Category,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,6 +8,10 @@ export default {
     errorMessage: '',
     loading: false,
     deleteCategoryId: null,
+    category: {
+      id: '',
+      name: '',
+    },
   },
   mutations: {
     doneGetAllCategories(state, { categories }) {
@@ -31,6 +35,12 @@ export default {
     },
     confirmDeleteCategory(state, { categoryId }) {
       state.deleteCategoryId = categoryId;
+    },
+    editedCategory(state, name) {
+      state.category.name = name;
+    },
+    doneGetCategory(state, category) {
+      state.category = category;
     },
   },
   actions: {
@@ -85,6 +95,33 @@ export default {
         }).catch(err => {
           commit('failRequest', { message: err.message });
         });
+      });
+    },
+    editedCategory({ commit }, name) {
+      commit('editedCategory', name);
+    },
+    updateCategory({ commit, rootGetters, state }) {
+      commit('toggleLoading');
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.category.id}`,
+        data: state.category,
+      }).then(() => {
+        commit('displayDoneMessage', { message: 'カテゴリー名を変更しました' });
+        commit('toggleLoading');
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+        commit('toggleLoading');
+      });
+    },
+    getTargetCategory({ commit, rootGetters }, id) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then(res => {
+        commit('doneGetCategory', res.data.category);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-569

## やったこと
- 更新ボタンを押した後の遷移画面の作成
- 戻る機能の実装
- 初期値にカテゴリー名が入力されているフォームの作成
- 更新ボタンを押すとAPI通信によりデータベースを更新し一覧に反映
- 更新ボタンを押した後は成功または失敗のメッセージを表示させる

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-571

## 特にレビューをお願いしたい箇所
なし
