### PR TITLE
カテゴリー管理画面作成

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -13,13 +13,9 @@
           </th>
         </tr>
       </thead>
-      <transition-group
-        name="fade"
-        tag="tbody"
-        class="category-list__table__body"
-      >
+      <transition-group name="fade" tag="tbody" class="category-list__table__body">
         <tr
-          v-for="category in targetArray"
+          v-for="category in categories"
           :key="category.id"
         >
           <td>
@@ -109,10 +105,6 @@ export default {
       default() {
         return [];
       },
-    },
-    targetArray: {
-      type: Array,
-      default: () => [],
     },
     categories: {
       type: Array,

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -13,8 +13,15 @@
           </th>
         </tr>
       </thead>
-      <transition-group name="fade" tag="tbody" class="category-list__table__body">
-        <tr v-for="category in categories" :key="category.id">
+      <transition-group
+        name="fade"
+        tag="tbody"
+        class="category-list__table__body"
+      >
+        <tr
+          v-for="category in targetArray"
+          :key="category.id"
+        >
           <td>
             <app-text tag="span">
               {{ category.name }}
@@ -85,7 +92,9 @@
 
 <script>
 import {
-  RouterLink, Button, Text,
+  RouterLink,
+  Button,
+  Text,
 } from '@Components/atoms';
 
 export default {
@@ -100,6 +109,10 @@ export default {
       default() {
         return [];
       },
+    },
+    targetArray: {
+      type: Array,
+      default: () => [],
     },
     categories: {
       type: Array,

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -6,7 +6,7 @@
       :access="access"
     />
     <app-category-list
-      :target-array="categoryList"
+      :categories="categoryList"
       :theads="theads"
       :access="access"
     />
@@ -25,7 +25,7 @@ export default {
   mixins: [Mixins],
   data() {
     return {
-      theads: ['カテゴリー名', '', '', ''],
+      theads: ['カテゴリー名'],
     };
   },
   computed: {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="category">
+    <app-category-post
+      class="category-post"
+      category=""
+      :access="access"
+    />
+    <app-category-list
+      :target-array="categoryList"
+      :theads="theads"
+      :access="access"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appCategoryList: CategoryList,
+    appCategoryPost: CategoryPost,
+  },
+  mixins: [Mixins],
+  data() {
+    return {
+      theads: ['カテゴリー名', '', '', ''],
+    };
+  },
+  computed: {
+    categoryList() {
+      return this.$store.state.categories.categoryList;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    this.fetchCategories();
+  },
+  methods: {
+    fetchCategories() {
+      this.$store.dispatch('categories/getAllCategories');
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category {
+  display: flex;
+  &-post{
+    height: 100%;
+    width: 40%;
+    padding-right: 20px;
+  }
+  &-list{
+    height: 100%;
+    width: 60%;
+    border-left: 1px solid $separator-color;
+    padding-left: 10px;
+  }
+  &__table{
+    margin-top: 20px;
+  }
+}
+</style>

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -5,6 +5,11 @@ export default [
     path: '/',
   },
   {
+    id: 2,
+    name: 'カテゴリー',
+    path: '/categories',
+  },
+  {
     id: 3,
     name: '記事',
     path: '/articles',

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -7,6 +7,9 @@ import Signout from '@Pages/Signout/index.vue';
 import NotFound from '@Pages/NotFound/index.vue';
 import Home from '@Pages/Home/index.vue';
 
+import Categories from '@Pages/Categories/index.vue';
+import CategoryList from '@Pages/Categories/List.vue';
+
 // 記事
 import Articles from '@Pages/Articles/index.vue';
 import ArticleList from '@Pages/Articles/List.vue';
@@ -66,6 +69,17 @@ const router = new VueRouter({
       name: 'profile',
       path: '/profile',
       component: Profile,
+    },
+    {
+      path: '/categories',
+      component: Categories,
+      children: [
+        {
+          name: 'categoryList',
+          path: '',
+          component: CategoryList,
+        },
+      ],
     },
     {
       path: '/articles',

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import {
-  auth, articles, users,
+  auth, articles, users, categories,
 } from './modules';
 
 Vue.use(Vuex);
@@ -11,5 +11,6 @@ export default new Vuex.Store({
     auth,
     articles,
     users,
+    categories,
   },
 });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -1,0 +1,86 @@
+import axios from '@Helpers/axiosDefault';
+
+export default {
+  namespaced: true,
+  state: {
+    targetCategory: {
+      id: null,
+      name: '',
+      category: {
+        id: null,
+        name: '',
+      },
+      user: {
+        account_name: '',
+        created_at: '',
+        email: '',
+        full_name: '',
+        id: '',
+        password_reset_flg: null,
+        role: '',
+        update_at: '',
+      },
+    },
+    categoryList: [],
+    deleteCategoryId: null,
+    loading: false,
+    doneMessage: '',
+    errorMessage: '',
+  },
+  getters: {
+    transformedCategories(state) {
+      return state.categoryList.map(category => ({
+        id: category.id,
+        content: `${category.title}`,
+      }));
+    },
+    targetCategory: state => state.targetCategory,
+    deleteCategoryId: state => state.deleteCategoryId,
+  },
+  mutations: {
+    initPostCategory(state) {
+      state.targetCategory = {
+        id: null,
+        name: '',
+        category: {
+          id: null,
+          name: '',
+        },
+        user: {
+          account_name: '',
+          created_at: '',
+          email: '',
+          full_name: '',
+          id: '',
+          password_reset_flg: null,
+          role: '',
+          update_at: '',
+        },
+      };
+    },
+    doneGetAllCategories(state, payload) {
+      state.categoryList = [...payload.categories];
+    },
+    failRequest(state, { message }) {
+      state.errorMessage = message;
+    },
+  },
+  actions: {
+    initPostCategory({ commit }) {
+      commit('initPostCategory');
+    },
+    getAllCategories({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then(response => {
+        const payload = {
+          categories: response.data.categories.reverse(),
+        };
+        commit('doneGetAllCategories', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+  },
+};

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,21 +10,9 @@ export default {
         id: null,
         name: '',
       },
-      user: {
-        account_name: '',
-        created_at: '',
-        email: '',
-        full_name: '',
-        id: '',
-        password_reset_flg: null,
-        role: '',
-        update_at: '',
-      },
     },
     categoryList: [],
-    deleteCategoryId: null,
     loading: false,
-    doneMessage: '',
     errorMessage: '',
   },
   getters: {
@@ -35,7 +23,6 @@ export default {
       }));
     },
     targetCategory: state => state.targetCategory,
-    deleteCategoryId: state => state.deleteCategoryId,
   },
   mutations: {
     initPostCategory(state) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -33,16 +33,6 @@ export default {
           id: null,
           name: '',
         },
-        user: {
-          account_name: '',
-          created_at: '',
-          email: '',
-          full_name: '',
-          id: '',
-          password_reset_flg: null,
-          role: '',
-          update_at: '',
-        },
       };
     },
     doneGetAllCategories(state, payload) {

--- a/src/js/_store/modules/index.js
+++ b/src/js/_store/modules/index.js
@@ -1,9 +1,11 @@
 import articles from './articles';
 import auth from './auth';
 import users from './users';
+import categories from './categories';
 
 export {
   articles,
   auth,
   users,
+  categories,
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-730

## やったこと
・サイドバーにカテゴリータブを追加
・カテゴリー管理画面ページを表示
・「カテゴリー管理」というタイトルの表示
・API通信でカテゴリー一覧を取得
・一覧の昇順表示を降順に変更
・「カテゴリー名」という見出しの表示
・作成フォームと一覧を左右分割されるように表示
・中央線の追加
・フォーム画面と一覧の間の余白の追加

## やらないこと
・「作成」「この記事の詳細」「更新」「削除」ボタンを押した際の実装

## テスト
https://gizumo.backlog.com/view/GIZFE-732

## 特にレビューをお願いしたい箇所
完成はしたが、余分な記述がないか。
コードの書き方が見にくくなっていないか。
