### PR TITLE
add:カテゴリー新規作成機能の追加

### DIFF
--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @update-value="$event =>$emit('update-value', $event)"
+      @update-value="$emit('update-value', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @update-value="$emit('update-value', $event)"
+      @update-value="$event =>$emit('update-value', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -6,7 +6,7 @@
         :error-message="errorMessage"
         :done-message="doneMessage"
         :category="targetCategory.name"
-        :disabled="loading"
+        :disabled="isLoading"
         @update-value="targetCategory.name = $event.target.value"
         @clear-message="clearMessage"
         @handle-submit="createCategory"
@@ -39,8 +39,8 @@ export default {
     };
   },
   computed: {
-    loading() {
-      return this.$store.state.categories.loading;
+    isLoading() {
+      return this.$store.state.categories.isLoading;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -63,7 +63,7 @@ export default {
       this.$store.dispatch('categories/clearMessage');
     },
     createCategory() {
-      if (this.loading) return;
+      if (this.isLoading) return;
       this.$store.dispatch('categories/createCategory', {
         name: this.targetCategory.name,
       }).then(() => {

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -6,8 +6,8 @@
         :error-message="errorMessage"
         :done-message="doneMessage"
         :category="targetCategory.name"
-        :disabled="loading ? true : false"
-        @update-value="$event =>targetCategory.name = $event.target.value"
+        :disabled="loading"
+        @update-value="targetCategory.name = $event.target.value"
         @clear-message="clearMessage"
         @handle-submit="createCategory"
       />

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -65,10 +65,10 @@ export default {
     createCategory() {
       if (this.loading) return;
       this.$store.dispatch('categories/createCategory', {
-        /* eslint-disable-next-line no-irregular-whitespace */
-        name: this.targetCategory.name.replace(/( |　)+/, '').trim(),
+        name: this.targetCategory.name,
       }).then(() => {
-        this.$router.go();
+        this.targetCategory.name = null;
+        this.$store.dispatch('categories/getAllCategories');
       });
     },
   },

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -6,6 +6,7 @@
         :error-message="errorMessage"
         :done-message="doneMessage"
         :category="targetCategory.name"
+        :disabled="loading ? true : false"
         @update-value="$event =>targetCategory.name = $event.target.value"
         @clear-message="clearMessage"
         @handle-submit="createCategory"
@@ -14,7 +15,6 @@
     <div class="category-list-pages">
       <app-category-list
         :categories="categoryList"
-        class="category__list"
         :theads="theads"
         :access="access"
       />
@@ -39,6 +39,9 @@ export default {
     };
   },
   computed: {
+    loading() {
+      return this.$store.state.categories.loading;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -64,6 +67,8 @@ export default {
       this.$store.dispatch('categories/createCategory', {
         /* eslint-disable-next-line no-irregular-whitespace */
         name: this.targetCategory.name.replace(/( |　)+/, '').trim(),
+      }).then(() => {
+        this.$router.go();
       });
     },
   },

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -4,11 +4,17 @@
       <app-category-post
         :access="access"
         :error-message="errorMessage"
+        :done-message="doneMessage"
+        :category="targetCategory.name"
+        @update-value="$event =>targetCategory.name = $event.target.value"
+        @clear-message="clearMessage"
+        @handle-submit="createCategory"
       />
     </div>
     <div class="category-list-pages">
       <app-category-list
         :categories="categoryList"
+        class="category__list"
         :theads="theads"
         :access="access"
       />
@@ -27,6 +33,9 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      targetCategory: {
+        name: '',
+      },
     };
   },
   computed: {
@@ -36,12 +45,27 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    createCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/createCategory', {
+        /* eslint-disable-next-line no-irregular-whitespace */
+        name: this.targetCategory.name.replace(/( |　)+/, '').trim(),
+      });
+    },
   },
 };
 </script>

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,11 +3,11 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    loading: false,
+    isLoading: false,
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
-    category: {
+    categoryName: {
       id: null,
       name: '',
     },
@@ -23,13 +23,14 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
-      state.loading = false;
     },
     applyRequest(state) {
-      state.loading = true;
+      state.isLoading = true;
+    },
+    reversalLoading(state) {
+      state.isLoading = false;
     },
     doneCreateCategory(state) {
-      state.loading = false;
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
     },
   },
@@ -48,25 +49,27 @@ export default {
           id: data.id,
           name: data.name,
         }));
+        commit('reversalLoading');
         commit('doneGetAllCategories', { categories });
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
     },
     // カテゴリー新規作成
-    createCategory({ commit, rootGetters }, category) {
+    createCategory({ commit, rootGetters }, categoryName) {
       commit('applyRequest');
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
-          data: category,
+          data: categoryName,
         }).then(response => {
           if (response.data.code === 0) throw new Error(response.data.message);
           commit('doneCreateCategory');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
+          commit('reversalLoading');
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,10 +7,6 @@ export default {
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
-    categoryName: {
-      id: null,
-      name: '',
-    },
   },
 
   mutations: {
@@ -24,11 +20,8 @@ export default {
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
-    applyRequest(state) {
-      state.isLoading = true;
-    },
-    reversalLoading(state) {
-      state.isLoading = false;
+    toggleLoading(state) {
+      state.isLoading = !state.isLoading;
     },
     doneCreateCategory(state) {
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
@@ -40,6 +33,7 @@ export default {
     },
     // カテゴリー全件取得
     getAllCategories({ commit, rootGetters }) {
+      commit('toggleLoading');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/category',
@@ -49,27 +43,29 @@ export default {
           id: data.id,
           name: data.name,
         }));
-        commit('reversalLoading');
+        commit('toggleLoading');
         commit('doneGetAllCategories', { categories });
       }).catch(err => {
+        commit('toggleLoading');
         commit('failRequest', { message: err.message });
       });
     },
     // カテゴリー新規作成
     createCategory({ commit, rootGetters }, categoryName) {
-      commit('applyRequest');
+      commit('toggleLoading');
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
           data: categoryName,
         }).then(response => {
+          commit('toggleLoading');
           if (response.data.code === 0) throw new Error(response.data.message);
           commit('doneCreateCategory');
           resolve();
         }).catch(err => {
+          commit('toggleLoading');
           commit('failRequest', { message: err.message });
-          commit('reversalLoading');
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,19 +3,39 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    loading: false,
     categoryList: [],
     errorMessage: '',
+    doneMessage: '',
+    category: {
+      id: null,
+      name: '',
+    },
   },
 
   mutations: {
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
     doneGetAllCategories(state, { categories }) {
       state.categoryList = categories.reverse();
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
+    applyRequest(state) {
+      state.loading = true;
+    },
+    doneCreateCategory(state) {
+      state.loading = false;
+      state.doneMessage = '新規カテゴリーの追加が完了しました。';
+    },
   },
   actions: {
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
     // カテゴリー全件取得
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
@@ -30,6 +50,23 @@ export default {
         commit('doneGetAllCategories', { categories });
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    // カテゴリー新規作成
+    createCategory({ commit, rootGetters }, category) {
+      commit('applyRequest');
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data: category,
+        }).then(response => {
+          if (response.data.code === 0) throw new Error(response.data.message);
+          commit('doneCreateCategory');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.response.data.message });
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -23,6 +23,7 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+      state.loading = false;
     },
     applyRequest(state) {
       state.loading = true;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -65,7 +65,7 @@ export default {
           commit('doneCreateCategory');
           resolve();
         }).catch(err => {
-          commit('failRequest', { message: err.response.data.message });
+          commit('failRequest', { message: err.message });
         });
       });
     },


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-616

## やったこと
・作成ボタンがクリックされたら、新規作成APIを実行
・API成功時、一覧画面が更新されメッセージを表示
・追加されたカテゴリーはカテゴリー一覧の一番上に表示
・DBから取得したカテゴリ一覧が画面右側に表示
・API取得失敗時のエラー表示


## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-618

## 特にレビューをお願いしたい箇所
完成はしたがコードがあっているかもっといい書き方があるか
