### PR TITLE
カテゴリー新規作成機能実装 812

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -155,7 +155,6 @@ export default {
       td {
         padding: 10px;
         vertical-align: middle;
-        //white-space: nowrap;
         &.is-disabled {
           color: $disabled-color;
           font-size: 12px;

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -155,6 +155,7 @@ export default {
       td {
         padding: 10px;
         vertical-align: middle;
+        //white-space: nowrap;
         &.is-disabled {
           color: $disabled-color;
           font-size: 12px;

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -9,7 +9,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="category"
-      @update-value="$emit('update-value', $event)"
+      @update-value="$emit('update-value', $event.target)"
     />
     <app-button
       class="category-management-post__submit"
@@ -70,6 +70,9 @@ export default {
     },
   },
   methods: {
+    updateValue($event) {
+      this.$emit('update-value', $event.target);
+    },
     addCategory() {
       if (!this.access.create) return;
       this.$emit('clear-message');

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -70,9 +70,6 @@ export default {
     },
   },
   methods: {
-    updateValue($event) {
-      this.$emit('update-value', $event.target);
-    },
     addCategory() {
       if (!this.access.create) return;
       this.$emit('clear-message');

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,8 +2,15 @@
   <div class="category">
     <app-category-post
       class="category-post"
-      category=""
+      :category="category"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
       :access="access"
+      :disabled="loading ? true : false"
+      :button-text="buttonText"
+      @handle-submit="addCategory"
+      @clear-message="clearMessage"
+      @update-value="updateValue"
     />
     <app-category-list
       :categories="categoryList"
@@ -26,22 +33,48 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      category: '',
     };
   },
   computed: {
+    loading() {
+      return this.$store.state.categories.loading;
+    },
     categoryList() {
       return this.$store.state.categories.categoryList;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    buttonText() {
+      return this.disabled ? '作成中...' : '作成';
     },
     access() {
       return this.$store.getters['auth/access'];
     },
   },
   created() {
-    this.fetchCategories();
+    this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
-    fetchCategories() {
-      this.$store.dispatch('categories/getAllCategories');
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue(target) {
+      this.category = target.value;
+    },
+    addCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/addCategory', {
+        category: this.category,
+      });
+      this.category = '';
+    },
+    editCategory() {
+      this.$store.dispatch('categories/editCategory');
     },
   },
 };
@@ -52,14 +85,14 @@ export default {
   display: flex;
   &-post{
     height: 100%;
-    width: 40%;
+    width: 30%;
     padding-right: 20px;
   }
   &-list{
     height: 100%;
-    width: 60%;
+    width: 70%;
     border-left: 1px solid $separator-color;
-    padding-left: 10px;
+    padding-left: 20px;
   }
   &__table{
     margin-top: 20px;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -73,9 +73,6 @@ export default {
       });
       this.category = '';
     },
-    editCategory() {
-      this.$store.dispatch('categories/editCategory');
-    },
   },
 };
 </script>

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -48,19 +48,9 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
-      state.loading = false;
     },
     doneAddCategory(state) {
-      state.loading = false;
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
-    },
-    doneEditCategory(state, { category }) {
-      state.targetCategory = { ...state.category, ...category };
-      state.loading = false;
-      state.doneMessage = 'カテゴリーの更新が完了しました。';
-    },
-    applyRequest(state) {
-      state.loading = false;
     },
     toggleLoading(state) {
       state.loading = !state.loading;
@@ -90,7 +80,6 @@ export default {
       });
     },
     addCategory({ commit, rootGetters, dispatch }, category) {
-      commit('applyRequest');
       commit('toggleLoading');
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
@@ -100,10 +89,12 @@ export default {
         }).then(response => {
           if (response.data.code === 0) throw new Error(response.data.message);
           dispatch('getAllCategories');
+          commit('toggleLoading');
           commit('doneAddCategory');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.response.data.message });
+          commit('toggleLoading');
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,6 +3,7 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    doneMessage: '',
     targetCategory: {
       id: null,
       name: '',
@@ -25,6 +26,10 @@ export default {
     targetCategory: state => state.targetCategory,
   },
   mutations: {
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
     initPostCategory(state) {
       state.targetCategory = {
         id: null,
@@ -35,16 +40,38 @@ export default {
         },
       };
     },
+    updateValue(state, { category, value }) {
+      state.category = { ...state.category, [category]: value };
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+      state.loading = false;
+    },
+    doneAddCategory(state) {
+      state.loading = false;
+      state.doneMessage = '新規カテゴリーの追加が完了しました。';
+    },
+    doneEditCategory(state, { category }) {
+      state.targetCategory = { ...state.category, ...category };
+      state.loading = false;
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
+    applyRequest(state) {
+      state.loading = false;
     },
   },
   actions: {
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
     initPostCategory({ commit }) {
       commit('initPostCategory');
+    },
+    updateValue({ commit }, target) {
+      commit('updateValue', target);
     },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
@@ -57,6 +84,40 @@ export default {
         commit('doneGetAllCategories', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    addCategory({ commit, rootGetters, dispatch }, category) {
+      commit('applyRequest');
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data: { name: category.category },
+        }).then(response => {
+          if (response.data.code === 0) throw new Error(response.data.message);
+          dispatch('getAllCategories');
+          commit('doneAddCategory');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.response.data.message });
+        });
+      });
+    },
+    editCategory({ commit, rootGetters }, category) {
+      commit('applyRequest');
+      axios(rootGetters['auth/token'])({
+        method: 'PUSH',
+        url: `/category/${category.id}`,
+        data: category,
+      }).then(response => {
+        if (response.data.code === 0) throw new Error(response.data.message);
+        const editedCategory = {
+          id: response.data.category.id,
+          name: response.data.category.id,
+        };
+        commit('doneEditCategory', { editedCategory });
+      }).catch(err => {
+        commit('failRequest', { message: err.response.data.message });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -48,18 +48,21 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
-      state.loading = !state.loading;
+      state.loading = false;
     },
     doneAddCategory(state) {
-      state.loading = !state.loading;
+      state.loading = false;
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
     },
     doneEditCategory(state, { category }) {
       state.targetCategory = { ...state.category, ...category };
-      state.loading = !state.loading;
+      state.loading = false;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
     applyRequest(state) {
+      state.loading = false;
+    },
+    toggleLoading(state) {
       state.loading = !state.loading;
     },
   },
@@ -88,6 +91,7 @@ export default {
     },
     addCategory({ commit, rootGetters, dispatch }, category) {
       commit('applyRequest');
+      commit('toggleLoading');
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'POST',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -48,19 +48,19 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
-      state.loading = false;
+      state.loading = !state.loading;
     },
     doneAddCategory(state) {
-      state.loading = false;
+      state.loading = !state.loading;
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
     },
     doneEditCategory(state, { category }) {
       state.targetCategory = { ...state.category, ...category };
-      state.loading = false;
+      state.loading = !state.loading;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
     applyRequest(state) {
-      state.loading = true;
+      state.loading = !state.loading;
     },
   },
   actions: {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -60,7 +60,7 @@ export default {
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
     applyRequest(state) {
-      state.loading = false;
+      state.loading = true;
     },
   },
   actions: {
@@ -101,23 +101,6 @@ export default {
         }).catch(err => {
           commit('failRequest', { message: err.response.data.message });
         });
-      });
-    },
-    editCategory({ commit, rootGetters }, category) {
-      commit('applyRequest');
-      axios(rootGetters['auth/token'])({
-        method: 'PUSH',
-        url: `/category/${category.id}`,
-        data: category,
-      }).then(response => {
-        if (response.data.code === 0) throw new Error(response.data.message);
-        const editedCategory = {
-          id: response.data.category.id,
-          name: response.data.category.id,
-        };
-        commit('doneEditCategory', { editedCategory });
-      }).catch(err => {
-        commit('failRequest', { message: err.response.data.message });
       });
     },
   },


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-812

## やったこと
・作成ボタンをクリックしたら、一覧画面が更新
・更新された際にメッセージが表示
・追加したカテゴリーは一覧の一番上に表示
・カテゴリー作成失敗時にエラーメッセージが表示
・入力欄が空欄のまま作成ボタンを押した時に警告が出る
・作成ボタンをクリック後、API通信中は作成ボタンが「作成中」に変わり、押せなくなる

## やらないこと
・「このカテゴリーの記事」「更新」「削除」ボタンを押した時の実装

## テスト
https://gizumo.backlog.com/view/GIZFE-814

## 特にレビューをお願いしたい箇所
書き直しを何度も行ったので、動作していない不要な記述が残っていないかの確認。
