### PR TITLE
GizumoWiki 新規作成機能追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ npm run dev
 | アドレス | guest@gizumo.com |  
 | パスワード | gizumowiki |  
 
-4. VS Codeに[OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)の拡張機能のインストール（API仕様書を参照する際に使用します）
-
 ## フォルダ構成
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm run dev
 | アドレス | guest@gizumo.com |  
 | パスワード | gizumowiki |  
 
-4. [swagger-viewer](https://chrome.google.com/webstore/detail/swagger-viewer/nfmkaonpdmaglhjjlggfhlndofdldfag?hl=ja)のインストール（API仕様書を参照する際に使用します）
+4. VS Codeに[OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)の拡張機能のインストール（API仕様書を参照する際に使用します）
 
 ## フォルダ構成
 

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -16,7 +16,6 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
-      @click="$emit('create-category')"
     >
       {{ buttonText }}
     </app-button>

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -16,6 +16,7 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
+      @click="$emit('create-category')"
     >
       {{ buttonText }}
     </app-button>

--- a/src/components/pages/Categories/PostList.vue
+++ b/src/components/pages/Categories/PostList.vue
@@ -3,7 +3,10 @@
     <app-category-post
       :access="access"
       :error-message="errorMessage"
+      :category="newCategory"
       class="category_post"
+      @update-value="addCategory"
+      @create-category="createCategory"
     />
     <app-category-list
       :access="access"
@@ -37,9 +40,20 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    newCategory() {
+      return this.$store.state.categories.newCategory;
+    },
   },
   created() {
     this.$store.dispatch('categories/getCategories');
+  },
+  methods: {
+    addCategory($event) {
+      this.$store.dispatch('categories/addCategory', $event.target.value);
+    },
+    createCategory() {
+      this.$store.dispatch('categories/createCategory');
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/PostList.vue
+++ b/src/components/pages/Categories/PostList.vue
@@ -3,10 +3,13 @@
     <app-category-post
       :access="access"
       :error-message="errorMessage"
-      :category="newCategory"
+      :category="targetCategory"
+      :disabled="disabled"
+      :done-message="doneMessage"
       class="category_post"
-      @update-value="addCategory"
-      @create-category="createCategory"
+      @update-value="getTargetCategory"
+      @clear-message="clearMessage"
+      @handle-submit="addCategory"
     />
     <app-category-list
       :access="access"
@@ -40,19 +43,28 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
-    newCategory() {
-      return this.$store.state.categories.newCategory;
+    targetCategory() {
+      return this.$store.state.categories.targetCategory;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
     },
   },
   created() {
     this.$store.dispatch('categories/getCategories');
   },
   methods: {
-    addCategory($event) {
-      this.$store.dispatch('categories/addCategory', $event.target.value);
+    getTargetCategory($event) {
+      this.$store.dispatch('categories/getTargetCategory', $event.target.value);
     },
-    createCategory() {
-      this.$store.dispatch('categories/createCategory');
+    addCategory() {
+      this.$store.dispatch('categories/addCategory');
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
     },
   },
 };

--- a/src/components/pages/Categories/PostList.vue
+++ b/src/components/pages/Categories/PostList.vue
@@ -7,7 +7,7 @@
       :disabled="disabled"
       :done-message="doneMessage"
       class="category_post"
-      @update-value="getTargetCategory"
+      @update-value="setTargetCategory"
       @clear-message="clearMessage"
       @handle-submit="addCategory"
     />
@@ -57,8 +57,8 @@ export default {
     this.$store.dispatch('categories/getCategories');
   },
   methods: {
-    getTargetCategory($event) {
-      this.$store.dispatch('categories/getTargetCategory', $event.target.value);
+    setTargetCategory($event) {
+      this.$store.dispatch('categories/setTargetCategory', $event.target.value);
     },
     addCategory() {
       this.$store.dispatch('categories/addCategory');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,16 +5,39 @@ export default {
   state: {
     categories: [],
     errorMessage: '',
+    newCategory: '',
   },
   mutations: {
+    addCategory(state, category) {
+      state.newCategory = category;
+    },
     doneGetCategories(state, categoriesList) {
       state.categories = [...categoriesList.reverse()];
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
+
+  },
+  getters: {
+    targetCategory: state => state.newCategory,
   },
   actions: {
+    addCategory({ commit }, category) {
+      commit('addCategory', category);
+    },
+    createCategory({ commit, rootGetters }) {
+      const data = {
+        name: rootGetters['categories/targetCategory'],
+      };
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data,
+      }).then(({data}) => {
+        console.log(data);
+      });
+    },
     getCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,7 +13,7 @@ export default {
     addCategory(state, addCategory) {
       state.categories.unshift(addCategory);
     },
-    getTargetCategory(state, category) {
+    setTargetCategory(state, category) {
       state.targetCategory = category;
     },
     doneGetCategories(state, categoriesList) {
@@ -40,8 +40,8 @@ export default {
     targetCategory: state => state.targetCategory,
   },
   actions: {
-    getTargetCategory({ commit }, category) {
-      commit('getTargetCategory', category);
+    setTargetCategory({ commit }, category) {
+      commit('setTargetCategory', category);
     },
     addCategory({ commit, rootGetters }) {
       commit('clearMessage');
@@ -55,7 +55,6 @@ export default {
         data,
       }).then(res => {
         commit('toggleLoading');
-        commit('displayDoneMessage');
         const addedCategory = res.data.category;
         commit('addCategory', addedCategory);
         commit('clearTargetInput');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -55,10 +55,11 @@ export default {
         data,
       }).then(res => {
         commit('toggleLoading');
-        commit('displayDoneMessage', { message: 'カテゴリーを追加しました' });
+        commit('displayDoneMessage');
         const addedCategory = res.data.category;
         commit('addCategory', addedCategory);
         commit('clearTargetInput');
+        commit('displayDoneMessage', { message: 'カテゴリーを追加しました' });
       }).catch(err => {
         commit('toggleLoading');
         commit('failRequest', { message: err.message });


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-924
## やったこと
* カテゴリーを入力し、作成ボタンを押すと一覧が更新される
* 新規カテゴリーが一覧の最上段に表示される
* ローディング中は作成ボタンのが作成中に変わる
* カテゴリーが追加されるとメッセージが表示される
* API通信に失敗するとメッセージが表示される
## やらないこと
* なし
## テスト
https://gizumo.backlog.com/view/GIZFE-926
## 特にレビューをお願いしたい箇所
新規カテゴリーを追加する方法として、今回はAPI通信で追加した値をカテゴリーの
配列に追加するというやり方にしましたが、別の方法としてAPI通信で追加した一覧を再度
API通信で表示しなおす、というやり方もあると思うんですがどちらのほうが適切などあれば
教えていただきたいです。