### PR TITLE
カテゴリー管理画面の作成（GIZFE-580）

### DIFF
--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -1,3 +1,70 @@
 <template>
-  <router-view />
+  <div class="categories">
+    <app-category-post
+      class="categories-item"
+      :error-message="errorMessage"
+      :access="access"
+    />
+    <app-category-list
+      class="categories-item"
+      :access="access"
+      :categories="categoryList"
+      :theads="theads"
+    />
+  </div>
 </template>
+
+<script>
+import { CategoryList, CategoryPost } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryPost: CategoryPost,
+    appCategoryList: CategoryList,
+  },
+  data() {
+    return {
+      theads: ['カテゴリー名'],
+    };
+  },
+  computed: {
+    categoryList() {
+      return this.$store.state.categories.categoryList;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+  },
+};
+</script>
+<style lang="scss" scoped>
+.categories {
+  display: flex;
+  flex-direction: row;
+
+  &-item:first-child {
+    width: 35%;
+    overflow: hidden;
+  }
+
+  &-item:last-child {
+    width: 65%;
+    overflow: hidden;
+
+  }
+  &-item + .categories-item{
+    border-left: 2px solid #e3e3e3;
+    margin-left: 20px;
+    padding-left: 20px;
+  }
+}
+</style>

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="categories">
     <app-category-post
-      class="categories-item"
+      class="categories-input"
       :error-message="errorMessage"
       :access="access"
     />
     <app-category-list
-      class="categories-item"
+      class="categories-list"
       :access="access"
       :categories="categoryList"
       :theads="theads"
@@ -51,17 +51,13 @@ export default {
   display: flex;
   flex-direction: row;
 
-  &-item:first-child {
+  &-input {
     width: 35%;
-    overflow: hidden;
   }
 
-  &-item:last-child {
+  &-list {
     width: 65%;
-    overflow: hidden;
-
-  }
-  &-item + .categories-item{
+    overflow:hidden;
     border-left: 2px solid #e3e3e3;
     margin-left: 20px;
     padding-left: 20px;

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -5,6 +5,11 @@ export default [
     path: '/',
   },
   {
+    id: 2,
+    name: 'カテゴリ',
+    path: '/categories',
+  },
+  {
     id: 3,
     name: '記事',
     path: '/articles',

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -14,6 +14,9 @@ import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
 
+// ↓追加↓ カテゴリ
+import Categories from '@Pages/Categories/index.vue';
+
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
 
@@ -106,6 +109,12 @@ const router = new VueRouter({
           component: ArticleEdit,
         },
       ],
+    },
+    // ↓追加↓ カテゴリ
+    {
+      name: 'categories',
+      path: '/categories',
+      component: Categories,
     },
     {
       path: '/users',

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 import {
   auth, articles, users,
 } from './modules';
+import categories from './modules/categories';
 
 Vue.use(Vuex);
 export default new Vuex.Store({
@@ -11,5 +12,6 @@ export default new Vuex.Store({
     auth,
     articles,
     users,
+    categories,
   },
 });

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -1,9 +1,8 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import {
-  auth, articles, users,
+  auth, articles, users, categories,
 } from './modules';
-import categories from './modules/categories';
 
 Vue.use(Vuex);
 export default new Vuex.Store({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -22,8 +22,7 @@ export default {
         url: '/category',
       }).then(res => {
         if (res.data.code === 0) throw new Error(res.data.message);
-        const categories = res.data.categories.map(data => data);
-        commit('doneGetAllCategories', categories);
+        commit('doneGetAllCategories', res.data.categories);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,7 +4,6 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
-    deleteCategoryId: null,
     doneMessage: '',
     errorMessage: '',
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -1,0 +1,33 @@
+import axios from '@Helpers/axiosDefault';
+
+export default {
+  namespaced: true,
+  state: {
+    categoryList: [],
+    deleteCategoryId: null,
+    doneMessage: '',
+    errorMessage: '',
+  },
+  mutations: {
+    doneGetAllCategories(state, categories) {
+      state.categoryList = categories.reverse();
+    },
+    failRequest(state, { message }) {
+      state.errorMessage = `${message}が発生しています。ご確認の上、再度お試しください。`;
+    },
+  },
+  actions: {
+    getAllCategories({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then(res => {
+        if (res.data.code === 0) throw new Error(res.data.message);
+        const categories = res.data.categories.map(data => data);
+        commit('doneGetAllCategories', categories);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+  },
+};

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,7 +12,7 @@ export default {
       state.categoryList = categories.reverse();
     },
     failRequest(state, { message }) {
-      state.errorMessage = `${message}が発生しています。ご確認の上、再度お試しください。`;
+      state.errorMessage = `${message} : ご確認の上、再度お試しください。`;
     },
   },
   actions: {

--- a/src/js/_store/modules/index.js
+++ b/src/js/_store/modules/index.js
@@ -1,9 +1,11 @@
 import articles from './articles';
 import auth from './auth';
 import users from './users';
+import categories from './categories';
 
 export {
   articles,
   auth,
   users,
+  categories,
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-580

## やったこと
・src/components/pages/Categories/index.vue
Pagesのカテゴリーを変更しました。

・src/js/_helpers/routeLinksArray.js
・src/js/_router/index.js
カテゴリーへのルートを追加しました。

・src/js/_store/modules/categories.js
カテゴリーのstoreを追加しました。

・src/js/_store/index.js
追加したカテゴリーのstoreをstoreをまとめているファイル内に追記し集約させました。

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-582

## 特にレビューをお願いしたい箇所
- カテゴリーのstoreを全体のstoreにまとめる際の記述について
src/js/_store/index.js
import {
  auth, articles, users,
} from './modules';
→この中にcategoriesを入れたかったのですが、うまくいきませんでした。
import categories from './modules/categories';
→このように記述することで集約できたようなのですが、どのように書けばよかったのかと疑問が残っております。

・カテゴリーの入力欄と一覧部分の間の区切り線がとても無理やりな気がしております。borderを使ったのですが、hrタグを使ったりもっとスマートな方法があれば確認したいです。

・また、事前に入力欄と一覧の幅の比率を確認すべきでした。現在、35%と65%という中途半端な幅になっています。　