### PR TITLE
削除済記事一覧ページ作成

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__create-link"
+    >
+      削除済み記事一覧
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -29,7 +41,7 @@
         align-items
         bg-white
         large
-        border-bottom-gray
+        bo1111rder-bottom-gray
       >
         <app-text
           class="article-list__title"
@@ -160,6 +172,11 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+      margin-left: 30px;
+
+      & :first-child {
+        margin-left: 0;
+      }
     }
     &__links {
       *:not(first-child) {

--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -41,7 +41,7 @@
         align-items
         bg-white
         large
-        bo1111rder-bottom-gray
+        border-bottom-gray
       >
         <app-text
           class="article-list__title"

--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -172,10 +172,8 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
-      margin-left: 30px;
-
-      & :first-child {
-        margin-left: 0;
+      &:last-of-type{
+        margin-left: 30px;
       }
     }
     &__links {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -45,6 +45,7 @@
           <td class="article-trashed-table__date border-bottom">
             <app-text tag="span" small>
               {{ displayDate(item.created_at) }}
+              <!-- {{ displayDate }} -->
             </app-text>
           </td>
         </tr>
@@ -90,9 +91,14 @@ export default {
       };
     },
     displayDate() {
-      return trashedDate => {
-        const date = trashedDate.slice(0, 10); // yyyy-mm-ddのみ表示
-        return date;
+      return createDate => {
+        const trashedDate = new Date(createDate);
+
+        const year = trashedDate.getFullYear();
+        const month = `0${trashedDate.getMonth() + 1}`.slice(-2);
+        const day = `0${trashedDate.getDate()}`.slice(-2);
+
+        return `${year}-${month}-${day}`;
       };
     },
   },

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -88,9 +88,6 @@ export default {
       };
     },
   },
-  // mounted() {
-  //   console.log(this.articleTrashedList);
-  // },
 };
 </script>
 

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -50,6 +50,10 @@
         </tr>
       </transition-group>
     </table>
+
+    <div v-if="errorMessage" class="article-trashed__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
   </div>
 </template>
 
@@ -70,6 +74,10 @@ export default {
     theads: {
       type: Array,
       default: () => [],
+    },
+    errorMessage: {
+      type: String,
+      default: '',
     },
   },
   computed: {
@@ -94,6 +102,10 @@ export default {
 <style lang="scss" scoped>
 .article-trashed {
   &__button {
+    margin-top: 20px;
+  }
+
+  &__notice {
     margin-top: 20px;
   }
 }

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="article-trashed">
+    <app-heading>削除済み記事一覧</app-heading>
+    <div class="article-trashed__button">
+      <app-router-link
+        to="/articles"
+        round
+        bg-lightgreen
+        white
+        small
+      >
+        すべての記事一覧へ戻る
+      </app-router-link>
+    </div>
+
+    <table class="article-trashed-table">
+      <thead class="article-trashed-table__head">
+        <tr class="border-bottom">
+          <th v-for="(thead, index) in theads" :key="index">
+            <app-text tag="span" theme-color bold>
+              {{ thead }}
+            </app-text>
+          </th>
+        </tr>
+      </thead>
+      <transition-group
+        name="fade"
+        tag="tbody"
+        class="article-trashed-table__body"
+      >
+        <tr
+          v-for="item in articleTrashedList"
+          :key="item.id"
+        >
+          <td class="article-trashed-table__title border-bottom">
+            <app-text tag="span" small>
+              {{ displayText(item.title) }}
+            </app-text>
+          </td>
+          <td class="article-trashed-table__content border-bottom">
+            <app-text tag="span" small>
+              {{ displayText(item.content) }}
+            </app-text>
+          </td>
+          <td class="article-trashed-table__date border-bottom">
+            <app-text tag="span" small>
+              {{ displayDate(item.created_at) }}
+            </app-text>
+          </td>
+        </tr>
+      </transition-group>
+    </table>
+  </div>
+</template>
+
+<script>
+import { Heading, Text, RouterLink } from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    articleTrashedList: {
+      type: Array,
+      default: () => [],
+    },
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    displayText() {
+      return trashedText => {
+        if (trashedText.length > 30) { // 30文字以上だった場合
+          return `${trashedText.slice(0, 30)}...`; // 30文字以降は...にする
+        }
+        return trashedText; // 30文字未満の場合そのまま表示
+      };
+    },
+    displayDate() {
+      return trashedDate => {
+        const date = trashedDate.slice(0, 10); // yyyy-mm-ddのみ表示
+        return date;
+      };
+    },
+  },
+  // mounted() {
+  //   console.log(this.articleTrashedList);
+  // },
+};
+</script>
+
+<style lang="scss" scoped>
+.article-trashed {
+  &__button {
+    margin-top: 20px;
+  }
+}
+.article-trashed-table {
+  width: 100%;
+  text-align: left;
+  margin-top: 20px;
+
+  &__title {
+    width: 30%;
+  }
+
+  &__content {
+    width: 60%;
+  }
+  &__date {
+    width: 10%;
+  }
+}
+
+.border-bottom {
+  border-bottom: 1px solid #eaeaea;
+  padding: 10px 0;
+}
+
+</style>

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -45,7 +45,6 @@
           <td class="article-trashed-table__date border-bottom">
             <app-text tag="span" small>
               {{ displayDate(item.created_at) }}
-              <!-- {{ displayDate }} -->
             </app-text>
           </td>
         </tr>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -17,6 +17,7 @@ import ArticleDetail from './ArticleDetail/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
 import Pagenation from './Pagenation/index.vue';
+import ArticleTrashed from './ArticleTrashed/index.vue';
 
 export {
   SigninForm,
@@ -38,4 +39,5 @@ export {
   DeleteModal,
   Notice,
   Pagenation,
+  ArticleTrashed,
 };

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -2,6 +2,7 @@
   <app-article-trashed
     :article-trashed-list="articleTrashedList"
     :theads="theads"
+    :error-message="errorMessage"
   />
 </template>
 
@@ -20,6 +21,9 @@ export default {
   computed: {
     articleTrashedList() {
       return this.$store.state.articles.articleTrashedList;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
     },
   },
   created() {

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,32 @@
+<template>
+  <app-article-trashed
+    :article-trashed-list="articleTrashedList"
+    :theads="theads"
+  />
+</template>
+
+<script>
+import { ArticleTrashed } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashed: ArticleTrashed,
+  },
+  data() {
+    return {
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    articleTrashedList() {
+      return this.$store.state.articles.articleTrashedList;
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getArticleTrashedList');
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -31,6 +31,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-</style>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -13,6 +13,7 @@ import ArticleList from '@Pages/Articles/List.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -111,6 +112,11 @@ const router = new VueRouter({
               next();
             }
           },
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articlePost',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -272,7 +272,6 @@ export default {
         method: 'GET',
         url: '/article/trashed',
       }).then(res => {
-        // console.log(res);
         const payload = res.data.articles;
         commit('doneGetArticleTrashedList', payload);
       }).catch(err => {

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -24,6 +24,7 @@ export default {
       },
     },
     articleList: [],
+    articleTrashedList: [],
     deleteArticleId: null,
     loading: false,
     doneMessage: '',
@@ -109,6 +110,11 @@ export default {
     },
     doneDeleteArticle(state) {
       state.deleteArticleId = null;
+    },
+    doneGetArticleTrashedList(state, payload) {
+      // console.log(payload);
+      state.articleTrashedList = [...payload];
+      // console.log(state.articleTrashedList);
     },
     toggleLoading(state) {
       state.loading = !state.loading;
@@ -259,6 +265,18 @@ export default {
       }).then(() => {
         commit('doneDeleteArticle');
         commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    getArticleTrashedList({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(res => {
+        // console.log(res);
+        const payload = res.data.articles;
+        commit('doneGetArticleTrashedList', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -112,9 +112,7 @@ export default {
       state.deleteArticleId = null;
     },
     doneGetArticleTrashedList(state, payload) {
-      // console.log(payload);
       state.articleTrashedList = [...payload];
-      // console.log(state.articleTrashedList);
     },
     toggleLoading(state) {
       state.loading = !state.loading;


### PR DESCRIPTION
<!-- 各項目のコメントアウトは削除すること（このコメントアウトも削除） -->
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-758

## やったこと
削除済記事一覧ボタンをクリックしたときに削除済記事一覧ページに遷移
削除記事一覧をAPI取得して表示画面の作成
全ての記事一覧へ戻るボタンをクリックしたときに記事一覧画面に遷移

## テスト
https://gizumo.backlog.com/view/GIZFE-760

## 特にレビューをお願いしたい箇所
作成日をyyyy-mm-ddのみ表示で、sliceメソッドをつかって強引な方法でやってしまった。
特にこの作成日の文字数は変わることはないと思いましたが、他にやり方はありますでしょうか。
