### PR TITLE
fix: カテゴリー削除機能実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -123,9 +123,9 @@ export default {
       if (!this.access.delete) return;
       this.$emit('open-modal', categoryId, categoryName);
     },
-    handleClick(categoryId) {
+    handleClick() {
       if (!this.access.delete) return;
-      this.$emit('handle-click', categoryId);
+      this.$emit('handle-click');
     },
   },
 };

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -113,6 +113,14 @@ export default {
       type: String,
       default: '',
     },
+    categoryId: {
+      type: Number,
+      default: null,
+    },
+    categoryName: {
+      type: String,
+      default: '',
+    },
     access: {
       type: Object,
       default: () => ({}),

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -113,14 +113,6 @@ export default {
       type: String,
       default: '',
     },
-    categoryId: {
-      type: Number,
-      default: null,
-    },
-    categoryName: {
-      type: String,
-      default: '',
-    },
     access: {
       type: Object,
       default: () => ({}),

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -123,9 +123,9 @@ export default {
       if (!this.access.delete) return;
       this.$emit('open-modal', categoryId, categoryName);
     },
-    handleClick() {
+    handleClick(categoryId) {
       if (!this.access.delete) return;
-      this.$emit('handle-click');
+      this.$emit('handle-click', categoryId);
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -18,9 +18,10 @@
         :categories="categoryList"
         :delete-category-name="deleteCategoryName"
         :error-message="errorMessage"
+        :category-id="categoryId"
         :access="access"
         @open-modal="openModal"
-        @handle-submit="deleteCategory"
+        @handle-click="deleteCategory"
       />
     </div>
   </section>
@@ -57,6 +58,9 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategoryId;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
@@ -87,7 +91,8 @@ export default {
       this.toggleModal();
     },
     deleteCategory() {
-
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,8 +16,12 @@
       <app-category-list
         :theads="theads"
         :categories="categoryList"
+        :category-id="categoryId"
+        :category-name="categoryName"
         :error-message="errorMessage"
         :access="access"
+        @open-modal="openModal"
+        @handle-submit="deleteCategory"
       />
     </div>
   </section>
@@ -37,6 +41,8 @@ export default {
     return {
       theads: ['カテゴリー名'],
       category: '',
+      categoryName: '',
+      categoryId: null,
     };
   },
   computed: {
@@ -70,6 +76,13 @@ export default {
       if (this.loading) return;
       this.$store.dispatch('categories/addCategory', this.category);
       this.category = '';
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/modalDeleteCategory', categoryId, categoryName);
+      this.toggleModal();
+    },
+    deleteCategory() {
+
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,8 +16,7 @@
       <app-category-list
         :theads="theads"
         :categories="categoryList"
-        :category-id="categoryId"
-        :category-name="categoryName"
+        :delete-category-name="deleteCategoryName"
         :error-message="errorMessage"
         :access="access"
         @open-modal="openModal"
@@ -55,6 +54,9 @@ export default {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
@@ -78,7 +80,10 @@ export default {
       this.category = '';
     },
     openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/modalDeleteCategory', categoryId, categoryName);
+      this.$store.dispatch('categories/modalDeleteCategory', {
+        id: categoryId,
+        name: categoryName,
+      });
       this.toggleModal();
     },
     deleteCategory() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -18,7 +18,6 @@
         :categories="categoryList"
         :delete-category-name="deleteCategoryName"
         :error-message="errorMessage"
-        :category-id="categoryId"
         :access="access"
         @open-modal="openModal"
         @handle-click="deleteCategory"
@@ -58,9 +57,6 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
-    deleteCategoryId() {
-      return this.$store.state.categories.deleteCategoryId;
-    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
@@ -84,7 +80,7 @@ export default {
       this.category = '';
     },
     openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/modalDeleteCategory', {
+      this.$store.dispatch('categories/setDeleteCategoryInfo', {
         id: categoryId,
         name: categoryName,
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,12 +13,14 @@ export default {
       name: '',
     },
     deleteCategoryName: '',
+    deleteCategoryId: null,
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
   },
   getters: {
     targetCategory: state => state.targetCategory,
+    deleteCategoryId: state => state.deleteCategoryId,
   },
   mutations: {
     clearMessage(state) {
@@ -31,6 +33,12 @@ export default {
     },
     modalDeleteCategory(state, payload) {
       state.deleteCategoryName = payload.categoryName;
+      state.deleteCategoryId = payload.categoryId;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = state.categoryId;
+      state.categoryList.splice(state.deleteCategoryId, 1);
+      state.doneMessage = 'カテゴリーの削除が完了しました。';
     },
     newAddCategory(state, payload) {
       state.loading = false;
@@ -64,6 +72,17 @@ export default {
         categoryName: name,
       };
       commit('modalDeleteCategory', payload);
+    },
+    deleteCategory({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        data: { id: this.deleteCategoryId },
+      }).then(() => {
+        commit('doneDeleteCategory');
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
     addCategory({ commit, rootGetters }, categoryName) {
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,11 +12,8 @@ export default {
       id: null,
       name: '',
     },
-    categoryList: [],
-    deleteCategoryId: null,
     deleteCategoryName: '',
-    categoryId: null,
-    categoryName: '',
+    categoryList: [],
     errorMessage: '',
     doneMessage: '',
   },
@@ -32,9 +29,8 @@ export default {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
     },
-    modalDeleteCategory(state, categoryId, categoryName) {
-      state.deleteCategoryId = categoryId;
-      state.deleteCategoryName = categoryName;
+    modalDeleteCategory(state, payload) {
+      state.deleteCategoryName = payload.categoryName;
     },
     newAddCategory(state, payload) {
       state.loading = false;
@@ -62,8 +58,12 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    modalDeleteCategory({ commit }, { categoryId, categoryName }) {
-      commit('modalDeleteCategory', { categoryId, categoryName });
+    modalDeleteCategory({ commit }, { id, name }) {
+      const payload = {
+        categoryId: id,
+        categoryName: name,
+      };
+      commit('modalDeleteCategory', payload);
     },
     addCategory({ commit, rootGetters }, categoryName) {
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -31,14 +31,15 @@ export default {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
     },
-    modalDeleteCategory(state, payload) {
+    setDeleteCategoryInfo(state, payload) {
       state.deleteCategoryName = payload.categoryName;
       state.deleteCategoryId = payload.categoryId;
     },
     doneDeleteCategory(state) {
-      state.deleteCategoryId = state.categoryId;
-      state.categoryList.splice(state.deleteCategoryId, 1);
+      const index = state.categoryList.findIndex(i => i.id === state.deleteCategoryId);
+      state.categoryList.splice(index, 1);
       state.doneMessage = 'カテゴリーの削除が完了しました。';
+      state.deleteCategoryId = null;
     },
     newAddCategory(state, payload) {
       state.loading = false;
@@ -66,17 +67,17 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    modalDeleteCategory({ commit }, { id, name }) {
+    setDeleteCategoryInfo({ commit }, { id, name }) {
       const payload = {
         categoryId: id,
         categoryName: name,
       };
-      commit('modalDeleteCategory', payload);
+      commit('setDeleteCategoryInfo', payload);
     },
     deleteCategory({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
-        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        url: `/category/${'deleteCategoryId'}`,
         data: { id: this.deleteCategoryId },
       }).then(() => {
         commit('doneDeleteCategory');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -77,7 +77,7 @@ export default {
     deleteCategory({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
-        url: `/category/${'deleteCategoryId'}`,
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
         data: { id: this.deleteCategoryId },
       }).then(() => {
         commit('doneDeleteCategory');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,6 +13,10 @@ export default {
       name: '',
     },
     categoryList: [],
+    deleteCategoryId: null,
+    deleteCategoryName: '',
+    categoryId: null,
+    categoryName: '',
     errorMessage: '',
     doneMessage: '',
   },
@@ -27,6 +31,10 @@ export default {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
+    },
+    modalDeleteCategory(state, categoryId, categoryName) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
     },
     newAddCategory(state, payload) {
       state.loading = false;
@@ -53,6 +61,9 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
+    },
+    modalDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('modalDeleteCategory', { categoryId, categoryName });
     },
     addCategory({ commit, rootGetters }, categoryName) {
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,10 +74,10 @@ export default {
       };
       commit('setDeleteCategoryInfo', payload);
     },
-    deleteCategory({ commit, rootGetters }) {
+    deleteCategory({ commit, rootGetters, state }) {
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
-        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        url: `/category/${state.deleteCategoryId}`,
         data: { id: this.deleteCategoryId },
       }).then(() => {
         commit('doneDeleteCategory');


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-746

## やったこと
・削除ボタンを押したら、削除確認用のモーダルが出現する
・削除確認用のモーダルには、削除対象のカテゴリ名が表示される
・削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行される
・成功したら一覧が更新され、メッセージを表示する

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-748

## 特にレビューをお願いしたい箇所
最後のカテゴリー内容をリストから消すところがどうすればよかったのか全く分からなかったのですが奇跡的に上手くいったのですがなんで上手くいったのかよくわからないのでそこらへんの説明があればお願いしたいです。
