### PR TITLE
カテゴリーの削除機能の追加（GIZFE-595）

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="category-list">
+    <div v-if="errorMessage" class="category-list__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+    <div v-if="doneMessage" class="category-list__notice--create">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
     <table class="category-list__table">
       <thead class="category-list__table__head">
         <tr>
@@ -114,6 +120,14 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
     },
   },
   methods: {

--- a/src/components/pages/Articles/Detail.vue
+++ b/src/components/pages/Articles/Detail.vue
@@ -90,7 +90,6 @@ export default {
       }
     },
     openModal(articleId) {
-      // console.log(this);
       this.$store.dispatch('articles/confirmDeleteArticle', articleId);
       this.toggleModal();
     },

--- a/src/components/pages/Articles/Detail.vue
+++ b/src/components/pages/Articles/Detail.vue
@@ -90,6 +90,7 @@ export default {
       }
     },
     openModal(articleId) {
+      // console.log(this);
       this.$store.dispatch('articles/confirmDeleteArticle', articleId);
       this.toggleModal();
     },

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -16,21 +16,32 @@
       :access="access"
       :categories="categoryList"
       :theads="theads"
+      :delete-category-name="$data.deleteCategory.name"
+      :error-message="listErrorMessage"
+      :done-message="listDoneMessage"
+      @handle-click="handleClick"
+      @open-modal="openModal"
     />
   </div>
 </template>
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
       targetCategory: {
+        name: '',
+      },
+      deleteCategory: {
+        id: '',
         name: '',
       },
     };
@@ -47,6 +58,12 @@ export default {
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
+    },
+    listErrorMessage() {
+      return this.$store.state.categories.listErrorMessage;
+    },
+    listDoneMessage() {
+      return this.$store.state.categories.listDoneMessage;
     },
     loadingStatus() {
       return this.$store.state.categories.loading;
@@ -66,6 +83,21 @@ export default {
     },
     updateValue(event) {
       this.targetCategory.name = event.target.value;
+    },
+    handleClick() {
+      const categoryId = this.$data.deleteCategory.id;
+      this.$store.dispatch('categories/deleteCategory', categoryId)
+        .then(() => {
+          this.toggleModal();
+        })
+        .catch(() => {
+          this.toggleModal();
+        });
+    },
+    openModal(id, name) {
+      this.toggleModal();
+      this.$data.deleteCategory.id = id;
+      this.$data.deleteCategory.name = name;
     },
   },
 

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -6,7 +6,7 @@
       :done-message="doneMessage"
       :disabled="loadingStatus"
       :access="access"
-      :category="$data.targetCategory.name"
+      :category="targetCategory.name"
       @handle-submit="handleSubmit"
       @update-value="updateValue"
     />
@@ -16,7 +16,7 @@
       :access="access"
       :categories="categoryList"
       :theads="theads"
-      :delete-category-name="$data.deleteCategory.name"
+      :delete-category-name="deleteCategory.name"
       :error-message="listErrorMessage"
       :done-message="listDoneMessage"
       @handle-click="handleClick"
@@ -85,7 +85,7 @@ export default {
       this.targetCategory.name = event.target.value;
     },
     handleClick() {
-      const categoryId = this.$data.deleteCategory.id;
+      const categoryId = this.deleteCategory.id;
       this.$store.dispatch('categories/deleteCategory', categoryId)
         .then(() => {
           this.toggleModal();
@@ -96,8 +96,8 @@ export default {
     },
     openModal(id, name) {
       this.toggleModal();
-      this.$data.deleteCategory.id = id;
-      this.$data.deleteCategory.name = name;
+      this.deleteCategory.id = id;
+      this.deleteCategory.name = name;
     },
   },
 

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -48,7 +48,7 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    postCategory({ commit, rootGetters }, payload) {
+    postCategory({ commit, dispatch, rootGetters }, payload) {
       return new Promise(resolve => {
         commit('clearMessage');
         commit('toggleLoading');
@@ -62,7 +62,7 @@ export default {
           commit('clearMessage');
           commit('toggleLoading');
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
-          this.dispatch('categories/getAllCategories');
+          dispatch('getAllCategories');
           resolve();
         }).catch(err => {
           commit('toggleLoading');
@@ -71,7 +71,7 @@ export default {
       });
     },
 
-    deleteCategory({ commit, rootGetters }, id) {
+    deleteCategory({ commit, dispatch, rootGetters }, id) {
       return new Promise((resolve, reject) => {
         commit('clearMessage');
         axios(rootGetters['auth/token'])({
@@ -81,7 +81,7 @@ export default {
           if (response.data.code === 0) throw new Error(response.data.message);
           commit('clearMessage');
           commit('doneDeleteCategory');
-          this.dispatch('categories/getAllCategories');
+          dispatch('getAllCategories');
           resolve();
         }).catch(err => {
           commit('listFailRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,7 +5,6 @@ export default {
   state: {
     categoryList: [],
     loading: false,
-    deleteLoading: false,
 
     doneMessage: '',
     errorMessage: '',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,8 +5,12 @@ export default {
   state: {
     categoryList: [],
     loading: false,
+    deleteLoading: false,
+
     doneMessage: '',
     errorMessage: '',
+    listDoneMessage: '',
+    listErrorMessage: '',
   },
   mutations: {
     doneGetAllCategories(state, categories) {
@@ -21,9 +25,17 @@ export default {
     clearMessage(state) {
       state.doneMessage = '';
       state.errorMessage = '';
+      state.listDoneMessage = '';
+      state.listErrorMessage = '';
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    doneDeleteCategory(state) {
+      state.listDoneMessage = 'カテゴリーの削除が完了しました。';
+    },
+    listFailRequest(state, { message }) {
+      state.listErrorMessage = `${message} ご確認の上、再度お試しください。`;
     },
   },
   actions: {
@@ -57,6 +69,25 @@ export default {
         }).catch(err => {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });
+        });
+      });
+    },
+
+    deleteCategory({ commit, rootGetters }, id) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${id}`,
+        }).then(response => {
+          if (response.data.code === 0) throw new Error(response.data.message);
+          commit('clearMessage');
+          commit('doneDeleteCategory');
+          this.dispatch('categories/getAllCategories');
+          resolve();
+        }).catch(err => {
+          commit('listFailRequest', { message: err.message });
+          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,7 +5,6 @@ export default {
   state: {
     categoryList: [],
     loading: false,
-
     doneMessage: '',
     errorMessage: '',
     listDoneMessage: '',


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-595

## やったこと
- カテゴリー一覧上部にerrorMessageとdoneMessageを表示させるためdivタグの追加

- dataにdeleteCategoryを追加し、「削除」ボタンをクリック時に削除するカテゴリー名とカテゴリーIDをdeleteCategoryに代入
- mixinをimportし、toggleModal()を記述することでモーダルの開閉が実行できるように変更
- モーダル上の「削除」をクリック時にactionsのdeleteCategoryを実行し、DELETEメソッドで該当のカテゴリーを削除
- 削除時のエラーメッセージ／成功メッセージをカテゴリー新規作成時、カテゴリー一覧のものと分けるためlistErrorMessage／listDoneMessageをstateに追加

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-597

## 特にレビューをお願いしたい箇所
- サイドバーのメニュー内「ユーザー」においてユーザーの削除実行時の成功メッセージがユーザー一覧の上部に出ていたため同じ挙動にしようと思い、カテゴリー一覧の上部にメッセージを表示するようにしています。認識が誤っておりましたら、修正させていただきます。