### PR TITLE
カテゴリ一新規作成機能実装

### DIFF
--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -42,9 +42,6 @@ export default {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
-    loading() {
-      return this.$store.state.categories.loading;
-    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
@@ -64,7 +61,6 @@ export default {
       this.category = $event.target.value;
     },
     handleSubmit() {
-      if (this.loading) return;
       this.$store.dispatch('categories/createCategory', this.category).then(() => {
         this.$store.dispatch('categories/getAllCategories');
         this.category = '';

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -42,6 +42,9 @@ export default {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
@@ -61,6 +64,7 @@ export default {
       this.category = $event.target.value;
     },
     handleSubmit() {
+      if (this.loading) return;
       this.$store.dispatch('categories/createCategory', this.category).then(() => {
         this.$store.dispatch('categories/getAllCategories');
         this.category = '';

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -65,6 +65,7 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/createCategory', this.category);
+      this.$store.dispatch('categories/getAllCategories');
     },
   },
 };

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -23,7 +23,7 @@
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
-/* eslint-disable no-console */
+
 export default {
   components: {
     appCategoryPost: CategoryPost,

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -5,6 +5,9 @@
         :error-message="errorMessage"
         :category="category"
         :access="access"
+        @clear-message="clearMessage"
+        @update-value="updateValue"
+        @handle-submit="handleSubmit"
       />
     </div>
     <div class="category-content__list">
@@ -38,14 +41,27 @@ export default {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
   },
-  method: {
-  },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue($event) {
+      this.category = $event.target.value;
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/createCategory', this.category);
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -3,6 +3,7 @@
     <div class="category-content__post">
       <app-category-post
         :error-message="errorMessage"
+        :done-message="doneMessage"
         :category="category"
         :access="access"
         @clear-message="clearMessage"
@@ -46,6 +47,9 @@ export default {
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
     },
   },
   created() {

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -23,7 +23,7 @@
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
-
+/* eslint-disable no-console */
 export default {
   components: {
     appCategoryPost: CategoryPost,
@@ -53,6 +53,7 @@ export default {
     },
   },
   created() {
+    this.$store.dispatch('categories/clearMessage');
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
@@ -64,8 +65,10 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/createCategory', this.category);
-      this.$store.dispatch('categories/getAllCategories');
+      this.$store.dispatch('categories/createCategory', this.category).then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+        this.category = '';
+      });
     },
   },
 };

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -75,7 +75,7 @@ const router = new VueRouter({
       component: Categories,
       children: [
         {
-          name: 'CategoriesManagement',
+          name: 'categoriesManagement',
           path: '',
           component: CategoriesManagement,
         },

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -75,7 +75,7 @@ const router = new VueRouter({
       component: Categories,
       children: [
         {
-          name: CategoriesManagement,
+          name: 'CategoriesManagement',
           path: '',
           component: CategoriesManagement,
         },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,8 +5,17 @@ export default {
   state: {
     categoryList: [],
     errorMessage: '',
+    doneMessage: '',
+    loading: false,
   },
   mutations: {
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
@@ -16,6 +25,9 @@ export default {
     },
   },
   actions: {
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -27,6 +39,20 @@ export default {
         commit('doneGetAllCategories', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    createCategory({ commit, rootGetters }, categoryValue) {
+      return new Promise(resolve => {
+        commit('toggleLoading');
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data: { name: categoryValue },
+        }).then(() => {
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.response.data.message });
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,7 +20,7 @@ export default {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
     },
-    createCategory(state) {
+    setCreatedDoneMessage(state) {
       state.doneMessage = '新規カテゴリーを作成しました。';
     },
     failRequest(state, { message }) {
@@ -44,15 +44,15 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    createCategory({ commit, rootGetters }, categoryValue) {
+    createCategory({ commit, rootGetters }, name) {
       return new Promise(resolve => {
         commit('toggleLoading');
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
-          data: { name: categoryValue },
+          data: { name },
         }).then(() => {
-          commit('createCategory');
+          commit('setCreatedDoneMessage');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.response.data.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -6,15 +6,11 @@ export default {
     categoryList: [],
     errorMessage: '',
     doneMessage: '',
-    loading: false,
   },
   mutations: {
     clearMessage(state) {
       state.errorMessage = '';
       state.doneMessage = '';
-    },
-    toggleLoading(state) {
-      state.loading = !state.loading;
     },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
@@ -46,7 +42,6 @@ export default {
     },
     createCategory({ commit, rootGetters }, name) {
       return new Promise(resolve => {
-        commit('toggleLoading');
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,6 +20,9 @@ export default {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
     },
+    createCategory(state) {
+      state.doneMessage = '新規カテゴリーを作成しました。';
+    },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
@@ -49,6 +52,7 @@ export default {
           url: '/category',
           data: { name: categoryValue },
         }).then(() => {
+          commit('createCategory');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.response.data.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,6 +4,7 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
+    loading: false,
     errorMessage: '',
     doneMessage: '',
   },
@@ -12,14 +13,19 @@ export default {
       state.errorMessage = '';
       state.doneMessage = '';
     },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
     },
     setCreatedDoneMessage(state) {
+      state.loading = false;
       state.doneMessage = '新規カテゴリーを作成しました。';
     },
     failRequest(state, { message }) {
+      state.loading = false;
       state.errorMessage = message;
     },
   },
@@ -42,6 +48,7 @@ export default {
     },
     createCategory({ commit, rootGetters }, name) {
       return new Promise(resolve => {
+        commit('toggleLoading');
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-773

## やったこと
- 作成ボタンがクリックされたら、新規作成APIを実行
- 成功時、一覧画面が更新され作成メッセージを表示及び入力フォームの初期化
- 追加カテゴリーを一覧の一番上に表示
- 完了メッセージが出ているときに別のページに遷移し、再度カテゴリー管理画面に戻ってきたときに作成完了メッセージをなくす

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-775

## 特にレビューをお願いしたい箇所
なし
