### PR TITLE
カテゴリー削除機能実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -77,7 +77,7 @@
           class="category-list__modal__button"
           bg-danger
           round
-          @click="$emit('handle-click')"
+          @click="handleClick"
         >
           削除する
         </app-button>
@@ -125,6 +125,10 @@ export default {
     openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
       this.$emit('open-modal', categoryId, categoryName);
+    },
+    handleClick() {
+      if (!this.access.delete) return;
+      this.$emit('handle-click');
     },
   },
 };

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -77,7 +77,7 @@
           class="category-list__modal__button"
           bg-danger
           round
-          @click="handleClick"
+          @click="$emit('handle-click')"
         >
           削除する
         </app-button>
@@ -125,10 +125,6 @@ export default {
     openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
       this.$emit('open-modal', categoryId, categoryName);
-    },
-    handleClick() {
-      if (!this.access.delete) return;
-      this.$emit('handle-click');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,6 +16,10 @@
       :categories="categoryList"
       :theads="theads"
       :access="access"
+      :delete-category-name="deleteCategoryName"
+      @clear-message="clearMessage"
+      @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
@@ -55,6 +59,9 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -62,6 +69,13 @@ export default {
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch(
+        'categories/confirmDeleteCategory',
+        { categoryId, categoryName },
+      );
+      this.toggleModal();
     },
     updateValue(target) {
       this.category = target.value;
@@ -72,6 +86,13 @@ export default {
         category: this.category,
       });
       this.category = '';
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategoryId })
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -60,7 +60,7 @@ export default {
       return this.$store.getters['auth/access'];
     },
     deleteCategoryName() {
-      return this.$store.state.categories.deleteCategoryName;
+      return this.$store.state.categories.deleteCategory.name;
     },
   },
   created() {
@@ -72,7 +72,7 @@ export default {
     },
     openModal(categoryId, categoryName) {
       this.$store.dispatch(
-        'categories/confirmDeleteCategory',
+        'categories/setTargetCategory',
         { categoryId, categoryName },
       );
       this.toggleModal();
@@ -88,10 +88,7 @@ export default {
       this.category = '';
     },
     handleClick() {
-      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategoryId })
-        .then(() => {
-          this.$store.dispatch('categories/getAllCategories');
-        });
+      this.$store.dispatch('categories/deleteCategory');
       this.toggleModal();
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -117,8 +117,6 @@ export default {
     },
     deleteCategory({ commit, rootGetters, dispatch }) {
       commit('clearMessage');
-      const data = new URLSearchParams();
-      data.append('categories', rootGetters['categories/deleteCategoryId']);
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
         url: `/category/${rootGetters['categories/deleteCategoryId']}`,

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,8 +13,10 @@ export default {
       },
     },
     categoryList: [],
-    deleteCategoryId: null,
-    deleteCategoryName: '',
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
     loading: false,
     errorMessage: '',
   },
@@ -26,8 +28,8 @@ export default {
       }));
     },
     targetCategory: state => state.targetCategory,
-    deleteCategoryId: state => state.deleteCategoryId,
-    deleteCategoryName: state => state.deleteCategoryName,
+    deleteCategoryId: state => state.deleteCategory.id,
+    deleteCategoryName: state => state.deleteCategory.name,
   },
   mutations: {
     clearMessage(state) {
@@ -56,12 +58,12 @@ export default {
     doneAddCategory(state) {
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
     },
-    confirmDeleteCategory(state, { categoryId, categoryName }) {
-      state.deleteCategoryId = categoryId;
-      state.deleteCategoryName = categoryName;
+    setTargetCategory(state, { categoryId, categoryName }) {
+      state.deleteCategory.id = categoryId;
+      state.deleteCategory.name = categoryName;
     },
     doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
+      state.deleteCategory.id = null;
       state.doneMessage = 'カテゴリー削除が完了しました。';
     },
     toggleLoading(state) {
@@ -110,8 +112,8 @@ export default {
         });
       });
     },
-    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
-      commit('confirmDeleteCategory', { categoryId, categoryName });
+    setTargetCategory({ commit }, { categoryId, categoryName }) {
+      commit('setTargetCategory', { categoryId, categoryName });
     },
     deleteCategory({ commit, rootGetters, dispatch }) {
       commit('clearMessage');
@@ -120,7 +122,6 @@ export default {
       axios(rootGetters['auth/token'])({
         method: 'DELETE',
         url: `/category/${rootGetters['categories/deleteCategoryId']}`,
-        data,
       }).then(() => {
         commit('doneDeleteCategory');
         dispatch('getAllCategories');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,6 +13,8 @@ export default {
       },
     },
     categoryList: [],
+    deleteCategoryId: null,
+    deleteCategoryName: '',
     loading: false,
     errorMessage: '',
   },
@@ -24,6 +26,8 @@ export default {
       }));
     },
     targetCategory: state => state.targetCategory,
+    deleteCategoryId: state => state.deleteCategoryId,
+    deleteCategoryName: state => state.deleteCategoryName,
   },
   mutations: {
     clearMessage(state) {
@@ -51,6 +55,14 @@ export default {
     },
     doneAddCategory(state) {
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
+    },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.doneMessage = 'カテゴリー削除が完了しました。';
     },
     toggleLoading(state) {
       state.loading = !state.loading;
@@ -96,6 +108,25 @@ export default {
           commit('failRequest', { message: err.response.data.message });
           commit('toggleLoading');
         });
+      });
+    },
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
+    deleteCategory({ commit, rootGetters, dispatch }) {
+      commit('clearMessage');
+      const data = new URLSearchParams();
+      data.append('categories', rootGetters['categories/deleteCategoryId']);
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        data,
+      }).then(() => {
+        commit('doneDeleteCategory');
+        dispatch('getAllCategories');
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+        commit('toggleLoading');
       });
     },
   },


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-899

## やったこと
・削除ボタンを押した際、確認用のモーダルが表示される
・モーダル内に削除対象のカテゴリー名が表示される
・モーダル内の削除ボタンを押すとAPI通信がされる
・カテゴリー削除後に一覧を再取得して更新
・削除後、完了メッセージが表示される

## やらないこと
・「このカテゴリーの記事」「更新」のボタンの実装

## テスト
https://gizumo.backlog.com/view/GIZFE-901

## 特にレビューをお願いしたい箇所
特になし
