### PR TITLE
add:カテゴリー削除機能の追加

### DIFF
--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -17,6 +17,9 @@
         :categories="categoryList"
         :theads="theads"
         :access="access"
+        :delete-category-name="deleteCategoryName"
+        @open-modal="openModal"
+        @handle-click="handleClick"
       />
     </div>
   </section>
@@ -24,16 +27,26 @@
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
+  // beforeRouteUpdate(to, from, next) {
+  // this.fetchCategory();
+  // next();
+  // },
   data() {
     return {
       theads: ['カテゴリー名'],
       targetCategory: {
+        name: '',
+      },
+      deleteCategory: {
+        id: '',
         name: '',
       },
     };
@@ -54,6 +67,9 @@ export default {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -70,6 +86,19 @@ export default {
         this.targetCategory.name = null;
         this.$store.dispatch('categories/getAllCategories');
       });
+    },
+    openModal(categoryId, categoryName) {
+      this.deleteCategory.id = categoryId;
+      this.deleteCategory.name = categoryName;
+      this.$store.dispatch('categories/modalCategory', { categoryId, categoryName });
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategory.id)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/Category.vue
+++ b/src/components/pages/Categories/Category.vue
@@ -35,10 +35,6 @@ export default {
     appCategoryList: CategoryList,
   },
   mixins: [Mixins],
-  // beforeRouteUpdate(to, from, next) {
-  // this.fetchCategory();
-  // next();
-  // },
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -68,7 +64,7 @@ export default {
       return this.$store.state.categories.categoryList;
     },
     deleteCategoryName() {
-      return this.$store.state.categories.deleteCategoryName;
+      return this.deleteCategory.name;
     },
   },
   created() {
@@ -90,7 +86,6 @@ export default {
     openModal(categoryId, categoryName) {
       this.deleteCategory.id = categoryId;
       this.deleteCategory.name = categoryName;
-      this.$store.dispatch('categories/modalCategory', { categoryId, categoryName });
       this.toggleModal();
     },
     handleClick() {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,9 +4,11 @@ export default {
   namespaced: true,
   state: {
     isLoading: false,
-    categoryList: [],
     errorMessage: '',
     doneMessage: '',
+    deleteCategoryId: null,
+    deleteCategoryName: '',
+    categoryList: [],
   },
 
   mutations: {
@@ -17,14 +19,24 @@ export default {
     doneGetAllCategories(state, { categories }) {
       state.categoryList = categories.reverse();
     },
-    failRequest(state, { message }) {
-      state.errorMessage = message;
-    },
     toggleLoading(state) {
       state.isLoading = !state.isLoading;
     },
     doneCreateCategory(state) {
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
+    },
+    modalDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+    },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
+    },
+    failRequest(state, { message }) {
+      state.errorMessage = message;
     },
   },
   actions: {
@@ -67,6 +79,25 @@ export default {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });
         });
+      });
+    },
+    // カテゴリー削除のモーダルを開く
+    modalCategory({ commit }, { categoryId, categoryName }) {
+      commit('modalDeleteCategory', { categoryId, categoryName });
+    },
+    // カテゴリー削除
+    deleteCategory({ commit, rootGetters }, categoryId) {
+      commit('clearMessage');
+      const data = new URLSearchParams();
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${categoryId}`,
+        data,
+      }).then(() => {
+        commit('doneDeleteCategory');
+        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -6,8 +6,6 @@ export default {
     isLoading: false,
     errorMessage: '',
     doneMessage: '',
-    deleteCategoryId: null,
-    deleteCategoryName: '',
     categoryList: [],
   },
 
@@ -21,9 +19,6 @@ export default {
     },
     toggleLoading(state) {
       state.isLoading = !state.isLoading;
-    },
-    doneCreateCategory(state) {
-      state.doneMessage = '新規カテゴリーの追加が完了しました。';
     },
     modalDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;
@@ -73,7 +68,7 @@ export default {
         }).then(response => {
           commit('toggleLoading');
           if (response.data.code === 0) throw new Error(response.data.message);
-          commit('doneCreateCategory');
+          commit('displayDoneMessage', { message: '新規カテゴリーの追加が完了しました' });
           resolve();
         }).catch(err => {
           commit('toggleLoading');


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-638

## やったこと
○削除確認用モーダルの表示処理
　 ・モーダルの表示
　 ・削除対象のカテゴリ名表示

○モーダル内部の削除ボタンをクリックした場合のAPI処理
     ・削除API成功時のメッセージを表示
　 ・AP I取得失敗時のエラーメッセージ

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-640#comment-231282744

## 特にレビューをお願いしたい箇所
実装はできたがもっといい書き方があるか
