### PR TITLE
カテゴリー画面削除機能実装

### DIFF
--- a/src/components/pages/Categories/PostList.vue
+++ b/src/components/pages/Categories/PostList.vue
@@ -63,6 +63,7 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getCategories');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     setTargetCategory($event) {

--- a/src/components/pages/Categories/PostList.vue
+++ b/src/components/pages/Categories/PostList.vue
@@ -15,19 +15,24 @@
       :access="access"
       :theads="theads"
       :categories="categories"
+      :delete-category-name="deleteCategoryName"
       class="category_list"
+      @open-modal="openModal"
+      @handle-click="deleteCategory"
     />
   </div>
 </template>
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryPost: CategoryPost,
     appCategoryList: CategoryList,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -52,6 +57,9 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategory.name;
+    },
   },
   created() {
     this.$store.dispatch('categories/getCategories');
@@ -65,6 +73,20 @@ export default {
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    openModal(categoryId, categoryName) {
+      const confirmCategory = {
+        id: categoryId,
+        name: categoryName,
+      };
+      this.$store.dispatch('categories/confirmDeleteCategory', confirmCategory);
+      this.toggleModal();
+    },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/getCategories');
+      });
+      this.toggleModal();
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -40,8 +40,7 @@ export default {
       state.targetCategory = '';
     },
     confirmDeleteCategory(state, confirmCategory) {
-      state.deleteCategory.id = confirmCategory.id;
-      state.deleteCategory.name = confirmCategory.name;
+      state.deleteCategory = confirmCategory;
     },
     doneDeleteCategory(state) {
       state.deleteCategory.id = null;
@@ -93,19 +92,18 @@ export default {
     confirmDeleteCategory({ commit }, confirmCategory) {
       commit('confirmDeleteCategory', confirmCategory);
     },
-    deleteCategory({ commit, rootGetters }) {
-      return new Promise((resolve, reject) => {
+    deleteCategory({ commit, rootGetters, getters }) {
+      return new Promise(resolve => {
         commit('clearMessage');
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          url: `/category/${getters.deleteCategoryId}`,
         }).then(() => {
           commit('doneDeleteCategory');
           resolve();
           commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
         }).catch(err => {
           commit('failRequest', { message: err.message });
-          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,6 +8,10 @@ export default {
     targetCategory: '',
     disabled: false,
     doneMessage: '',
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     addCategory(state, addCategory) {
@@ -35,9 +39,17 @@ export default {
     clearTargetInput(state) {
       state.targetCategory = '';
     },
+    confirmDeleteCategory(state, confirmCategory) {
+      state.deleteCategory.id = confirmCategory.id;
+      state.deleteCategory.name = confirmCategory.name;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategory.id = null;
+    },
   },
   getters: {
     targetCategory: state => state.targetCategory,
+    deleteCategoryId: state => state.deleteCategory.id,
   },
   actions: {
     setTargetCategory({ commit }, category) {
@@ -77,6 +89,25 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    confirmDeleteCategory({ commit }, confirmCategory) {
+      commit('confirmDeleteCategory', confirmCategory);
+    },
+    deleteCategory({ commit, rootGetters }) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        }).then(() => {
+          commit('doneDeleteCategory');
+          resolve();
+          commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+          reject();
+        });
+      });
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-939
## やったこと
* 削除ボタンを押すとモーダルが表示されるメソッドを追加
* モーダルに対象カテゴリ名を表示
* モーダル内の削除ボタンを押すとAPIで削除リクエストを送るメソッドを追加
* API通信に成功すると対象カテゴリ削除済みの一覧を表示
* API通信成功時・失敗時にそれぞれメッセージを表示
## やらないこと
* なし
## テスト
https://gizumo.backlog.com/view/GIZFE-941
## 特にレビューをお願いしたい箇所
削除済みの一覧を表示させる方法として、最新の一覧を再表示させる方法しか思いつかなかったのですが
他に方法があればアドバイスいただきたいです。