### PR TITLE
カテゴリ一削除機能実装

### DIFF
--- a/src/components/pages/Categories/Manage.vue
+++ b/src/components/pages/Categories/Manage.vue
@@ -15,18 +15,23 @@
       :categories="categoriesList"
       :error-message="errorMessage"
       :access="access"
+      :delete-category-name="deleteCategoryName"
+      @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名', '', '', ''],
@@ -46,6 +51,9 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategory.name;
+    },
   },
   created() {
     this.$store.dispatch('categories/getCategoryList');
@@ -62,6 +70,18 @@ export default {
       const categoryName = this.category;
       this.$store.dispatch('categories/addCategory', categoryName);
       this.category = '';
+    },
+    openModal(categoryId, categoryName) {
+      this.toggleModal();
+      const categoryIdName = {
+        id: categoryId,
+        name: categoryName,
+      };
+      this.$store.dispatch('categories/confirmDeleteCategory', categoryIdName);
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -6,6 +6,13 @@ export default {
     categoriesList: [],
     doneMessage: '',
     errorMessage: '',
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
+  },
+  getters: {
+    deleteCategoryId: state => state.deleteCategory.id,
   },
   mutations: {
     failRequest(state, { message }) {
@@ -20,6 +27,17 @@ export default {
     },
     doneCreateCategory(state) {
       state.doneMessage = '新しいカテゴリーが作成されました。';
+    },
+    confirmDeleteCategory(state, categoryIdName) {
+      state.deleteCategory.id = categoryIdName.id;
+      state.deleteCategory.name = categoryIdName.name;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategory.id = null;
+      state.deleteCategory.name = '';
+    },
+    displayDoneMessage(state) {
+      state.doneMessage = 'カテゴリーの削除が完了しました。';
     },
   },
   actions: {
@@ -47,6 +65,21 @@ export default {
       }).then(() => {
         dispatch('getCategoryList');
         commit('doneCreateCategory');
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    confirmDeleteCategory({ commit }, categoryIdName) {
+      commit('confirmDeleteCategory', categoryIdName);
+    },
+    deleteCategory({ commit, rootGetters, dispatch }) {
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+      }).then(() => {
+        dispatch('getCategoryList');
+        commit('doneDeleteCategory');
+        commit('displayDoneMessage');
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-879

## やったこと

- 削除ボタンをクリック時にモーダルを展開
- モーダルに削除するカテゴリー名を表示
- モーダル内の削除ボタンをクリック時にAPI通信を行う
- 一覧が更新され、削除した旨のメッセージを表示

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-881

## 特にレビューをお願いしたい箇所
なし
