### PR TITLE
カテゴリ一削除機能実装

### DIFF
--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -92,6 +92,7 @@ export default {
       this.$store.dispatch('categories/confirmDeleteCategory', this.deleteCategory);
     },
     handleClick() {
+      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategory.id });
       this.toggleModal();
     },
   },

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -18,6 +18,7 @@
         :delete-category-name="deleteCategoryName"
         :access="access"
         @open-modal="openModal"
+        @handle-click="handleClick"
       />
     </div>
   </section>
@@ -89,6 +90,9 @@ export default {
       };
       this.$store.dispatch('categories/clearMessage');
       this.$store.dispatch('categories/confirmDeleteCategory', this.deleteCategory);
+    },
+    handleClick() {
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -15,6 +15,7 @@
       <app-category-list
         :categories="categoryList"
         :theads="theads"
+        :delete-category-name="deleteCategoryName"
         :access="access"
         @open-modal="openModal"
       />
@@ -36,6 +37,10 @@ export default {
     return {
       category: '',
       theads: ['カテゴリー名'],
+      deleteCategory: {
+        id: null,
+        name: '',
+      },
     };
   },
   computed: {
@@ -53,6 +58,9 @@ export default {
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
+    },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
     },
   },
   created() {
@@ -73,8 +81,14 @@ export default {
         this.category = '';
       });
     },
-    openModal() {
+    openModal(categoryId, categoryName) {
       this.toggleModal();
+      this.deleteCategory = {
+        id: categoryId,
+        name: categoryName,
+      };
+      this.$store.dispatch('categories/clearMessage');
+      this.$store.dispatch('categories/confirmDeleteCategory', this.deleteCategory);
     },
   },
 };

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -61,7 +61,7 @@ export default {
       return this.$store.state.categories.doneMessage;
     },
     deleteCategoryName() {
-      return this.$store.state.categories.deleteCategoryName;
+      return this.$store.state.categories.deleteCategory.name;
     },
   },
   created() {

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -16,6 +16,7 @@
         :categories="categoryList"
         :theads="theads"
         :access="access"
+        @open-modal="openModal"
       />
     </div>
   </section>
@@ -23,12 +24,14 @@
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
   data() {
     return {
       category: '',
@@ -69,6 +72,9 @@ export default {
         this.$store.dispatch('categories/getAllCategories');
         this.category = '';
       });
+    },
+    openModal() {
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -92,7 +92,10 @@ export default {
       this.$store.dispatch('categories/confirmDeleteCategory', this.deleteCategory);
     },
     handleClick() {
-      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategory.id });
+      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategory.id })
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
       this.toggleModal();
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -30,6 +30,11 @@ export default {
       state.deleteCategoryId = deleteCategory.id;
       state.deleteCategoryName = deleteCategory.name;
     },
+    deleteCategory(state) {
+      state.loading = false;
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
+    },
     failRequest(state, { message }) {
       state.loading = false;
       state.errorMessage = message;
@@ -69,6 +74,22 @@ export default {
     },
     confirmDeleteCategory({ commit }, deleteCategory) {
       commit('confirmDeleteCategory', { deleteCategory });
+    },
+    deleteCategory({ commit, rootGetters }, { id }) {
+      return new Promise(resolve => {
+        commit('toggleLoading');
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${id}`,
+        }).then(response => {
+          if (response.data.code === 0) throw new Error(response.data.message);
+
+          commit('deleteCategory');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
+      });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -34,6 +34,7 @@ export default {
       state.loading = false;
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
+      state.doneMessage = 'カテゴリーの削除が完了しました。';
     },
     failRequest(state, { message }) {
       state.loading = false;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,8 @@ export default {
     loading: false,
     errorMessage: '',
     doneMessage: '',
+    deleteCategoryId: null,
+    deleteCategoryName: '',
   },
   mutations: {
     clearMessage(state) {
@@ -23,6 +25,10 @@ export default {
     setCreatedDoneMessage(state) {
       state.loading = false;
       state.doneMessage = '新規カテゴリーを作成しました。';
+    },
+    confirmDeleteCategory(state, { deleteCategory }) {
+      state.deleteCategoryId = deleteCategory.id;
+      state.deleteCategoryName = deleteCategory.name;
     },
     failRequest(state, { message }) {
       state.loading = false;
@@ -60,6 +66,9 @@ export default {
           commit('failRequest', { message: err.response.data.message });
         });
       });
+    },
+    confirmDeleteCategory({ commit }, deleteCategory) {
+      commit('confirmDeleteCategory', { deleteCategory });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,8 +7,10 @@ export default {
     loading: false,
     errorMessage: '',
     doneMessage: '',
-    deleteCategoryId: null,
-    deleteCategoryName: '',
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -27,13 +29,13 @@ export default {
       state.doneMessage = '新規カテゴリーを作成しました。';
     },
     confirmDeleteCategory(state, { deleteCategory }) {
-      state.deleteCategoryId = deleteCategory.id;
-      state.deleteCategoryName = deleteCategory.name;
+      state.deleteCategory.id = deleteCategory.id;
+      state.deleteCategory.name = deleteCategory.name;
     },
     deleteCategory(state) {
       state.loading = false;
-      state.deleteCategoryId = null;
-      state.deleteCategoryName = '';
+      state.deleteCategory.id = null;
+      state.deleteCategory.name = '';
       state.doneMessage = 'カテゴリーの削除が完了しました。';
     },
     failRequest(state, { message }) {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-790

## やったこと
- 削除ボタンをクリック後、削除確認用モーダルを表示
- 削除確認用モーダル内に削除対象のカテゴリ名及び削除ボタンを表示
- 削除確認用モーダル内の削除ボタンをクリック後、削除APIの実行及びモーダルが閉じる
- 削除成功時、カテゴリー一覧画面更新及び削除完了メッセージの表示

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-792

## 特にレビューをお願いしたい箇所
なし
