### PR TITLE
カテゴリ一更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -4,6 +4,7 @@
     <app-router-link
       underline
       hover-opacity
+      :to="'/categories'"
       class="category-edit__back-link"
     >
       カテゴリー一覧へ戻る
@@ -40,7 +41,7 @@
 
 <script>
 import {
-  Heading, RouterLink, Input, Button,
+  Heading, RouterLink, Input, Button, Text,
 } from '@Components/atoms';
 
 export default {
@@ -49,6 +50,7 @@ export default {
     appRouterLink: RouterLink,
     appInput: Input,
     appButton: Button,
+    appText: Text,
   },
   props: {
     loading: {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -16,9 +16,9 @@
       placeholder="追加するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
-      :value="category"
+      :value="editCategoryName"
       class="category-edit__form"
-      @update-value="$emit('update-value', $event)"
+      @update-value="$emit('edited-category-name', $event)"
     />
     <app-button
       class="category-edit__submit"
@@ -53,6 +53,18 @@ export default {
     appText: Text,
   },
   props: {
+    editCategoryName: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
     loading: {
       type: Boolean,
       default: false,

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -16,9 +16,9 @@
       placeholder="追加するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
-      :value="editCategoryName"
+      :value="editCategory.name"
       class="category-edit__form"
-      @update-value="$emit('edited-category-name', $event)"
+      @update-value="$emit('edited-name', $event)"
     />
     <app-button
       class="category-edit__submit"
@@ -53,9 +53,9 @@ export default {
     appText: Text,
   },
   props: {
-    editCategoryName: {
-      type: String,
-      default: '',
+    editCategory: {
+      type: Object,
+      default: () => ({}),
     },
     errorMessage: {
       type: String,
@@ -84,8 +84,12 @@ export default {
     },
   },
   methods: {
+    updateValue($event) {
+      this.$emit('update-value', $event.target);
+    },
     handleSubmit() {
       if (!this.access.edit) return;
+      this.$emit('clear-message');
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('handle-submit');
       });

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="category-edit">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      underline
+      hover-opacity
+      class="category-edit__back-link"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      name="category"
+      type="text"
+      placeholder="追加するカテゴリー名を入力してください"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="category"
+      class="category-edit__form"
+      @update-value="$emit('update-value', $event)"
+    />
+    <app-button
+      class="category-edit__submit"
+      button-type="submit"
+      round
+      :disabled="!disabled"
+      @click="handleSubmit"
+    >
+      {{ buttonText }}
+    </app-button>
+    <div v-if="errorMessage" class="category-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  Heading, RouterLink, Input, Button,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+    appInput: Input,
+    appButton: Button,
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  .category-edit {
+    &__back-link {
+      margin-top: 16px;
+    }
+    &__form {
+      margin-top: 20px;
+    }
+    &__submit {
+      margin-top: 16px;
+    }
+    &__notice {
+      margin-top: 16px;
+    }
+  }
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -16,7 +16,7 @@
       placeholder="追加するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
-      :value="editCategory.name"
+      :value="targetCategory.name"
       class="category-edit__form"
       @update-value="$emit('editing-name', $event)"
     />
@@ -53,7 +53,7 @@ export default {
     appText: Text,
   },
   props: {
-    editCategory: {
+    targetCategory: {
       type: Object,
       default: () => ({}),
     },

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -71,6 +71,14 @@ export default {
       return this.access.edit && !this.loading;
     },
   },
+  methods: {
+    handleSubmit() {
+      if (!this.access.edit) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
 };
 </script>
 

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -18,7 +18,7 @@
       :error-messages="errors.collect('category')"
       :value="editCategory.name"
       class="category-edit__form"
-      @update-value="$emit('edited-name', $event)"
+      @update-value="$emit('editing-name', $event)"
     />
     <app-button
       class="category-edit__submit"

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -25,6 +25,11 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    targetId() {
+      let { id } = this.$route.params;
+      id = parseInt(id, 10);
+      return id;
+    },
     targetCategory() {
       return this.$store.state.categories.targetCategory;
     },
@@ -36,8 +41,7 @@ export default {
     },
   },
   created() {
-    const { id } = this.$route.params;
-    this.$store.dispatch('categories/getCategory', { id });
+    this.$store.dispatch('categories/getCategory', this.targetId);
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -6,7 +6,7 @@
     :loading="loading"
     :access="access"
     @clear-message="clearMessage"
-    @edited-name="editedName"
+    @editing-name="editingName"
     @handle-submit="handleSubmit"
   />
 </template>
@@ -44,8 +44,8 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    editedName($event) {
-      this.$store.dispatch('categories/editedName', $event.target.value);
+    editingName($event) {
+      this.$store.dispatch('categories/editingName', $event.target.value);
     },
     handleSubmit() {
       if (this.loading) return;

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,5 +1,8 @@
 <template>
   <app-category-edit
+    :error-message="errorMessage"
+    :done-message="doneMessage"
+    :edit-category-name="editCategoryName"
     :loading="loading"
     :access="access"
   />
@@ -12,13 +15,33 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
+  data() {
+    return {
+      name: '',
+    };
+  },
   computed: {
-    loading() {
-      return this.$store.state.categories.loading;
-    },
     access() {
       return this.$store.getters['auth/access'];
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    editCategoryName() {
+      const { name } = this.$store.state.categories.editCategory;
+      return name;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategory', { id });
+    this.$store.dispatch('categories/clearMessage');
   },
 };
 </script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -2,7 +2,7 @@
   <app-category-edit
     :error-message="errorMessage"
     :done-message="doneMessage"
-    :edit-category="editCategory"
+    :target-category="targetCategory"
     :loading="loading"
     :access="access"
     @clear-message="clearMessage"
@@ -25,8 +25,8 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
-    editCategory() {
-      return this.$store.state.categories.editCategory;
+    targetCategory() {
+      return this.$store.state.categories.targetCategory;
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
@@ -50,9 +50,9 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/updateCategory', {
-        id: this.editCategory.id,
+        id: this.targetCategory.id,
         /* eslint-disable-next-line no-irregular-whitespace */
-        name: this.editCategory.name.replace(/(　)+/, ' ').trim(),
+        name: this.targetCategory.name.replace(/(　)+/, ' ').trim(),
       });
     },
   },

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>カテゴリー更新画面（仮）</div>
+</template>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,3 +1,24 @@
 <template>
-  <div>カテゴリー更新画面（仮）</div>
+  <app-category-edit
+    :loading="loading"
+    :access="access"
+  />
 </template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -2,9 +2,12 @@
   <app-category-edit
     :error-message="errorMessage"
     :done-message="doneMessage"
-    :edit-category-name="editCategoryName"
+    :edit-category="editCategory"
     :loading="loading"
     :access="access"
+    @clear-message="clearMessage"
+    @edited-name="editedName"
+    @handle-submit="handleSubmit"
   />
 </template>
 
@@ -15,11 +18,6 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
-  data() {
-    return {
-      name: '',
-    };
-  },
   computed: {
     access() {
       return this.$store.getters['auth/access'];
@@ -27,9 +25,8 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
-    editCategoryName() {
-      const { name } = this.$store.state.categories.editCategory;
-      return name;
+    editCategory() {
+      return this.$store.state.categories.editCategory;
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
@@ -42,6 +39,22 @@ export default {
     const { id } = this.$route.params;
     this.$store.dispatch('categories/getCategory', { id });
     this.$store.dispatch('categories/clearMessage');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    editedName($event) {
+      this.$store.dispatch('categories/editedName', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory', {
+        id: this.editCategory.id,
+        /* eslint-disable-next-line no-irregular-whitespace */
+        name: this.editCategory.name.replace(/(　)+/, ' ').trim(),
+      });
+    },
   },
 };
 </script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoriesManagement from '@Pages/Categories/Management.vue';
+import CategoriesEdit from '@Pages/Categories/Edit.vue';
 // 記事
 import Articles from '@Pages/Articles/index.vue';
 import ArticleList from '@Pages/Articles/List.vue';
@@ -78,6 +79,11 @@ const router = new VueRouter({
           name: 'categoriesManagement',
           path: '',
           component: CategoriesManagement,
+        },
+        {
+          name: 'categoriesEdit',
+          path: ':id',
+          component: CategoriesEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,7 +11,7 @@ export default {
       id: null,
       name: '',
     },
-    editCategory: {
+    targetCategory: {
       id: null,
       name: '',
     },
@@ -29,7 +29,7 @@ export default {
       state.categoryList = state.categoryList.reverse();
     },
     doneGetCategory(state, payload) {
-      state.editCategory = { ...state.editCategory, ...payload };
+      state.targetCategory = { ...state.targetCategory, ...payload };
       state.loading = false;
     },
     setCreatedDoneMessage(state) {
@@ -37,11 +37,11 @@ export default {
       state.doneMessage = '新規カテゴリーを作成しました。';
     },
     editingName(state, payload) {
-      state.editCategory = { ...state.editCategory, name: payload.name };
+      state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
     updateCategory(state, { category }) {
       state.loading = false;
-      state.editCategory = { ...state.editCategory, ...category };
+      state.targetCategory = { ...state.targetCategory, ...category };
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
     confirmDeleteCategory(state, { deleteCategory }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -36,6 +36,14 @@ export default {
       state.loading = false;
       state.doneMessage = '新規カテゴリーを作成しました。';
     },
+    editedName(state, payload) {
+      state.editCategory = { ...state.editCategory, name: payload.name };
+    },
+    updateCategory(state, { category }) {
+      state.loading = false;
+      state.editCategory = { ...state.editCategory, ...category };
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
     confirmDeleteCategory(state, { deleteCategory }) {
       state.deleteCategory.id = deleteCategory.id;
       state.deleteCategory.name = deleteCategory.name;
@@ -97,6 +105,32 @@ export default {
         }).catch(err => {
           commit('failRequest', { message: err.response.data.message });
         });
+      });
+    },
+    editedName({ commit }, name) {
+      commit({
+        type: 'editedName',
+        name,
+      });
+    },
+    updateCategory({ commit, rootGetters }, category) {
+      commit('toggleLoading');
+
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${category.id}`,
+        data: category,
+      }).then(response => {
+        if (response.data.code === 0) throw new Error(response.data.message);
+
+        const editedCategory = {
+          id: response.data.category.id,
+          name: response.data.category.name,
+        };
+
+        commit('updateCategory', { editedCategory });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
     confirmDeleteCategory({ commit }, deleteCategory) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,6 +11,10 @@ export default {
       id: null,
       name: '',
     },
+    editCategory: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -23,6 +27,10 @@ export default {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
       state.categoryList = state.categoryList.reverse();
+    },
+    doneGetCategory(state, payload) {
+      state.editCategory = { ...state.editCategory, ...payload };
+      state.loading = false;
     },
     setCreatedDoneMessage(state) {
       state.loading = false;
@@ -56,6 +64,22 @@ export default {
           categories: res.data.categories,
         };
         commit('doneGetAllCategories', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    getCategory({ commit, rootGetters }, { id }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then(res => {
+        if (res.data.code === 0) throw new Error(res.data.message);
+        const data = res.data.category;
+        const payload = {
+          id: data.id,
+          name: data.name,
+        };
+        commit('doneGetCategory', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -36,7 +36,7 @@ export default {
       state.loading = false;
       state.doneMessage = '新規カテゴリーを作成しました。';
     },
-    editedName(state, payload) {
+    editingName(state, payload) {
       state.editCategory = { ...state.editCategory, name: payload.name };
     },
     updateCategory(state, { category }) {
@@ -107,9 +107,9 @@ export default {
         });
       });
     },
-    editedName({ commit }, name) {
+    editingName({ commit }, name) {
       commit({
-        type: 'editedName',
+        type: 'editingName',
         name,
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -76,10 +76,10 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    getCategory({ commit, rootGetters }, { id }) {
+    getCategory({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
-        url: `/category/${id}`,
+        url: `/category/${categoryId}`,
       }).then(res => {
         if (res.data.code === 0) throw new Error(res.data.message);
         const data = res.data.category;


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-796

## やったこと
- カテゴリー更新画面作成
- 管理画面の更新ボタンをクリック後、対象のカテゴリー更新画面へ遷移
- カテゴリー一覧へ戻るボタンをクリックしたら、管理画面へ遷移
- 入力フォームの初期表示に対象のカテゴリー名を表示
- 未記入の状態で更新ボタンをクリックしたら、バリデーションエラーのメッセージを表示
- 更新ボタンをクリックしてAPI通信中のとき、更新ボタンが非活性の状態になる
- 更新成功時、カテゴリー名が更新され完了メッセージを表示
- API通信失敗時、エラーメッセージを表示

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-798

## 特にレビューをお願いしたい箇所
なし
