### PR TITLE
カテゴリー更新画面実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -34,7 +34,7 @@
       class="category-edit-submit"
       button-type="submit"
       round
-      :disabled="!disabled"
+      :disabled="disabled"
       @click="handleSubmit"
     >
       {{ buttonText }}
@@ -80,18 +80,20 @@ export default {
       type: String,
       default: '',
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
-    disabled() {
-      return this.access.edit && !this.loading;
-    },
     buttonText() {
-      if (!this.access.create) return '作成権限がありません';
-      return this.disabled ? '更新' : '更新中...';
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {
     updateValue($event) {
+      this.$emit('clear-message');
       this.$emit('update-value', $event);
     },
     handleSubmit() {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,122 @@
+<template>
+  <section class="category-edit">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="category-edit__back">
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        to="/categories"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+    <form class="category-edit__title">
+      <div class="category-edit__title__name">
+        <app-input
+          v-validate="'required'"
+          name="category"
+          type="text"
+          data-vv-as="カテゴリー名"
+          :value="categoryName"
+          @update-value="updateValue"
+        />
+      </div>
+      <div v-if="errorMessage" class="category-edited__notice">
+        <app-text bg-error>{{ errorMessage }}</app-text>
+      </div>
+      <div v-if="doneMessage" class="category-edited__notice">
+        <app-text bg-success>{{ doneMessage }}</app-text>
+      </div>
+    </form>
+    <app-button
+      class="category-edit-submit"
+      button-type="submit"
+      round
+      :disabled="!disabled"
+      @click="handleSubmit"
+    >
+      {{ buttonText }}
+    </app-button>
+  </section>
+</template>
+
+<script>
+import {
+  Heading,
+  RouterLink,
+  Input,
+  Button,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    categoryName: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+    buttonText() {
+      if (!this.access.create) return '作成権限がありません';
+      return this.disabled ? '更新' : '更新中...';
+    },
+  },
+  methods: {
+    updateValue($event) {
+      this.$emit('update-value', $event);
+    },
+    handleSubmit() {
+      if (!this.access.edit) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-edit {
+  &__back {
+    margin-top: 20px;
+  }
+  &__title {
+    margin-top: 20px;
+  }
+  &-submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -6,7 +6,6 @@
     :done-message="doneMessage"
     :error-message="errorMessage"
     :disabled="loading ? true : false"
-    :button-text="buttonText"
     @clear-message="clearMessage"
     @update-value="updateValue"
     @handle-submit="handleSubmit"
@@ -15,13 +14,11 @@
 
 <script>
 import { CategoryEdit } from '@Components/molecules';
-import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
-  mixins: [Mixins],
   computed: {
     loading() {
       return this.$store.state.categories.loading;
@@ -38,9 +35,6 @@ export default {
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
-    },
-    buttonText() {
-      return this.disabled ? '更新' : '更新中...';
     },
   },
   created() {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,65 @@
+<template>
+  <app-category-edit
+    :access="access"
+    :loading="loading"
+    :category-name="categoryName"
+    :done-message="doneMessage"
+    :error-message="errorMessage"
+    :disabled="loading ? true : false"
+    :button-text="buttonText"
+    @clear-message="clearMessage"
+    @update-value="updateValue"
+    @handle-submit="handleSubmit"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  mixins: [Mixins],
+  computed: {
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    categoryName() {
+      const { name } = this.$store.state.categories.targetCategory.category;
+      return name;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    buttonText() {
+      return this.disabled ? '更新' : '更新中...';
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategory', this.$route.params.id);
+    this.$store.dispatch('categories/clearMessage');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory', this.$route.params.id);
+    },
+    updateValue(event) {
+      if (
+        !this.loading
+      ) this.$store.dispatch('categories/updateValue', event.target.value);
+    },
+  },
+};
+</script>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -65,6 +65,7 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     clearMessage() {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -9,6 +9,7 @@ import Home from '@Pages/Home/index.vue';
 
 import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/List.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -78,6 +79,11 @@ const router = new VueRouter({
           name: 'categoryList',
           path: '',
           component: CategoryList,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -58,8 +58,7 @@ export default {
     doneAddCategory(state) {
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
     },
-    doneEditCategory(state, { targetCategory }) {
-      state.targetCategory = { ...state.targetCategory, ...targetCategory };
+    doneEditCategory(state) {
       state.loading = false;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
@@ -151,7 +150,6 @@ export default {
           name: response.data.category.name,
         };
         commit('updateValue');
-        commit('toggleLoading');
         commit('doneEditCategory', { editedCategory });
       }).catch(err => {
         commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -46,8 +46,8 @@ export default {
         },
       };
     },
-    updateValue(state, { category, value }) {
-      state.category = { ...state.category, [category]: value };
+    updateValue(state, value) {
+      state.targetCategory.name = value;
     },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
@@ -58,6 +58,11 @@ export default {
     doneAddCategory(state) {
       state.doneMessage = '新規カテゴリーの追加が完了しました。';
     },
+    doneEditCategory(state, { targetCategory }) {
+      state.targetCategory = { ...state.targetCategory, ...targetCategory };
+      state.loading = false;
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
     setTargetCategory(state, { categoryId, categoryName }) {
       state.deleteCategory.id = categoryId;
       state.deleteCategory.name = categoryName;
@@ -65,6 +70,9 @@ export default {
     doneDeleteCategory(state) {
       state.deleteCategory.id = null;
       state.doneMessage = 'カテゴリー削除が完了しました。';
+    },
+    doneGetCategory(state, payload) {
+      state.targetCategory.category = payload;
     },
     toggleLoading(state) {
       state.loading = !state.loading;
@@ -77,8 +85,8 @@ export default {
     initPostCategory({ commit }) {
       commit('initPostCategory');
     },
-    updateValue({ commit }, target) {
-      commit('updateValue', target);
+    updateValue({ commit }, value) {
+      commit('updateValue', value);
     },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
@@ -126,6 +134,44 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
         commit('toggleLoading');
+      });
+    },
+    updateCategory({ commit, rootGetters, state }, id) {
+      commit('toggleLoading');
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${id}`,
+        data: {
+          name: state.targetCategory.name,
+        },
+      }).then(response => {
+        if (response.data.code === 0) throw new Error(response.data.message);
+        const editedCategory = {
+          id: response.data.category.id,
+          name: response.data.category.name,
+        };
+        commit('updateValue');
+        commit('toggleLoading');
+        commit('doneEditCategory', { editedCategory });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+        commit('toggleLoading');
+      });
+    },
+    getCategory({ commit, rootGetters }, category) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${category}`,
+      }).then(response => {
+        if (response.data.code === 0) throw new Error(response.data.message);
+        const data = response.data.category;
+        const categoryName = {
+          id: data.id,
+          name: data.name,
+        };
+        commit('doneGetCategory', categoryName);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-933

## やったこと
・カテゴリー更新画面のページ追加。
・カテゴリー一覧画面で「更新」ボタンを押すと、カテゴリー更新画面に遷移する。
・画面遷移時、更新画面の入力フォームに対象のカテゴリー名が表示されている。
・更新画面の「更新」ボタンを押すと、API通信が行われ、カテゴリー名が更新される。
・API通信中はボタンが「更新中」になり押せない状態となる。
・API通信後、更新完了のメッセージが出る。
・カテゴリー名を変えずにそのまま「更新」ボタンを押すと、エラーメッセージが出る。
・「カテゴリー一覧へ戻る」のボタンを押すとカテゴリー一覧画面へと遷移する。
・ページ遷移時、更新・削除・作成の完了メッセージが消える。

## やらないこと
・カテゴリー一覧画面の「このカテゴリーの記事」のボタンを押した際のページ遷移。

## テスト
https://gizumo.backlog.com/view/GIZFE-935

## 特にレビューをお願いしたい箇所
なし
