### PR TITLE
カテゴリー新規作成機能実装（佐和）

### DIFF
--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="category__main">
     <div class="category__main__post">
-      <app-category-post />
+      <app-category-post
+        :category="category"
+        :error-message="errorMessage"
+        :done-message="doneMessage"
+        :access="access"
+        @update-value="updateValue"
+        @handle-submit="postCategory"
+        @clear-message="clearMessage"
+      />
     </div>
     <div class="category__main__list">
       <app-category-list
@@ -41,10 +49,26 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
   },
 
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+
+  methods: {
+    updateValue($event) {
+      this.category = $event.target.value;
+    },
+    postCategory() {
+      this.$store.dispatch('categories/postCategory', this.category);
+      this.category = '';
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -59,8 +59,8 @@ export default {
   },
 
   methods: {
-    updateValue($event) {
-      this.category = $event.target.value;
+    updateValue(event) {
+      this.category = event.target.value;
     },
     postCategory() {
       this.$store.dispatch('categories/postCategory', this.category);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,15 +5,24 @@ export default {
   state: {
     categoryList: [],
     errorMessage: '',
+    doneMessage: '',
   },
 
   mutations: {
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+    },
+    donePostCategory(state, newCategory) {
+      state.categoryList.unshift(newCategory);
+      state.doneMessage = 'カテゴリーを作成しました。';
     },
   },
 
@@ -27,9 +36,30 @@ export default {
           categories: res.data.categories,
         };
         commit('doneGetAllCategories', payload);
+        commit('clearMessage');
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
+    },
+    postCategory({ commit, rootGetters }, category) {
+      const data = new FormData();
+      data.append('name', category);
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data,
+      }).then(res => {
+        const newCategory = {
+          id: res.data.category.id,
+          name: res.data.category.name,
+        };
+        commit('donePostCategory', newCategory);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -38,7 +38,7 @@ export default {
         commit('doneGetAllCategories', payload);
         commit('clearMessage');
       }).catch(err => {
-        commit('failRequest', { message: err.message });
+        commit('failRequest', err);
       });
     },
     postCategory({ commit, rootGetters }, category) {
@@ -55,7 +55,7 @@ export default {
         };
         commit('donePostCategory', newCategory);
       }).catch(err => {
-        commit('failRequest', { message: err.message });
+        commit('failRequest', err);
       });
     },
     clearMessage({ commit }) {


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-613

## やったこと
- 入力されたカテゴリー名をAPI通信で追加。
- リストの更新、追加カテゴリーを最上部に表示。
- エラーメッセージ、完了メッセージのいずれかを表示。

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-615

## 特にレビューをお願いしたい箇所
なし
