### PR TITLE
Github のアプデにより swagger-viewer が使用できなくなったため対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ npm run dev
 | アドレス | guest@gizumo.com |  
 | パスワード | gizumowiki |  
 
-4. VS Codeに[OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)の拡張機能のインストール（API仕様書を参照する際に使用します）
-
 ## フォルダ構成
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm run dev
 | アドレス | guest@gizumo.com |  
 | パスワード | gizumowiki |  
 
-4. [swagger-viewer](https://chrome.google.com/webstore/detail/swagger-viewer/nfmkaonpdmaglhjjlggfhlndofdldfag?hl=ja)のインストール（API仕様書を参照する際に使用します）
+4. VS Codeに[OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)の拡張機能のインストール（API仕様書を参照する際に使用します）
 
 ## フォルダ構成
 


### PR DESCRIPTION
Google Chrome で swagger-viewer のアイコンをクリックして使おうとすると以下のエラーが出るので、VSCode の拡張機能で API 仕様書を見てもらうようにします。
また、その説明を Backlog に移動させたので、README から削除しています。

![スクリーンショット 0005-05-10 10 19 41](https://github.com/gizumo-education/gizumo_wiki_lesson/assets/48352529/b09536b1-1fb8-4252-90d3-c1a8679bcf4a)
