### PR TITLE
削除済みの記事一覧機能の追加（GIZFE-714）

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -19,6 +19,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-danger
+      small
+      round
+      hover-opacity
+      class="article-list__trashed-link"
+    >
+      削除済み記事一覧
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -136,7 +148,7 @@ export default {
   },
   computed: {
     articleTitle() {
-      return `${this.title}の一覧`;
+      return `${this.title}一覧`;
     },
     buttonText() {
       return this.access.delete ? '削除' : '削除権限がありません';
@@ -167,6 +179,9 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+    }
+    &__trashed-link {
+      margin-left: 16px;
     }
     &__links {
       *:not(first-child) {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="article-trashed">
-    <app-heading :level="1">{{ articleTitle }}</app-heading>
+    <app-heading :level="1">削除済み記事一覧</app-heading>
     <div v-if="errorMessage" class="article-trashed__notice--create">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
@@ -26,21 +26,37 @@
           </th>
         </tr>
       </thead>
-      <transition-group name="fade" tag="tbody" class="article-trashed__table__body ">
-        <tr v-for="article in targetArray" :key="article.id">
+      <transition-group
+        name="fade"
+        tag="tbody"
+        class="article-trashed__table__body "
+      >
+        <tr
+          v-for="target in targetArray"
+          :key="target.id"
+        >
           <td>
-            <app-text tag="span" small>
-              {{ article.title | setSlice }}
+            <app-text
+              tag="span"
+              small
+            >
+              {{ target.title }}
             </app-text>
           </td>
           <td>
-            <app-text tag="span" small>
-              {{ article.content | setSlice }}
+            <app-text
+              tag="span"
+              small
+            >
+              {{ target.content }}
             </app-text>
           </td>
           <td>
-            <app-text tag="span" small>
-              {{ article.created_at | setData }}
+            <app-text
+              tag="span"
+              small
+            >
+              {{ target.created_at }}
             </app-text>
           </td>
         </tr>
@@ -62,22 +78,10 @@ export default {
     appRouterLink: RouterLink,
     appText: Text,
   },
-  filters: {
-    setSlice(value) {
-      return value.length > 30 ? `${value.slice(0, 30)}...` : value;
-    },
-    setData(value) {
-      return value.slice(0, 10);
-    },
-  },
   props: {
     targetArray: {
       type: Array,
       default: () => [],
-    },
-    title: {
-      type: String,
-      default: 'すべて',
     },
     errorMessage: {
       type: String,
@@ -88,10 +92,10 @@ export default {
       default: () => [],
     },
   },
-  computed: {
-    articleTitle() {
-      return `${this.title}一覧`;
-    },
+  data() {
+    return {
+      newArray: [],
+    };
   },
 };
 </script>

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -40,7 +40,7 @@
               tag="span"
               small
             >
-              {{ target.title }}
+              {{ setSlice( target.title ) }}
             </app-text>
           </td>
           <td>
@@ -48,7 +48,7 @@
               tag="span"
               small
             >
-              {{ target.content }}
+              {{ setSlice(target.content) }}
             </app-text>
           </td>
           <td>
@@ -56,7 +56,7 @@
               tag="span"
               small
             >
-              {{ target.created_at }}
+              {{ setData(target.created_at) }}
             </app-text>
           </td>
         </tr>
@@ -92,10 +92,19 @@ export default {
       default: () => [],
     },
   },
-  data() {
-    return {
-      newArray: [],
-    };
+  computed: {
+    setSlice() {
+      return target => {
+        const slicedTarget = target.length > 30 ? `${target.slice(0, 30)}...` : target;
+        return slicedTarget;
+      };
+    },
+    setData() {
+      return targetData => {
+        const slicedTarget = targetData.slice(0, 10);
+        return slicedTarget;
+      };
+    },
   },
 };
 </script>

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="article-trashed">
+    <app-heading :level="1">{{ articleTitle }}</app-heading>
+    <div v-if="errorMessage" class="article-trashed__notice--create">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+    <app-router-link
+      to="/articles"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-trashed__all-link"
+    >
+      すべての記事一覧へ戻る
+    </app-router-link>
+    <table class="article-trashed__table">
+      <thead class="article-trashed__table__head">
+        <tr>
+          <th v-for="(thead, index) in theads" :key="index">
+            <app-text tag="span" theme-color bold>
+              {{ thead }}
+            </app-text>
+          </th>
+        </tr>
+      </thead>
+      <transition-group name="fade" tag="tbody" class="article-trashed__table__body ">
+        <tr v-for="article in targetArray" :key="article.id">
+          <td>
+            <app-text tag="span" small>
+              {{ article.title | setSlice }}
+            </app-text>
+          </td>
+          <td>
+            <app-text tag="span" small>
+              {{ article.content | setSlice }}
+            </app-text>
+          </td>
+          <td>
+            <app-text tag="span" small>
+              {{ article.created_at | setData }}
+            </app-text>
+          </td>
+        </tr>
+      </transition-group>
+    </table>
+  </div>
+</template>
+
+<script>
+import {
+  Heading,
+  RouterLink,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+    appText: Text,
+  },
+  filters: {
+    setSlice(value) {
+      return value.length > 30 ? `${value.slice(0, 30)}...` : value;
+    },
+    setData(value) {
+      return value.slice(0, 10);
+    },
+  },
+  props: {
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+    title: {
+      type: String,
+      default: 'すべて',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    articleTitle() {
+      return `${this.title}一覧`;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.article-trashed {
+  &__table {
+    width: 100%;
+    text-align: left;
+    background-color: #fff;
+    margin-top: 16px;
+
+    tr {
+      border-bottom: 1px solid $separator-color;
+    }
+
+    &__head {
+      th {
+        padding: 5px 10px;
+        vertical-align: middle;
+      }
+    }
+
+    &__body {
+      td {
+        padding: 10px;
+        vertical-align: middle;
+      }
+    }
+    .fade-enter-active,
+    .fade-leave-active {
+        transition: opacity .5s;
+      }
+
+    .fade-enter,
+    .fade-leave-to {
+      opacity: 0;
+    }
+
+    &__title {
+      width: 60%;
+    }
+  }
+
+  &__notice--create {
+      margin-top: 16px;
+    }
+
+  &__all-link {
+      margin-top: 16px;
+    }
+}
+</style>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -14,6 +14,7 @@ import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
+import ArticleTrashed from './ArticleTrashed/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
 import Pagination from './Pagination/index.vue';
@@ -35,6 +36,7 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrashed,
   DeleteModal,
   Notice,
   Pagination,

--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -35,7 +35,7 @@ export default {
   },
   data() {
     return {
-      title: 'すべて',
+      title: '記事',
     };
   },
   computed: {

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,6 +1,5 @@
 <template>
   <app-article-trashed
-    :title="削除済み記事"
     :theads="['タイトル', '本文', '作成日']"
     :target-array="articlesList"
     :error-message="errorMessage"

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -6,6 +6,7 @@
     :error-message="errorMessage"
   />
 </template>
+
 <script>
 import { ArticleTrashed } from '@Components/molecules';
 import Mixins from '@Helpers/mixins';

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,7 +1,7 @@
 <template>
   <app-article-trashed
-    :title="title"
-    :theads="theads"
+    :title="削除済み記事"
+    :theads="['タイトル', '本文', '作成日']"
     :target-array="articlesList"
     :error-message="errorMessage"
   />
@@ -16,12 +16,6 @@ export default {
     appArticleTrashed: ArticleTrashed,
   },
   mixins: [Mixins],
-  data() {
-    return {
-      title: '削除済み記事',
-      theads: ['タイトル', '本文', '作成日'],
-    };
-  },
   computed: {
     articlesList() {
       return this.$store.state.articles.deletedArticleList;

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,39 @@
+<template>
+  <app-article-trashed
+    :title="title"
+    :theads="theads"
+    :target-array="articlesList"
+    :error-message="errorMessage"
+  />
+</template>
+<script>
+import { ArticleTrashed } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appArticleTrashed: ArticleTrashed,
+  },
+  mixins: [Mixins],
+  data() {
+    return {
+      title: '削除済み記事',
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    articlesList() {
+      return this.$store.state.articles.articleList;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getTrashedArticles');
+  },
+};
+</script>

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -24,7 +24,7 @@ export default {
   },
   computed: {
     articlesList() {
-      return this.$store.state.articles.articleList;
+      return this.$store.state.articles.deletedArticleList;
     },
     errorMessage() {
       return this.$store.state.articles.errorMessage;

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -13,6 +13,7 @@ import ArticleList from '@Pages/Articles/List.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 
 // カテゴリ
 import Categories from '@Pages/Categories/index.vue';
@@ -94,6 +95,11 @@ const router = new VueRouter({
               next();
             }
           },
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articlePost',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -137,13 +137,7 @@ export default {
       state.pages.lastPage = payload;
     },
     doneGetTrashedArticles(state, { articles }) {
-      const lists = articles;
-      for (let i = 0; i < lists.length; i += 1) {
-        lists[i].title = lists[i].title.length > 30 ? `${lists[i].title.slice(0, 30)}...` : lists[i].title;
-        lists[i].content = lists[i].content.length > 30 ? `${lists[i].content.slice(0, 30)}...` : lists[i].content;
-        lists[i].created_at = lists[i].created_at.slice(0, 10);
-      }
-      state.deletedArticleList = [...lists];
+      state.deletedArticleList = articles;
     },
   },
   actions: {

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -30,6 +30,7 @@ export default {
     },
     url: '',
     articleList: [],
+    deletedArticleList: [],
     deleteArticleId: null,
     loading: false,
     isClickable: true,
@@ -136,10 +137,7 @@ export default {
       state.pages.lastPage = payload;
     },
     doneGetTrashedArticles(state, payload) {
-      state.articleList = [...payload.articles];
-    },
-    clearListArray(state) {
-      state.articleList = [];
+      state.deletedArticleList = [...payload.articles];
     },
   },
   actions: {
@@ -337,7 +335,6 @@ export default {
     },
     getTrashedArticles({ commit, rootGetters }) {
       commit('clearMessage');
-      commit('clearListArray');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/article/trashed',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -136,8 +136,14 @@ export default {
     reflectPage(state, payload) {
       state.pages.lastPage = payload;
     },
-    doneGetTrashedArticles(state, payload) {
-      state.deletedArticleList = [...payload.articles];
+    doneGetTrashedArticles(state, { articles }) {
+      const lists = articles;
+      for (let i = 0; i < lists.length; i += 1) {
+        lists[i].title = lists[i].title.length > 30 ? `${lists[i].title.slice(0, 30)}...` : lists[i].title;
+        lists[i].content = lists[i].content.length > 30 ? `${lists[i].content.slice(0, 30)}...` : lists[i].content;
+        lists[i].created_at = lists[i].created_at.slice(0, 10);
+      }
+      state.deletedArticleList = [...lists];
     },
   },
   actions: {
@@ -334,17 +340,20 @@ export default {
       commit('clearMessage');
     },
     getTrashedArticles({ commit, rootGetters }) {
-      commit('clearMessage');
-      axios(rootGetters['auth/token'])({
-        method: 'GET',
-        url: '/article/trashed',
-      }).then(res => {
-        const pageAll = {
-          articles: res.data.articles,
-        };
-        commit('doneGetTrashedArticles', pageAll);
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
+      return new Promise(resolve => {
+        commit('clearMessage');
+        axios(rootGetters['auth/token'])({
+          method: 'GET',
+          url: '/article/trashed',
+        }).then(res => {
+          const pageAll = {
+            articles: res.data.articles,
+          };
+          commit('doneGetTrashedArticles', pageAll);
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
       });
     },
   },

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -342,7 +342,7 @@ export default {
         const pageAll = {
           articles: res.data.articles,
         };
-        commit('doneGetAllArticles', pageAll);
+        commit('doneGetTrashedArticles', pageAll);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -135,6 +135,12 @@ export default {
     reflectPage(state, payload) {
       state.pages.lastPage = payload;
     },
+    doneGetTrashedArticles(state, payload) {
+      state.articleList = [...payload.articles];
+    },
+    clearListArray(state) {
+      state.articleList = [];
+    },
   },
   actions: {
     initPostArticle({ commit }) {
@@ -328,6 +334,21 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    getTrashedArticles({ commit, rootGetters }) {
+      commit('clearMessage');
+      commit('clearListArray');
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(res => {
+        const pageAll = {
+          articles: res.data.articles,
+        };
+        commit('doneGetAllArticles', pageAll);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-714

## やったこと
・moleculesにArticlesTrashedを追加
・PagesにTrashedを追加
・ルーティングを追加
・削除済み記事を取得するAPIをarticles.jsに追加

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-716

## 特にレビューをお願いしたい箇所
・filtersで「slice」を使うことで日付は10文字まで、タイトルと本文は30文字目まで表示しそれ以降は「…」が表示されるようにしていますが、やり方が合っているか不安です。