### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/components/globals/Sidebar/index.vue
+++ b/src/components/globals/Sidebar/index.vue
@@ -3,7 +3,6 @@
     <app-sidebar-list
       class-name="sidebar-list"
       :target-array="routeLinksArray"
-      @clear-edited-value="clearEditedValue"
     />
   </aside>
 </template>
@@ -19,11 +18,6 @@ export default {
   computed: {
     routeLinksArray() {
       return routeLinksArray;
-    },
-  },
-  methods: {
-    clearEditedValue() {
-      this.$store.dispatch('categories/clearEditedValue');
     },
   },
 };

--- a/src/components/globals/Sidebar/index.vue
+++ b/src/components/globals/Sidebar/index.vue
@@ -3,6 +3,7 @@
     <app-sidebar-list
       class-name="sidebar-list"
       :target-array="routeLinksArray"
+      @clear-edited-value="clearEditedValue"
     />
   </aside>
 </template>
@@ -18,6 +19,11 @@ export default {
   computed: {
     routeLinksArray() {
       return routeLinksArray;
+    },
+  },
+  methods: {
+    clearEditedValue() {
+      this.$store.dispatch('categories/clearEditedValue');
     },
   },
 };

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -97,6 +97,7 @@ export default {
   },
 };
 </script>
+
 <style lang="scss" scoped>
 .category-management-edit {
   &__link {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,115 @@
+<template>
+  <form @submit.prevent="editCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      class="category-management-edit__link"
+      underline
+      small
+      hover-opacity
+      :to="`/categories`"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      name="category"
+      type="text"
+      placeholder="更新するカテゴリー名を入力してください"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="category"
+      @update-value="$emit('update-value', $event)"
+    />
+    <app-button
+      class="category-management-edit__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.create"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+<script>
+import {
+  RouterLink,
+  Heading,
+  Input,
+  Button,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appRouterLink: RouterLink,
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+  },
+  props: {
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    category: {
+      type: String,
+      default: '',
+    },
+    categoryId: {
+      type: Number,
+      default: 0,
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    editCategory() {
+      if (!this.access.edit) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('edit-category');
+      });
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.category-management-edit {
+  &__link {
+    margin-top: 16px;
+  }
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -8,7 +8,7 @@
       hover-opacity
       :to="`/categories`"
     >
-      <span @click="clearEditedValue">カテゴリー一覧へ戻る</span>
+      カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
       v-validate="'required'"
@@ -85,9 +85,6 @@ export default {
     },
   },
   methods: {
-    clearEditedValue() {
-      this.$emit('clear-edited-value');
-    },
     editCategory() {
       if (!this.access.edit) return;
       this.$validator.validate().then(valid => {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -8,7 +8,7 @@
       hover-opacity
       :to="`/categories`"
     >
-      カテゴリー一覧へ戻る
+      <span @click="clearEditedValue">カテゴリー一覧へ戻る</span>
     </app-router-link>
     <app-input
       v-validate="'required'"
@@ -38,6 +38,7 @@
     </div>
   </form>
 </template>
+
 <script>
 import {
   RouterLink,
@@ -64,10 +65,6 @@ export default {
       type: String,
       default: '',
     },
-    categoryId: {
-      type: Number,
-      default: 0,
-    },
     errorMessage: {
       type: String,
       default: '',
@@ -88,6 +85,9 @@ export default {
     },
   },
   methods: {
+    clearEditedValue() {
+      this.$emit('clear-edited-value');
+    },
     editCategory() {
       if (!this.access.edit) return;
       this.$validator.validate().then(valid => {

--- a/src/components/molecules/SidebarList/index.vue
+++ b/src/components/molecules/SidebarList/index.vue
@@ -13,7 +13,7 @@
         white
         round
       >
-        {{ item.name }}
+        <span @click="clearEditedValue">{{ item.name }}</span>
       </app-router-link>
     </app-list-item>
   </ul>
@@ -35,6 +35,11 @@ export default {
     targetArray: {
       type: Array,
       default: () => [],
+    },
+  },
+  methods: {
+    clearEditedValue() {
+      this.$emit('clear-edited-value');
     },
   },
 };

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -8,6 +8,7 @@ import UserCreate from './UserCreate/index.vue';
 import UserTable from './UserTable/index.vue';
 import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
@@ -27,6 +28,7 @@ export {
   UserTable,
   UserDetail,
   UserList,
+  CategoryEdit,
   CategoryPost,
   CategoryList,
   ArticleEdit,

--- a/src/components/pages/Articles/Edit.vue
+++ b/src/components/pages/Articles/Edit.vue
@@ -65,7 +65,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('articles/getAllArticles');
     this.$store.dispatch('articles/getArticleDetail', parseInt(this.articleId, 10));
   },
   methods: {

--- a/src/components/pages/Categories/Categories.vue
+++ b/src/components/pages/Categories/Categories.vue
@@ -63,8 +63,12 @@ export default {
   },
   created() {
     this.fetchCategories();
+    this.clearEditedValue();
   },
   methods: {
+    clearEditedValue() {
+      this.$store.dispatch('categories/clearEditedValue');
+    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,60 @@
+<template>
+  <app-category-edit
+    :access="access"
+    :category="category"
+    :category-id="categoryId"
+    :current-category-name="currentCategoryName"
+    :disabled="disabled"
+    :done-message="doneMessage"
+    :error-message="errorMessage"
+    @update-value="updateValue"
+    @edit-category="editCategory"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    category() {
+      return this.$store.state.categories.category.name;
+    },
+    categoryId() {
+      let { id } = this.$route.params;
+      id = parseInt(id, 10);
+      return id;
+    },
+    currentCategoryName() {
+      return this.$store.state.categories.category.name;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategoryDetail', parseInt(this.categoryId, 10));
+  },
+  methods: {
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event.target.value);
+    },
+    editCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/editCategory');
+    },
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -2,11 +2,10 @@
   <app-category-edit
     :access="access"
     :category="category"
-    :category-id="categoryId"
-    :current-category-name="currentCategoryName"
     :disabled="disabled"
     :done-message="doneMessage"
     :error-message="errorMessage"
+    @clear-edited-value="clearEditedValue"
     @update-value="updateValue"
     @edit-category="editCategory"
   />
@@ -27,9 +26,7 @@ export default {
       return this.$store.state.categories.category.name;
     },
     categoryId() {
-      let { id } = this.$route.params;
-      id = parseInt(id, 10);
-      return id;
+      return parseInt(this.$route.params.id, 10);
     },
     currentCategoryName() {
       return this.$store.state.categories.category.name;
@@ -45,9 +42,12 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getCategoryDetail', parseInt(this.categoryId, 10));
+    this.$store.dispatch('categories/getCategoryDetail', this.categoryId);
   },
   methods: {
+    clearEditedValue() {
+      this.$store.dispatch('categories/clearEditedValue');
+    },
     updateValue($event) {
       this.$store.dispatch('categories/updateValue', $event.target.value);
     },

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryPage from '@Pages/Categories/Categories.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -72,12 +73,20 @@ const router = new VueRouter({
       component: Profile,
     },
     {
-      name: 'categories',
       path: '/categories',
       component: Categories,
-      components: {
-        default: CategoryPage,
-      },
+      children: [
+        {
+          name: 'categoryPage',
+          path: '',
+          component: CategoryPage,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
+        },
+      ],
     },
     {
       path: '/articles',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -27,6 +27,9 @@ export default {
     clearMessage(state) {
       state.errorMessage = '';
     },
+    clearDoneMessage(state) {
+      state.doneMessage = '';
+    },
     confirmDeleteCategory(state, categoryDetail) {
       state.categoryDetail.deleteCategoryName = categoryDetail.categoryName;
       state.categoryDetail.deleteCategoryId = categoryDetail.categoryId;
@@ -66,6 +69,10 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
+    clearEditedValue({ commit }) {
+      commit('clearDoneMessage');
+      commit('initCategory');
+    },
     confirmDeleteCategory({ commit }, categoryDetail) {
       commit('confirmDeleteCategory', categoryDetail);
     },
@@ -85,7 +92,6 @@ export default {
       commit('clearMessage');
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/category'].id);
       data.append('name', rootGetters['categories/category'].name);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
@@ -99,7 +105,6 @@ export default {
           },
         };
         commit('doneEditCategory', payload);
-        commit('initCategory');
         commit('toggleLoading');
         commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
       }).catch(() => {
@@ -124,14 +129,10 @@ export default {
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then(res => {
-        const category = res.data.category
-          ? res.data.category
-          : { id: null, name: '' };
         const payload = {
           category: {
             id: res.data.category.id,
             name: res.data.category.name,
-            category,
           },
         };
         commit('doneGetCategory', payload);


### PR DESCRIPTION
<!-- 各項目のコメントアウトは削除すること（このコメントアウトも削除） -->
## チケットのリンク
<!-- Backlogの親チケットのリンクを記載 -->

## やったこと
<!-- このPRで行ったことをリスト形式で記載 -->
カテゴリー更新機能を追加
・更新画面の作成
・一覧の更新ボタンで更新画面へ遷移します
・更新画面の更新ボタンで更新されたカテゴリー名が一覧に表示されます
・「カテゴリー一覧に戻る」リンクで一覧画面に遷移します
・上記アクション失敗時にエラーが表示されます

## やらないこと
<!-- このPRのスコープ外とする項目があれば記載。なければ「なし」と記載 -->

## テスト
<!-- Backlogのテストチケットのリンクを記載 -->
https://gizumo.backlog.com/view/GIZFE-751

## 特にレビューをお願いしたい箇所
<!--
「完成はしたけど冗長になってしまった」
「もっと良い書き方がある気がする」 
など特に重点的に見て欲しい箇所、アドバイスが欲しい箇所があれば記載。
なければ「なし」と記載
-->
前回いただいたask「categoryはなぜ必要だったか」ですが、正直よくわかっておりません。categoryのidとnameをそれぞれ空にスイッチするための三項演算子だと思うのですが、削除してみたところ機能実装に不要なものとだけわかりました。
あの記述はArticlesにおいてどのような機能を果たすのでしょうか。