### PR TITLE
カテゴリー新規作成機能の追加

### DIFF
--- a/src/components/pages/Categories/Manage.vue
+++ b/src/components/pages/Categories/Manage.vue
@@ -5,6 +5,9 @@
       :done-message="doneMessage"
       :access="access"
       :category="category"
+      @update-value="updateValue"
+      @clear-message="clearMessage"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       :theads="theads"
@@ -26,14 +29,12 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名', '', '', ''],
+      category: '',
     };
   },
   computed: {
     access() {
       return this.$store.getters['auth/access'];
-    },
-    category() {
-      return this.$store.state.categories.category;
     },
     categoriesList() {
       return this.$store.state.categories.categoriesList;
@@ -47,6 +48,21 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getCategoryList');
+  },
+  methods: {
+    updateValue($event) {
+      const categoryName = $event.target.value;
+      this.category = categoryName;
+    },
+    clearMessage() {
+      return this.$store.dispatch('categories/clearMessage');
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      const categoryName = this.category;
+      this.$store.dispatch('categories/updateCategory', categoryName);
+      this.category = '';
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/Manage.vue
+++ b/src/components/pages/Categories/Manage.vue
@@ -5,6 +5,7 @@
       :done-message="doneMessage"
       :access="access"
       :category="category"
+      :error-message="errorMessage"
       @update-value="updateValue"
       @clear-message="clearMessage"
       @handle-submit="handleSubmit"
@@ -50,9 +51,8 @@ export default {
     this.$store.dispatch('categories/getCategoryList');
   },
   methods: {
-    updateValue($event) {
-      const categoryName = $event.target.value;
-      this.category = categoryName;
+    updateValue(event) {
+      this.category = event.target.value;
     },
     clearMessage() {
       return this.$store.dispatch('categories/clearMessage');
@@ -60,7 +60,7 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       const categoryName = this.category;
-      this.$store.dispatch('categories/updateCategory', categoryName);
+      this.$store.dispatch('categories/addCategory', categoryName);
       this.category = '';
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,10 +3,10 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    category: '',
     categoriesList: [],
-    deleteCategoriesList: null,
-    errorMessage: '',
     doneMessage: '',
+    errorMessage: '',
   },
   mutations: {
     failRequest(state, { message }) {
@@ -21,6 +21,9 @@ export default {
     },
   },
   actions: {
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
     getCategoryList({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -28,6 +31,29 @@ export default {
       }).then(res => {
         const categories = res.data.categories.reverse();
         commit('setCategories', { categories });
+        commit('clearMessage');
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    updateCategory({ commit, rootGetters }, categoryName) {
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data: {
+          name: categoryName,
+        },
+      }).then(() => {
+        axios(rootGetters['auth/token'])({
+          method: 'GET',
+          url: '/category',
+        }).then(res => {
+          const categories = res.data.categories.reverse();
+          commit('setCategories', { categories });
+          commit('clearMessage');
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
         commit('clearMessage');
       }).catch(err => {
         commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,7 +3,6 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    category: '',
     categoriesList: [],
     doneMessage: '',
     errorMessage: '',
@@ -19,6 +18,9 @@ export default {
     setCategories(state, { categories }) {
       state.categoriesList = categories;
     },
+    doneCreateCategory(state) {
+      state.doneMessage = '新しいカテゴリーが作成されました。';
+    },
   },
   actions: {
     clearMessage({ commit }) {
@@ -31,12 +33,11 @@ export default {
       }).then(res => {
         const categories = res.data.categories.reverse();
         commit('setCategories', { categories });
-        commit('clearMessage');
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
     },
-    updateCategory({ commit, rootGetters }, categoryName) {
+    addCategory({ commit, rootGetters }, categoryName) {
       axios(rootGetters['auth/token'])({
         method: 'POST',
         url: '/category',
@@ -50,11 +51,10 @@ export default {
         }).then(res => {
           const categories = res.data.categories.reverse();
           commit('setCategories', { categories });
-          commit('clearMessage');
         }).catch(err => {
           commit('failRequest', { message: err.message });
         });
-        commit('clearMessage');
+        commit('doneCreateCategory');
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -37,7 +37,7 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    addCategory({ commit, rootGetters }, categoryName) {
+    addCategory({ commit, rootGetters, dispatch }, categoryName) {
       axios(rootGetters['auth/token'])({
         method: 'POST',
         url: '/category',
@@ -45,15 +45,7 @@ export default {
           name: categoryName,
         },
       }).then(() => {
-        axios(rootGetters['auth/token'])({
-          method: 'GET',
-          url: '/category',
-        }).then(res => {
-          const categories = res.data.categories.reverse();
-          commit('setCategories', { categories });
-        }).catch(err => {
-          commit('failRequest', { message: err.message });
-        });
+        dispatch('getCategoryList');
         commit('doneCreateCategory');
       }).catch(err => {
         commit('failRequest', { message: err.message });


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-856

## やったこと
CategoryPostで$emitされている処理をManage.vueのapp-category-postのカスタムタグに追記
Manage.vueでemitされてきた処理の詳細を記述
- ユーザーが入力した値の取得
- 作成ボタンクリック時にAPI通信を行えるように設定

categories.jsでユーザーが入力した値を受け取り、API通信を行う処理を追記

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-858

## 特にレビューをお願いしたい箇所
更新するためにcategoriesのactionの処理updateCategoryで2度API通信を行っているですがよくないでしょうか？
