### PR TITLE
カテゴリ一削除機能実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -74,7 +74,7 @@
           class="category-list__modal__button"
           bg-danger
           round
-          @click="handleClick"
+          @click="$emit('handle-click')"
         >
           削除する
         </app-button>
@@ -120,10 +120,6 @@ export default {
     openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
       this.$emit('open-modal', categoryId, categoryName);
-    },
-    handleClick() {
-      if (!this.access.delete) return;
-      this.$emit('handle-click');
     },
   },
 };

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -74,7 +74,7 @@
           class="category-list__modal__button"
           bg-danger
           round
-          @click="$emit('handle-click')"
+          @click="handleClick"
         >
           削除する
         </app-button>
@@ -120,6 +120,10 @@ export default {
     openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
       this.$emit('open-modal', categoryId, categoryName);
+    },
+    handleClick() {
+      if (!this.access.delete) return;
+      this.$emit('handle-click');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -72,19 +72,22 @@ export default {
       this.$store.dispatch('categories/editedCategory', event.target.value);
       this.$store.dispatch('categories/clearMessage');
     },
-    openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/deleteCategoryName', categoryName);
-      this.toggleModal();
-    },
-    handleClick() {
-      this.$store.dispatch('categories/deleteCategory');
-      this.toggleModal();
-    },
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory').then(() => {
         this.$store.dispatch('categories/getAllCategories');
       });
+    },
+    openModal(categoryId, categoryName) {
+      // console.log(categoryName);
+      const actionName = 'categories/confirmDeleteCategory';
+      this.$store.dispatch(actionName, { categoryId, categoryName });
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
+      this.$store.dispatch('categories/getAllCategories');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -79,7 +79,6 @@ export default {
       });
     },
     openModal(categoryId, categoryName) {
-      // const actionName = 'categories/confirmDeleteCategory';
       this.$store.dispatch(
         'categories/confirmDeleteCategory',
         { categoryId, categoryName },
@@ -89,7 +88,6 @@ export default {
     handleClick() {
       this.$store.dispatch('categories/deleteCategory');
       this.toggleModal();
-      this.$store.dispatch('categories/getAllCategories');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,6 +16,9 @@
         :theads="theads"
         :categories="categoryList"
         :access="access"
+        :delete-category-name="deleteCategoryName"
+        @open-modal="openModal"
+        @handle-click="handleClick"
       />
     </article>
   </div>
@@ -23,12 +26,14 @@
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -53,6 +58,9 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -63,6 +71,14 @@ export default {
     editedCategory(event) {
       this.$store.dispatch('categories/editedCategory', event.target.value);
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/deleteCategoryName', categoryName);
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
     },
     handleSubmit() {
       if (this.loading) return;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -79,9 +79,11 @@ export default {
       });
     },
     openModal(categoryId, categoryName) {
-      // console.log(categoryName);
-      const actionName = 'categories/confirmDeleteCategory';
-      this.$store.dispatch(actionName, { categoryId, categoryName });
+      // const actionName = 'categories/confirmDeleteCategory';
+      this.$store.dispatch(
+        'categories/confirmDeleteCategory',
+        { categoryId, categoryName },
+      );
       this.toggleModal();
     },
     handleClick() {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -31,8 +31,11 @@ export default {
     deleteCategoryName(state, { categoryName }) {
       state.deleteCategoryName = categoryName;
     },
+    confirmDeleteCategory(state, { categoryId }) {
+      state.deleteCategoryId = categoryId;
+    },
     doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
+      state.targetCategoryId = null;
     },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories.reverse()];
@@ -75,17 +78,19 @@ export default {
     editedCategory({ commit }, name) {
       commit('editedCategory', name);
     },
-    deleteCategoryName({ commit }, categoryName) {
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId });
       commit('deleteCategoryName', { categoryName });
     },
     deleteCategory({ commit, rootGetters }) {
       commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
-        url: `/Category/${rootGetters['categories/deleteCategoryId']}`,
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
       }).then(() => {
         commit('doneDeleteCategory');
         commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+        commit('getAllCategories');
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -37,6 +37,9 @@ export default {
     doneDeleteCategory(state) {
       state.targetCategoryId = null;
     },
+    displayAllCategories(state, payload) {
+      state.categoryList = state.categoryList.filter(value => value.id !== payload.id);
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories.reverse()];
     },
@@ -87,10 +90,13 @@ export default {
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
         url: `/category/${rootGetters['categories/deleteCategoryId']}`,
-      }).then(() => {
+      }).then(res => {
+        const payload = {
+          id: res.data.category.id,
+        };
         commit('doneDeleteCategory');
         commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
-        commit('getAllCategories');
+        commit('displayAllCategories', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,6 +8,8 @@ export default {
       name: '',
     },
     categoryList: [],
+    deleteCategoryId: null,
+    deleteCategoryName: '',
     loading: false,
     doneMessage: '',
     errorMessage: '',
@@ -17,6 +19,7 @@ export default {
     categoryList(state) {
       return state.categoryList;
     },
+    deleteCategoryId: state => state.deleteCategoryId,
   },
   mutations: {
     initPostCategory(state) {
@@ -24,6 +27,12 @@ export default {
         id: null,
         name: '',
       };
+    },
+    deleteCategoryName(state, { categoryName }) {
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
     },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories.reverse()];
@@ -65,6 +74,21 @@ export default {
     },
     editedCategory({ commit }, name) {
       commit('editedCategory', name);
+    },
+    deleteCategoryName({ commit }, categoryName) {
+      commit('deleteCategoryName', { categoryName });
+    },
+    deleteCategory({ commit, rootGetters }) {
+      commit('clearMessage');
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/Category/${rootGetters['categories/deleteCategoryId']}`,
+      }).then(() => {
+        commit('doneDeleteCategory');
+        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
     postCategory({ commit, rootGetters }) {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-896

## やったこと
削除ボタンを押したときの、削除確認用のモーダルの表示
削除確認用のモーダルに、削除対象のカテゴリ名を表示
削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIを実行
削除が成功したらカテゴリー一覧が更新され、メッセージを表示

## やらないこと
なし

## テスト
<!-- Backlogのテストチケットのリンクを記載 -->
https://gizumo.backlog.com/view/GIZFE-898

## 特にレビューをお願いしたい箇所
dispatchの使い方について、認識に間違いがないか確認をお願いしたいです。

詳細：
カテゴリーを削除するときにpages > Categories > List.vueのhandleClick()メソッドで、
（「記事」の削除で使っているアクションやメソッドを参考にし、）以下の順番で複数回dispatchをするかたちで書きました。

```
this.$store.dispatch('categories/deleteCategory');
this.toggleModal();
this.$store.dispatch('categories/getAllCategories');``
```

１つ目のdispatchが終わって（deleteCategoryが実行されてうまくいって）から、２つ目のdispatch（getAllCategpries: 削除対象となるカテゴリーがリストから消えたものを表示）がされるのでないと実行する順としてうまくいかないのではないかと思ったのですが、画面上の動きは少なくとも想定していた動きとして問題はないように見えました。

メソッドの中でdispatchで呼び出した場合、dispatchされたaction の中身が実行終わるまで、
次のdispatchには処理が進まない（dispatchはひとつずつ実行される）認識で良いのでしょうか。
もしかしたらうまくいかない可能性があると思いつつやってみたところ、画面の表示は想定通りにいったので、どうしてできたのか少し不思議です。

削除対象項目が消された状態の、新しいカテゴリーリストの表示は、このやり方で問題ないのでしょうか。
もしくは、違うやり方で進めるべきでしたでしょうか。ご確認いただけますでしょうか。