### PR TITLE
1-1 カテゴリ一管理画面実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -131,11 +131,13 @@ export default {
 
 <style lang="scss" scoped>
 .category-list {
-  padding: 10px 0 20px;
+  border-left: 1px solid $separator-color;
+  padding: 10px 25px 20px;
   height: 100%;
   overflow: scroll;
   &__table {
     width: 100%;
+    padding-left: 10px;
     text-align: left;
     tr {
       border-bottom: 1px solid $separator-color;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="Categories-edit">
+    <app-category-post class="app-category-post">
+    </app-category-post>
+    <app-category-list
+    :categories="categoriesList"
+    :theads="theads"
+    class="app-category-list"
+    >
+    </app-category-list>
+  </div>
+</template>
+
+<script>
+import { CategoryList } from '@Components/molecules'
+import { CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appCategoryList: CategoryList,
+    appCategoryPost: CategoryPost,
+  },
+  mixins: [Mixins],
+  data() {
+    return {
+      theads: ['カテゴリー名', '', '', '', '', ''],
+    };
+  },
+  computed: {
+    categoriesList(){
+      return this.$store.state.categories.categoriesList;
+    }
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+  },
+}
+
+</script>
+
+<style lang="scss" scoped>
+.Categories-edit {
+  display: flex;
+  justify-content: space-between;
+}
+.app-category-post {
+  width: 350px;
+}
+.app-category-list {
+  width: 900px;
+}
+
+</style>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -24,7 +24,7 @@ export default {
   mixins: [Mixins],
   data() {
     return {
-      theads: ['カテゴリー名', '', '', '', '', ''],
+      theads: ['カテゴリー名'],
     };
   },
   computed: {
@@ -45,10 +45,10 @@ export default {
   justify-content: space-between;
 }
 .app-category-post {
-  width: 350px;
+  width: 27%;
 }
 .app-category-list {
-  width: 900px;
+  width: 70%;
 }
 
 </style>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -1,19 +1,16 @@
 <template>
   <div class="Categories-edit">
-    <app-category-post class="app-category-post">
-    </app-category-post>
+    <app-category-post class="app-category-post" />
     <app-category-list
-    :categories="categoriesList"
-    :theads="theads"
-    class="app-category-list"
-    >
-    </app-category-list>
+      :categories="categoriesList"
+      :theads="theads"
+      class="app-category-list"
+    />
   </div>
 </template>
 
 <script>
-import { CategoryList } from '@Components/molecules'
-import { CategoryPost } from '@Components/molecules';
+import { CategoryList, CategoryPost } from '@Components/molecules';
 import Mixins from '@Helpers/mixins';
 
 export default {
@@ -28,14 +25,14 @@ export default {
     };
   },
   computed: {
-    categoriesList(){
+    categoriesList() {
       return this.$store.state.categories.categoriesList;
-    }
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
   },
-}
+};
 
 </script>
 

--- a/src/components/pages/index.vue
+++ b/src/components/pages/index.vue
@@ -59,7 +59,7 @@ export default {
     }
   }
   &-inner {
-    padding: 20px;
+    padding: 20px 0px 20px 20px;
     height: 100%;
   }
 }

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -5,6 +5,11 @@ export default [
     path: '/',
   },
   {
+    id: 2,
+    name: 'カテゴリ',
+    path: '/categories',
+  },
+  {
     id: 3,
     name: '記事',
     path: '/articles',

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -7,8 +7,8 @@ import Signout from '@Pages/Signout/index.vue';
 import NotFound from '@Pages/NotFound/index.vue';
 import Home from '@Pages/Home/index.vue';
 
-//カテゴリ
-import Categories from '@Pages/Categories/index.vue'
+// カテゴリ
+import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/List.vue';
 
 // 記事
@@ -72,7 +72,7 @@ const router = new VueRouter({
       component: Profile,
     },
     {
-      path:'/categories',
+      path: '/categories',
       component: Categories,
       children: [
         {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -32,7 +32,6 @@ import PasswordInit from '@Pages/Password/init.vue';
 import PasswordUpdate from '@Pages/Password/update.vue';
 
 import Store from '../_store';
-// import { component } from 'vue/types/umd';
 
 Vue.use(VueRouter);
 const router = new VueRouter({

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -7,6 +7,10 @@ import Signout from '@Pages/Signout/index.vue';
 import NotFound from '@Pages/NotFound/index.vue';
 import Home from '@Pages/Home/index.vue';
 
+//カテゴリ
+import Categories from '@Pages/Categories/index.vue'
+import CategoryList from '@Pages/Categories/List.vue';
+
 // 記事
 import Articles from '@Pages/Articles/index.vue';
 import ArticleList from '@Pages/Articles/List.vue';
@@ -28,6 +32,7 @@ import PasswordInit from '@Pages/Password/init.vue';
 import PasswordUpdate from '@Pages/Password/update.vue';
 
 import Store from '../_store';
+// import { component } from 'vue/types/umd';
 
 Vue.use(VueRouter);
 const router = new VueRouter({
@@ -66,6 +71,17 @@ const router = new VueRouter({
       name: 'profile',
       path: '/profile',
       component: Profile,
+    },
+    {
+      path:'/categories',
+      component: Categories,
+      children: [
+        {
+          name: 'categoryList',
+          path: '',
+          component: CategoryList,
+        },
+      ],
     },
     {
       path: '/articles',

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import {
-  auth, articles, users,
+  auth, articles, users, categories
 } from './modules';
 
 Vue.use(Vuex);
@@ -11,5 +11,6 @@ export default new Vuex.Store({
     auth,
     articles,
     users,
+    categories,
   },
 });

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import {
-  auth, articles, users, categories
+  auth, articles, users, categories,
 } from './modules';
 
 Vue.use(Vuex);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -27,6 +27,6 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
-    }
-  }
-}
+    },
+  },
+};

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -1,0 +1,28 @@
+import axios from '@Helpers/axiosDefault';
+
+export default {
+  namespaced: true,
+  state: {
+    categoriesList: [],
+  },
+  mutations: {
+    doneGetAllCategories(state, payload) {
+      state.categoriesList = [...payload.categories];
+    },
+  },
+  actions: {
+    getAllCategories({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then(res => {
+        const payload = {
+          categories: res.data.categories,
+        };
+        commit('doneGetAllCategories', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    }
+  }
+}

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,10 +4,14 @@ export default {
   namespaced: true,
   state: {
     categoriesList: [],
+    errorMessage: '',
   },
   mutations: {
     doneGetAllCategories(state, payload) {
       state.categoriesList = [...payload.categories];
+    },
+    failRequest(state, { message }) {
+      state.errorMessage = message;
     },
   },
   actions: {

--- a/src/js/_store/modules/index.js
+++ b/src/js/_store/modules/index.js
@@ -1,9 +1,11 @@
 import articles from './articles';
 import auth from './auth';
 import users from './users';
+import categories from './categories'
 
 export {
   articles,
   auth,
   users,
+  categories,
 };

--- a/src/js/_store/modules/index.js
+++ b/src/js/_store/modules/index.js
@@ -1,7 +1,7 @@
 import articles from './articles';
 import auth from './auth';
 import users from './users';
-import categories from './categories'
+import categories from './categories';
 
 export {
   articles,


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-577

## やったこと
・カテゴリボタンを押すと「/categories」のページが表示される。
・ブラウザの表示が仕様通り正しくできているか確認します。
・API通信が成功し、カテゴリ一覧情報を取得後、取得したカテゴリ一覧が画面右側に表示される。>

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-579

## 特にレビューをお願いしたい箇所
横並びのstyleの指定、こちらでよろしいでしょうか。
