### PR TITLE
削除済記事一覧画面実装

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__trashed-link"
+    >
+      削除済み記事一覧へ移動する
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -160,6 +172,10 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+    }
+    &__trashed-link {
+      margin-top: 16px;
+      margin-left: 16px;
     }
     &__links {
       *:not(first-child) {

--- a/src/components/molecules/ArticleTrash/index.vue
+++ b/src/components/molecules/ArticleTrash/index.vue
@@ -1,20 +1,20 @@
 <template>
-  <div class="trashed-list">
-    <app-heading :level="1">{{ trashedTitle }}</app-heading>
+  <div class="article-trash">
+    <app-heading :level="1">削除済み記事一覧</app-heading>
     <app-router-link
-      :to="path"
+      to="/articles"
       key-color
       white
       bg-lightgreen
       small
       round
       hover-opacity
-      class="trashed-list__link"
+      class="article-trash__link"
     >
       すべての記事一覧へ戻る
     </app-router-link>
-    <table class="trashed-list__table">
-      <thead class="trashed-list__table-head">
+    <table class="article-trash__table">
+      <thead class="article-trash__table-head">
         <tr>
           <th v-for="(thead, index) in theads" :key="index">
             <app-text tag="span" theme-color bold>
@@ -26,7 +26,7 @@
       <transition-group
         name="fade"
         tag="tbody"
-        class="trashed-list__table-body"
+        class="article-trash__table-body"
       >
         <tr v-for="trash in trashes" :key="trash.id">
           <td>
@@ -47,7 +47,7 @@
         </tr>
       </transition-group>
     </table>
-    <div v-if="errorMessage" class="trashed-list__notice">
+    <div v-if="errorMessage" class="article-trash__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
   </div>
@@ -71,14 +71,6 @@ export default {
     },
   },
   props: {
-    path: {
-      type: String,
-      default: '',
-    },
-    title: {
-      type: String,
-      default: '',
-    },
     theads: {
       type: Array,
       default: () => [],
@@ -92,16 +84,11 @@ export default {
       default: '',
     },
   },
-  computed: {
-    trashedTitle() {
-      return `削除済み${this.title}一覧`;
-    },
-  },
 };
 </script>
 
 <style lang="scss" scoped>
-.trashed-list {
+.article-trash {
   .fade-enter, .fade-leave-to {
     opacity: 0;
   }

--- a/src/components/molecules/ArticleTrash/index.vue
+++ b/src/components/molecules/ArticleTrash/index.vue
@@ -28,20 +28,20 @@
         tag="tbody"
         class="article-trash__table-body"
       >
-        <tr v-for="trash in trashes" :key="trash.id">
+        <tr v-for="trash in omittedTrashes" :key="trash.id">
           <td>
             <app-text tag="span" small>
-              {{ trash.title | omittedText }}
+              {{ trash.title }}
             </app-text>
           </td>
           <td>
             <app-text tag="span" small>
-              {{ trash.content | omittedText }}
+              {{ trash.text }}
             </app-text>
           </td>
           <td>
             <app-text tag="span" small>
-              {{ trash.createdDate | omittedDate }}
+              {{ trash.date }}
             </app-text>
           </td>
         </tr>
@@ -62,14 +62,6 @@ export default {
     appRouterLink: RouterLink,
     appText: Text,
   },
-  filters: {
-    omittedText(text) {
-      return text.length > 30 ? `${text.slice(0, 30)}...` : text;
-    },
-    omittedDate(text) {
-      return text.length > 10 ? text.slice(0, 10) : text;
-    },
-  },
   props: {
     theads: {
       type: Array,
@@ -82,6 +74,18 @@ export default {
     errorMessage: {
       type: String,
       default: '',
+    },
+  },
+  computed: {
+    omittedTrashes() {
+      const omittedTrashes = this.trashes.map(data => ({
+        id: data.id,
+        title: data.title.length > 30 ? `${data.title.slice(0, 30)}...` : data.title,
+        text: data.content.length > 30 ? `${data.content.slice(0, 30)}...` : data.content,
+        date: data.createdDate.length > 10
+          ? data.createdDate.slice(0, 10) : data.createdDate,
+      }));
+      return omittedTrashes;
     },
   },
 };

--- a/src/components/molecules/TrashedList/index.vue
+++ b/src/components/molecules/TrashedList/index.vue
@@ -30,13 +30,19 @@
       >
         <tr v-for="trash in targetArray" :key="trash.id">
           <td>
-            <app-text tag="span" small>{{ trash.title }}</app-text>
+            <app-text tag="span" small>
+              {{ trash.title | omittedText }}
+            </app-text>
           </td>
           <td>
-            <app-text tag="span" small>{{ trash.content }}</app-text>
+            <app-text tag="span" small>
+              {{ trash.content | omittedText }}
+            </app-text>
           </td>
           <td>
-            <app-text tag="span" small>{{ trash.createdDate }}</app-text>
+            <app-text tag="span" small>
+              {{ trash.createdDate | omittedDate }}
+            </app-text>
           </td>
         </tr>
       </transition-group>
@@ -52,6 +58,14 @@ export default {
     appHeading: Heading,
     appRouterLink: RouterLink,
     appText: Text,
+  },
+  filters: {
+    omittedText(text) {
+      return text.length > 30 ? `${text.slice(0, 30)}...` : text;
+    },
+    omittedDate(text) {
+      return text.length > 10 ? text.slice(0, 10) : text;
+    },
   },
   props: {
     path: {
@@ -88,19 +102,8 @@ export default {
   .fade-enter, .fade-leave-to {
     opacity: 0;
   }
-  &__title {
-    width: 60%;
-  }
   &__link {
     margin-top: 16px;
-  }
-  &__links {
-    *:not(first-child) {
-      margin-left: 16px;
-    }
-  }
-  &__notice--create {
-    margin-bottom: 16px;
   }
   &__table {
     width: 100%;
@@ -120,10 +123,6 @@ export default {
       td {
         padding: 10px;
         vertical-align: middle;
-        &.is-disabled {
-          color: $disabled-color;
-          font-size: 12px;
-        }
       }
       .fade-enter-active, .fade-leave-active {
         transition: opacity 0.5s;

--- a/src/components/molecules/TrashedList/index.vue
+++ b/src/components/molecules/TrashedList/index.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="trashed-list">
+    <app-heading :level="1">{{ trashedTitle }}</app-heading>
+    <app-router-link
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="trashed-list__link"
+    >
+      すべての記事一覧へ戻る
+    </app-router-link>
+    <table class="trashed-list__table">
+      <thead class="trashed-list__table-head">
+        <tr>
+          <th v-for="(thead, index) in theads" :key="index">
+            <app-text tag="span" theme-color bold>
+              {{ thead }}
+            </app-text>
+          </th>
+        </tr>
+      </thead>
+      <transition-group
+        name="fade"
+        tag="tbody"
+        class="trashed-list__table-body"
+      >
+        <tr v-for="trash in targetArray" :key="trash.id">
+          <td>
+            <app-text tag="span" small>{{ trash.title }}</app-text>
+          </td>
+          <td>
+            <app-text tag="span" small>{{ trash.content }}</app-text>
+          </td>
+          <td>
+            <app-text tag="span" small>{{ trash.createdDate }}</app-text>
+          </td>
+        </tr>
+      </transition-group>
+    </table>
+  </div>
+</template>
+
+<script>
+import { Heading, RouterLink, Text } from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+    appText: Text,
+  },
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+    borderGray: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    trashedTitle() {
+      return `削除済み${this.title}一覧`;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.trashed-list {
+  .fade-enter, .fade-leave-to {
+    opacity: 0;
+  }
+  &__title {
+    width: 60%;
+  }
+  &__link {
+    margin-top: 16px;
+  }
+  &__links {
+    *:not(first-child) {
+      margin-left: 16px;
+    }
+  }
+  &__notice--create {
+    margin-bottom: 16px;
+  }
+  &__table {
+    width: 100%;
+    text-align: left;
+    margin-top: 16px;
+    background-color: #fff;
+    tr {
+      border-bottom: 1px solid $separator-color;
+    }
+    &-head {
+      th {
+        padding: 5px 10px;
+        vertical-align: middle;
+      }
+    }
+    &-body {
+      td {
+        padding: 10px;
+        vertical-align: middle;
+        &.is-disabled {
+          color: $disabled-color;
+          font-size: 12px;
+        }
+      }
+      .fade-enter-active, .fade-leave-active {
+        transition: opacity 0.5s;
+      }
+      .fade-enter, .fade-leave-to {
+        opacity: 0;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/molecules/TrashedList/index.vue
+++ b/src/components/molecules/TrashedList/index.vue
@@ -28,7 +28,7 @@
         tag="tbody"
         class="trashed-list__table-body"
       >
-        <tr v-for="trash in targetArray" :key="trash.id">
+        <tr v-for="trash in trashes" :key="trash.id">
           <td>
             <app-text tag="span" small>
               {{ trash.title | omittedText }}
@@ -83,7 +83,7 @@ export default {
       type: Array,
       default: () => [],
     },
-    targetArray: {
+    trashes: {
       type: Array,
       default: () => [],
     },

--- a/src/components/molecules/TrashedList/index.vue
+++ b/src/components/molecules/TrashedList/index.vue
@@ -47,6 +47,9 @@
         </tr>
       </transition-group>
     </table>
+    <div v-if="errorMessage" class="trashed-list__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
   </div>
 </template>
 
@@ -87,6 +90,10 @@ export default {
     borderGray: {
       type: Boolean,
       default: false,
+    },
+    errorMessage: {
+      type: String,
+      default: '',
     },
   },
   computed: {
@@ -131,6 +138,9 @@ export default {
         opacity: 0;
       }
     }
+  }
+  &__notice {
+    margin-top: 16px;
   }
 }
 </style>

--- a/src/components/molecules/TrashedList/index.vue
+++ b/src/components/molecules/TrashedList/index.vue
@@ -2,6 +2,7 @@
   <div class="trashed-list">
     <app-heading :level="1">{{ trashedTitle }}</app-heading>
     <app-router-link
+      :to="path"
       key-color
       white
       bg-lightgreen
@@ -53,6 +54,10 @@ export default {
     appText: Text,
   },
   props: {
+    path: {
+      type: String,
+      default: '',
+    },
     title: {
       type: String,
       default: '',

--- a/src/components/molecules/TrashedList/index.vue
+++ b/src/components/molecules/TrashedList/index.vue
@@ -87,10 +87,6 @@ export default {
       type: Array,
       default: () => [],
     },
-    borderGray: {
-      type: Boolean,
-      default: false,
-    },
     errorMessage: {
       type: String,
       default: '',

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -17,6 +17,7 @@ import ArticleDetail from './ArticleDetail/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
 import Pagination from './Pagination/index.vue';
+import TrashedList from './TrashedList/index.vue';
 
 export {
   SigninForm,
@@ -38,4 +39,5 @@ export {
   DeleteModal,
   Notice,
   Pagination,
+  TrashedList,
 };

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -14,10 +14,10 @@ import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
+import ArticleTrash from './ArticleTrash/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
 import Pagination from './Pagination/index.vue';
-import TrashedList from './TrashedList/index.vue';
 
 export {
   SigninForm,
@@ -36,8 +36,8 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrash,
   DeleteModal,
   Notice,
   Pagination,
-  TrashedList,
 };

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,7 +1,8 @@
 <template>
   <app-trashed-list
-    :theads="theads"
+    :path="path"
     :title="title"
+    :theads="theads"
     :target-array="trashedArticle"
     border-gray
   />
@@ -16,6 +17,7 @@ export default {
   },
   data() {
     return {
+      path: '/articles',
       title: '記事',
       theads: ['タイトル', '本文', '作成日'],
     };

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -3,7 +3,7 @@
     :path="path"
     :title="title"
     :theads="theads"
-    :target-array="trashedArticle"
+    :trashes="trashedArticle"
     :error-message="errorMessage"
     border-gray
   />

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -3,7 +3,7 @@
     :path="path"
     :title="title"
     :theads="theads"
-    :trashes="trashedArticle"
+    :trashes="trashedArticles"
     :error-message="errorMessage"
     border-gray
   />
@@ -24,7 +24,7 @@ export default {
     };
   },
   computed: {
-    trashedArticle() {
+    trashedArticles() {
       return this.$store.state.articles.trashedArticle;
     },
     errorMessage() {

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,25 +1,20 @@
 <template>
-  <app-trashed-list
-    :path="path"
-    :title="title"
+  <app-article-trash
     :theads="theads"
     :trashes="trashedArticles"
     :error-message="errorMessage"
-    border-gray
   />
 </template>
 
 <script>
-import { TrashedList } from '@Components/molecules';
+import { ArticleTrash } from '@Components/molecules';
 
 export default {
   components: {
-    appTrashedList: TrashedList,
+    appArticleTrash: ArticleTrash,
   },
   data() {
     return {
-      path: '/articles',
-      title: '記事',
       theads: ['タイトル', '本文', '作成日'],
     };
   },

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -4,6 +4,7 @@
     :title="title"
     :theads="theads"
     :target-array="trashedArticle"
+    :error-message="errorMessage"
     border-gray
   />
 </template>
@@ -25,6 +26,9 @@ export default {
   computed: {
     trashedArticle() {
       return this.$store.state.articles.trashedArticle;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
     },
   },
   created() {

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,32 @@
+<template>
+  <app-trashed-list
+    :theads="theads"
+    :title="title"
+    :target-array="trashedArticle"
+    border-gray
+  />
+</template>
+
+<script>
+import { TrashedList } from '@Components/molecules';
+
+export default {
+  components: {
+    appTrashedList: TrashedList,
+  },
+  data() {
+    return {
+      title: '記事',
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    trashedArticle() {
+      return this.$store.state.articles.trashedArticle;
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getTrashedArticle');
+  },
+};
+</script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -17,6 +17,7 @@ import ArticleList from '@Pages/Articles/List.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -114,6 +115,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -23,6 +23,7 @@ export default {
         updated_at: '',
       },
     },
+    trashedArticle: [],
     articleList: [],
     currentPage: 1,
     totalPage: null,
@@ -112,6 +113,9 @@ export default {
     },
     doneDeleteArticle(state) {
       state.deleteArticleId = null;
+    },
+    doneGetTrashedArticle(state, { articles }) {
+      state.trashedArticle = articles;
     },
     toggleLoading(state) {
       state.loading = !state.loading;
@@ -291,6 +295,22 @@ export default {
           commit('failRequest', { message: err.message });
           reject();
         });
+      });
+    },
+    getTrashedArticle({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(res => {
+        const articles = res.data.articles.map(data => ({
+          id: data.id,
+          title: data.title,
+          content: data.content,
+          createdDate: data.created_at,
+        }));
+        commit('doneGetTrashedArticle', { articles });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
     clearMessage({ commit }) {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-902

## やったこと
- 削除済記事一覧画面作成
- 初期表示にAPIから取得した削除済記事一覧の表示
- タイトル及び記事本文の表示文字数の制限
- 作成日をyyyy-mm-ddで表示
- 全ての記事一覧ボタンをクリックしたら、記事一覧画面へ遷移
- API通信失敗時、エラーメッセージの表示

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-904

## 特にレビューをお願いしたい箇所
なし
