### PR TITLE
カテゴリー新規作成機能の実装（GIZFE-586）

### DIFF
--- a/src/components/atoms/Input/index.vue
+++ b/src/components/atoms/Input/index.vue
@@ -6,7 +6,7 @@
       :type="type"
       :placeholder="placeholder"
       :value="value"
-      @input="$emit('update-value', $event.target.value)"
+      @input="$emit('update-value', $event)"
     >
 
     <transition name="shake">

--- a/src/components/atoms/Input/index.vue
+++ b/src/components/atoms/Input/index.vue
@@ -6,7 +6,7 @@
       :type="type"
       :placeholder="placeholder"
       :value="value"
-      @input="$emit('update-value', $event)"
+      @input="$emit('update-value', $event.target.value)"
     >
 
     <transition name="shake">

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -44,7 +44,7 @@ export default {
   props: {
     category: {
       type: String,
-      default: '',
+      required: true,
     },
     errorMessage: {
       type: String,

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -7,8 +7,8 @@
       type="text"
       placeholder="追加するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
-      :error-messages="errors.collect('category')"
       :value="category"
+      :error-messages="errors.collect('category')"
       @update-value="$emit('update-value', $event)"
     />
     <app-button

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -9,6 +9,7 @@
       @handle-submit="handleSubmit"
       @update-value="updateValue"
     />
+
     <app-category-list
       class="categories-list"
       :access="access"
@@ -28,6 +29,9 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      targetCategory: {
+        name: '',
+      },
     };
   },
   computed: {
@@ -44,7 +48,7 @@ export default {
       return this.$store.state.categories.doneMessage;
     },
     categoryName() {
-      return this.$store.state.categories.targetCategory.name;
+      return this.$data.targetCategory.name;
     },
   },
   created() {
@@ -53,12 +57,20 @@ export default {
   methods: {
     handleSubmit() {
       if (this.$store.state.categories.loading) return;
-      this.$store.dispatch('categories/postCategory');
+      const categoryName = this.targetCategory.name;
+      this.$store.dispatch('categories/postCategory', categoryName)
+        .then(() => {
+          this.targetCategory.name = '';
+        })
+        .catch(() => {
+          this.targetCategory.name = categoryName;
+        });
     },
-    updateValue(data) {
-      this.$store.dispatch('categories/updateValue', data.target.value);
+    updateValue(event) {
+      this.targetCategory.name = event.target.value;
     },
   },
+
 };
 </script>
 <style lang="scss" scoped>

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -65,9 +65,6 @@ export default {
       this.$store.dispatch('categories/postCategory', categoryName)
         .then(() => {
           this.targetCategory.name = '';
-        })
-        .catch(() => {
-          this.targetCategory.name = categoryName;
         });
     },
     updateValue(event) {

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -4,6 +4,7 @@
       class="categories-input"
       :error-message="errorMessage"
       :done-message="doneMessage"
+      :disabled="loadingStatus"
       :access="access"
       :category="categoryName"
       @handle-submit="handleSubmit"
@@ -49,6 +50,9 @@ export default {
     },
     categoryName() {
       return this.$data.targetCategory.name;
+    },
+    loadingStatus() {
+      return this.$store.state.categories.loading;
     },
   },
   created() {

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -6,7 +6,7 @@
       :done-message="doneMessage"
       :disabled="loadingStatus"
       :access="access"
-      :category="categoryName"
+      :category="$data.targetCategory.name"
       @handle-submit="handleSubmit"
       @update-value="updateValue"
     />
@@ -47,9 +47,6 @@ export default {
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
-    },
-    categoryName() {
-      return this.$data.targetCategory.name;
     },
     loadingStatus() {
       return this.$store.state.categories.loading;

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -3,7 +3,11 @@
     <app-category-post
       class="categories-input"
       :error-message="errorMessage"
+      :done-message="doneMessage"
       :access="access"
+      :category="changeCategory"
+      @handle-submit="handleSubmit"
+      @update-value="updateValue"
     />
     <app-category-list
       class="categories-list"
@@ -13,7 +17,6 @@
     />
   </div>
 </template>
-
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
 
@@ -40,9 +43,21 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
+    changeCategory() {
+      return this.$store.state.categories.targetCategory.name;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory');
+    },
+    updateValue(data) {
+      this.$store.dispatch('categories/updateValue', data);
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -56,7 +56,7 @@ export default {
       this.$store.dispatch('categories/postCategory');
     },
     updateValue(data) {
-      this.$store.dispatch('categories/updateValue', data);
+      this.$store.dispatch('categories/updateValue', data.target.value);
     },
   },
 };

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -5,7 +5,7 @@
       :error-message="errorMessage"
       :done-message="doneMessage"
       :access="access"
-      :category="changeCategory"
+      :category="categoryName"
       @handle-submit="handleSubmit"
       @update-value="updateValue"
     />
@@ -43,7 +43,7 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
-    changeCategory() {
+    categoryName() {
       return this.$store.state.categories.targetCategory.name;
     },
   },
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
     handleSubmit() {
-      if (this.loading) return;
+      if (this.$store.state.categories.loading) return;
       this.$store.dispatch('categories/postCategory');
     },
     updateValue(data) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -62,16 +62,16 @@ export default {
           url: '/category',
           data,
         }).then(() => {
-          commit('toggleLoading');
           commit('clearMessage');
           commit('clearValue');
+          commit('toggleLoading');
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
           this.dispatch('categories/getAllCategories');
           resolve();
         }).catch(err => {
           commit('toggleLoading');
-          reject();
           commit('failRequest', { message: err.message });
+          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,6 +4,11 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
+    targetCategory: {
+      id: null,
+      name: '',
+    },
+    loading: false,
     doneMessage: '',
     errorMessage: '',
   },
@@ -12,8 +17,27 @@ export default {
       state.categoryList = categories.reverse();
     },
     failRequest(state, { message }) {
-      state.errorMessage = `${message} : ご確認の上、再度お試しください。`;
+      state.errorMessage = `${message} ご確認の上、再度お試しください。`;
     },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
+    },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    updateValue(state, data) {
+      state.targetCategory.name = data;
+    },
+    clearValue(state) {
+      state.targetCategory.name = '';
+    },
+  },
+  getters: {
+    targetCategory: state => state.targetCategory,
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -26,6 +50,41 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
+    },
+    postCategory({ commit, rootGetters }) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', rootGetters['categories/targetCategory'].name);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('clearMessage');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          axios(rootGetters['auth/token'])({
+            method: 'GET',
+            url: '/category',
+          }).then(res => {
+            if (res.data.code === 0) throw new Error(res.data.message);
+            commit('doneGetAllCategories', res.data.categories);
+            commit('clearValue');
+            resolve();
+          }).catch(err => {
+            commit('failRequest', { message: err.message });
+          });
+        }).catch(err => {
+          commit('toggleLoading');
+          reject();
+          commit('failRequest', { message: err.message });
+        });
+      });
+    },
+    updateValue({ commit }, data) {
+      commit('updateValue', data);
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -56,7 +56,7 @@ export default {
         commit('clearMessage');
         commit('toggleLoading');
         const data = new URLSearchParams();
-        data.append('name', rootGetters['categories/targetCategory'].name);
+        data.append('name', this.getters['categories/targetCategory'].name);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -64,18 +64,10 @@ export default {
         }).then(() => {
           commit('toggleLoading');
           commit('clearMessage');
-          axios(rootGetters['auth/token'])({
-            method: 'GET',
-            url: '/category',
-          }).then(res => {
-            if (res.data.code === 0) throw new Error(res.data.message);
-            commit('doneGetAllCategories', res.data.categories);
-            commit('clearValue');
-            commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
-            resolve();
-          }).catch(err => {
-            commit('failRequest', { message: err.message });
-          });
+          commit('clearValue');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          this.dispatch('categories/getAllCategories');
+          resolve();
         }).catch(err => {
           commit('toggleLoading');
           reject();

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,10 +4,6 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
-    targetCategory: {
-      id: null,
-      name: '',
-    },
     loading: false,
     doneMessage: '',
     errorMessage: '',
@@ -29,15 +25,6 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
-    updateValue(state, data) {
-      state.targetCategory.name = data;
-    },
-    clearValue(state) {
-      state.targetCategory.name = '';
-    },
-  },
-  getters: {
-    targetCategory: state => state.targetCategory,
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -51,19 +38,18 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    postCategory({ commit, rootGetters }) {
+    postCategory({ commit, rootGetters }, payload) {
       return new Promise((resolve, reject) => {
         commit('clearMessage');
         commit('toggleLoading');
         const data = new URLSearchParams();
-        data.append('name', this.getters['categories/targetCategory'].name);
+        data.append('name', payload);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
           data,
         }).then(() => {
           commit('clearMessage');
-          commit('clearValue');
           commit('toggleLoading');
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
           this.dispatch('categories/getAllCategories');
@@ -74,10 +60,6 @@ export default {
           reject();
         });
       });
-    },
-    updateValue({ commit }, data) {
-      commit('updateValue', data);
-      commit('clearMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -39,7 +39,7 @@ export default {
       });
     },
     postCategory({ commit, rootGetters }, payload) {
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         commit('clearMessage');
         commit('toggleLoading');
         const data = new URLSearchParams();
@@ -57,7 +57,6 @@ export default {
         }).catch(err => {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });
-          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -85,6 +85,7 @@ export default {
     },
     updateValue({ commit }, data) {
       commit('updateValue', data);
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -64,7 +64,6 @@ export default {
         }).then(() => {
           commit('toggleLoading');
           commit('clearMessage');
-          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
           axios(rootGetters['auth/token'])({
             method: 'GET',
             url: '/category',
@@ -72,6 +71,7 @@ export default {
             if (res.data.code === 0) throw new Error(res.data.message);
             commit('doneGetAllCategories', res.data.categories);
             commit('clearValue');
+            commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
             resolve();
           }).catch(err => {
             commit('failRequest', { message: err.message });


### PR DESCRIPTION
<!-- 各項目のコメントアウトは削除すること（このコメントアウトも削除） -->
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-586

## やったこと
 - inputイベント時に取得する値を「$event」から「$event.target.value」に変更
 - propsの「category（changeCagegory）」を受け取り必須に変更
 - 子コンポーネントに渡すpropsに「doneMessage」「changeCategory」を追加、
　それに伴いcomputedに「changeCategory」を追加。
 - 子コンポーネントから受け取るemitに「hundleSubmit」「updateValue」を追加。
 - store > categoriesのactionsに「postCategory」と「updateValue」を追加、
　mutationsに「displayDoneMessage」「ClearMessage」「ToggleLoading」「updateValue」「clearValue」を追加、
　gettersに「targetCategory」を追加、stateに「targetCategory」を追加。
 - エラーメッセージを一部修正

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-588

## 特にレビューをお願いしたい箇所
・現在はstore > categoriesにあるactions/mutationsの「updateValue」、stateの「targetCategory」をpages > categoriesへ移そうとしたのですが、actionsの「postCategory」で「targetCategory」のnameを呼び出す際（59行目）にエラーが出てしまいうまく実装できませんでした…。
力不足で恐縮なのですが、もし良い方法がありましたらご教示いただけますと幸いです。

・カテゴリー作成後に「カテゴリーを作成しました」のdoneMessageがずっと出ているのが気になり、カテゴリー入力欄にinputした際に「clearMessage」を呼び出して消しています。そのような挙動で問題がないかご確認いただきたいです。
