### PR TITLE
Feature/GIZFE-942 カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <form @submit.prevent="putCategory">
+  <form @submit.prevent="handleSubmit">
     <app-heading :level="1">カテゴリー管理</app-heading>
     <app-router-link
       class="category-edit__link"
@@ -80,7 +80,7 @@ export default {
     },
   },
   methods: {
-    putCategory() {
+    handleSubmit() {
       if (!this.access.edit) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,109 @@
+<template>
+  <form @submit.prevent="putCategory">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      class="category-edit__link"
+      underline
+      hover-opacity
+      :to="`/categories`"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      class="category-edit__input"
+      name="category"
+      type="text"
+      placeholder="編集するカテゴリー名を入力してください"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="categoryName"
+      @update-value="$emit('update-value', $event)"
+    />
+    <app-button
+      class="category-edit__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.create"
+    >
+      {{ buttonText }}
+    </app-button>
+    <div v-if="errorMessage" class="category-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    categoryName: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    putCategory() {
+      if (!this.access.edit) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-edit {
+  &__link {
+    margin-top: 16px;
+  }
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -24,7 +24,7 @@
       class="category-edit__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.create"
+      :disabled="disabled || !access.edit"
     >
       {{ buttonText }}
     </app-button>
@@ -75,7 +75,7 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '更新権限がありません';
+      if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
     },
   },

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -8,6 +8,7 @@ import UserCreate from './UserCreate/index.vue';
 import UserTable from './UserTable/index.vue';
 import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
@@ -27,6 +28,7 @@ export {
   UserTable,
   UserDetail,
   UserList,
+  CategoryEdit,
   CategoryPost,
   CategoryList,
   ArticleEdit,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -38,7 +38,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getEditCategory', this.$route.params.id);
+    this.$store.dispatch('categories/getCategoryDetail', this.$route.params.id);
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <app-category-edit
+      :access="access"
+      :disabled="disabled"
+      :category-name="categoryName"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      @update-value="setEditCategory"
+      @clear-message="clearMessage"
+      @handle-submit="putCategory"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    categoryName() {
+      return this.$store.state.categories.targetEditCategory.name;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getEditCategory', this.$route.params.id);
+    this.$store.dispatch('categories/clearMessage');
+  },
+  methods: {
+    setEditCategory($event) {
+      this.$store.dispatch('categories/setEditCategory', $event.target.value);
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    putCategory() {
+      this.$store.dispatch('categories/putCategory');
+    },
+  },
+};
+</script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryPostList from '@Pages/Categories/PostList.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -64,6 +65,11 @@ const router = new VueRouter({
           name: 'categoryPostList',
           path: '',
           component: CategoryPostList,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -138,12 +138,13 @@ export default {
       };
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${getters.targetEditCategory.id}`,
+        url: `/ategory/${getters.targetEditCategory.id}`,
         data,
       }).then(() => {
         commit('toggleLoading');
         commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
       }).catch(err => {
+        commit('toggleLoading');
         commit('failRequest', { message: err.message });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,6 +12,10 @@ export default {
       id: null,
       name: '',
     },
+    targetEditCategory: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     addCategory(state, addCategory) {
@@ -45,10 +49,17 @@ export default {
     doneDeleteCategory(state) {
       state.deleteCategory.id = null;
     },
+    getEditCategory(state, editCategory) {
+      state.targetEditCategory = editCategory;
+    },
+    setEditCategory(state, editedCategory) {
+      state.targetEditCategory.name = editedCategory;
+    },
   },
   getters: {
     targetCategory: state => state.targetCategory,
     deleteCategoryId: state => state.deleteCategory.id,
+    targetEditCategory: state => state.targetEditCategory,
   },
   actions: {
     setTargetCategory({ commit }, category) {
@@ -105,6 +116,35 @@ export default {
         }).catch(err => {
           commit('failRequest', { message: err.message });
         });
+      });
+    },
+    getEditCategory({ commit, rootGetters }, editCategoryId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${editCategoryId}`,
+      }).then(res => {
+        const editCategory = res.data.category;
+        commit('getEditCategory', editCategory);
+      });
+    },
+    setEditCategory({ commit }, editedCategory) {
+      commit('setEditCategory', editedCategory);
+    },
+    putCategory({ commit, rootGetters, getters }) {
+      commit('clearMessage');
+      commit('toggleLoading');
+      const data = {
+        name: getters.targetEditCategory.name,
+      };
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${getters.targetEditCategory.id}`,
+        data,
+      }).then(() => {
+        commit('toggleLoading');
+        commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -49,7 +49,7 @@ export default {
     doneDeleteCategory(state) {
       state.deleteCategory.id = null;
     },
-    getEditCategory(state, editCategory) {
+    getCategoryDetail(state, editCategory) {
       state.targetEditCategory = editCategory;
     },
     setEditCategory(state, editedCategory) {
@@ -118,13 +118,13 @@ export default {
         });
       });
     },
-    getEditCategory({ commit, rootGetters }, editCategoryId) {
+    getCategoryDetail({ commit, rootGetters }, editCategoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${editCategoryId}`,
       }).then(res => {
         const editCategory = res.data.category;
-        commit('getEditCategory', editCategory);
+        commit('getCategoryDetail', editCategory);
       });
     },
     setEditCategory({ commit }, editedCategory) {
@@ -138,7 +138,7 @@ export default {
       };
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/ategory/${getters.targetEditCategory.id}`,
+        url: `/category/${getters.targetEditCategory.id}`,
         data,
       }).then(() => {
         commit('toggleLoading');


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-942
## やったこと
* 更新画面へのルーティング
* 更新画面のpage,molecule作成
* スタイルの調整
* API通信で入力欄に初期値を設定
* API通信で一覧に編集内容を反映
* 更新ボタンを押した後、通信成功時・失敗時のメッセージ表示
## やらないこと
* なし
## テスト
<!-- Backlogのテストチケットのリンクを記載 -->
https://gizumo.backlog.com/view/GIZFE-944
## 特にレビューをお願いしたい箇所
メソッドや引数の値の命名が不自然ではないか確認していただきたいです。