### PR TITLE
feat: カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -28,13 +28,6 @@
       {{ buttonText }}
     </app-button>
 
-    <div v-if="errorMessage" class="category-management-edit__notice">
-      <app-text bg-error>{{ errorMessage }}</app-text>
-    </div>
-
-    <div v-if="doneMessage" class="category-management-edit__notice">
-      <app-text bg-success>{{ doneMessage }}</app-text>
-    </div>
   </form>
 </template>
 <script>
@@ -54,14 +47,6 @@ export default {
     category: {
       type: String,
       required: true,
-    },
-    errorMessage: {
-      type: String,
-      default: '',
-    },
-    doneMessage: {
-      type: String,
-      default: '',
     },
     disabled: {
       type: Boolean,

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -27,12 +27,12 @@
     >
       {{ buttonText }}
     </app-button>
-
   </form>
 </template>
+
 <script>
 import {
-  Heading, Input, Button, Text, RouterLink,
+  Heading, Input, Button, RouterLink,
 } from '@Components/atoms';
 
 export default {
@@ -40,7 +40,6 @@ export default {
     appHeading: Heading,
     appInput: Input,
     appButton: Button,
-    appText: Text,
     appRouterLink: RouterLink,
   },
   props: {
@@ -74,6 +73,7 @@ export default {
   },
 };
 </script>
+
 <style lang="scss" scoped>
 .category-management-edit {
   &__input {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,18 +1,26 @@
 <template>
-  <form @submit.prevent="addCategory">
+  <form @submit.prevent="handleSubmit">
     <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="category-edit__back">
+      <app-router-link
+        class="category-edit__back__link"
+        to="/categories"
+      >
+        カテゴリー一覧に戻る
+      </app-router-link>
+    </div>
     <app-input
       v-validate="'required'"
       name="category"
       type="text"
-      placeholder="追加するカテゴリー名を入力してください"
+      placeholder="新しいカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
       @update-value="$emit('update-value', $event)"
     />
     <app-button
-      class="category-management-post__submit"
+      class="category-management-edit__submit"
       button-type="submit"
       round
       :disabled="disabled || !access.create"
@@ -20,18 +28,18 @@
       {{ buttonText }}
     </app-button>
 
-    <div v-if="errorMessage" class="category-management-post__notice">
+    <div v-if="errorMessage" class="category-management-edit__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div v-if="doneMessage" class="category-management-post__notice">
+    <div v-if="doneMessage" class="category-management-edit__notice">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
 <script>
 import {
-  Heading, Input, Button, Text,
+  Heading, Input, Button, Text, RouterLink,
 } from '@Components/atoms';
 
 export default {
@@ -40,6 +48,7 @@ export default {
     appInput: Input,
     appButton: Button,
     appText: Text,
+    appRouterLink: RouterLink,
   },
   props: {
     category: {
@@ -65,13 +74,14 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '作成権限がありません';
-      return this.disabled ? '作成中...' : '作成';
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {
-    addCategory() {
+    handleSubmit() {
       if (!this.access.create) return;
+      this.$emit('clear-message');
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('handle-submit');
       });
@@ -80,7 +90,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-.category-management-post {
+.category-management-edit {
   &__input {
     margin-top: 16px;
   }
@@ -89,6 +99,15 @@ export default {
   }
   &__notice {
     margin-top: 16px;
+  }
+}
+.category-edit {
+  &__back {
+    margin-top: 20px;
+
+    &__link {
+      text-decoration: underline;
+    }
   }
 }
 </style>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -61,7 +61,7 @@ export default {
   },
 
   created() {
-    this.$store.dispatch('categories/getAllCategories');
+    // this.$store.dispatch('categories/getAllCategories');
   },
 
   methods: {

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -8,7 +8,6 @@
         :access="access"
         @update-value="updateValue"
         @handle-submit="postCategory"
-        @clear-message="clearMessage"
       />
     </div>
     <div class="category__main__list">
@@ -72,9 +71,6 @@ export default {
     postCategory() {
       this.$store.dispatch('categories/postCategory', this.category);
       this.category = '';
-    },
-    clearMessage() {
-      this.$store.dispatch('categories/clearMessage');
     },
     openModal(categoryId, categoryName) {
       this.deleteCategory = {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="category__edit">
+    <app-category-edit
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      :access="access"
+      :category="targetCategory.name"
+      @update-value="updateValue"
+      @handle-submit="editCategory"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+
+  data() {
+    return {
+      updatedCategory: {
+        id: '',
+        name: '',
+      },
+    };
+  },
+
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    targetCategory() {
+      return this.$store.state.categories.editTargetCategory;
+    },
+    loading() {
+      return this.$store.state.articles.loading;
+    },
+  },
+
+  created() {
+    this.$store.dispatch('categories/setTargetCategory', this.$route.params.id);
+    this.$store.dispatch('categories/clearMessage');
+  },
+
+  methods: {
+    updateValue(event) {
+      this.updatedCategory = {
+        id: this.targetCategory.id,
+        name: event.target.value,
+      };
+    },
+
+    editCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/editCategory', this.updatedCategory).then(() => {
+        this.$router.push('/categories');
+        this.updatedCategory = '';
+      });
+    },
+  },
+};
+
+</script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -125,6 +125,7 @@ const router = new VueRouter({
             if (isEdit) {
               next();
             } else {
+              Store.dispatch('categories/getAllCategories');
               Store.dispatch('categories/clearMessage');
               next();
             }

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -17,6 +17,7 @@ import ArticlePost from '@Pages/Articles/Post.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import Category from '@Pages/Categories/Category.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -119,6 +120,20 @@ const router = new VueRouter({
           name: 'categoryMain',
           path: '',
           component: Category,
+          beforeEnter(to, from, next) {
+            const isEdit = from.name === 'categoryEdit';
+            if (isEdit) {
+              next();
+            } else {
+              Store.dispatch('categories/clearMessage');
+              next();
+            }
+          },
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -41,6 +41,10 @@ export default {
     doneSetTarget(state, target) {
       state.editTargetCategory = target;
     },
+    doneEditCategory(state, editedCategory) {
+      const editedIndex = state.categoryList.findIndex(v => v.id === editedCategory.id);
+      state.categoryList.splice(editedIndex, 1, editedCategory);
+    },
   },
 
   actions: {
@@ -95,7 +99,12 @@ export default {
         method: 'PUT',
         url: `/category/${updated.id}`,
         data: { name: updated.name },
-      }).then(() => {
+      }).then(res => {
+        const editedCategory = {
+          id: res.data.category.id,
+          name: res.data.category.name,
+        };
+        commit('doneEditCategory', editedCategory);
         commit('showDoneMessage', '変更');
       }).catch(err => {
         commit('failRequest', err);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -6,12 +6,20 @@ export default {
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
+    loading: false,
+    editTargetCategory: {
+      id: '',
+      name: '',
+    },
   },
 
   mutations: {
     clearMessage(state) {
       state.doneMessage = '';
       state.errorMessage = '';
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
     },
     showDoneMessage(state, target) {
       state.doneMessage = `カテゴリーを${target}しました。`;
@@ -30,6 +38,9 @@ export default {
       const deleteIndex = state.categoryList.findIndex(v => v.id === deletedCategoryId);
       state.categoryList.splice(deleteIndex, 1);
     },
+    doneSetTarget(state, target) {
+      state.editTargetCategory = target;
+    },
   },
 
   actions: {
@@ -37,6 +48,7 @@ export default {
       commit('clearMessage');
     },
     getAllCategories({ commit, rootGetters }) {
+      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/category',
@@ -45,18 +57,16 @@ export default {
           categories: res.data.categories,
         };
         commit('doneGetAllCategories', payload);
-        commit('clearMessage');
       }).catch(err => {
         commit('failRequest', err);
       });
     },
-    postCategory({ commit, rootGetters }, category) {
-      const data = new FormData();
-      data.append('name', category);
+    postCategory({ commit, rootGetters }, categoryName) {
+      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'POST',
         url: '/category',
-        data,
+        data: { name: categoryName },
       }).then(res => {
         const newCategory = {
           id: res.data.category.id,
@@ -69,12 +79,38 @@ export default {
       });
     },
     deleteCategory({ commit, rootGetters }, deleteCategoryId) {
+      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
         url: `/category/${deleteCategoryId}`,
       }).then(res => {
         commit('doneDeleteCategory', res.data.category.id);
         commit('showDoneMessage', '削除');
+      }).catch(err => {
+        commit('failRequest', err);
+      });
+    },
+    editCategory({ commit, rootGetters }, updated) {
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${updated.id}`,
+        data: { name: updated.name },
+      }).then(() => {
+        commit('showDoneMessage', '変更');
+      }).catch(err => {
+        commit('failRequest', err);
+      });
+    },
+    setTargetCategory({ commit, rootGetters }, targetId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${targetId}`,
+      }).then(res => {
+        const targetCategory = {
+          id: res.data.category.id,
+          name: res.data.category.name,
+        };
+        commit('doneSetTarget', targetCategory);
       }).catch(err => {
         commit('failRequest', err);
       });


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-627

## やったこと
- カテゴリー更新ページ作成
- API通信と更新機能実装
- カテゴリー管理画面に遷移、更新されたリスト表示
- カテゴリ管理画面に完了・エラーメッセージ表示

## やらないこと
categories.jsのactionsの引数名変更はわかりやすくしただけなので、今回の課題とは無関係です。

## テスト
https://gizumo.backlog.com/view/GIZFE-629

## 特にレビューをお願いしたい箇所
routeのbeforeEnterの記述が不安。
