### PR TITLE
カテゴリー新規作成機能の追加

### DIFF
--- a/src/components/pages/Categories/Categories.vue
+++ b/src/components/pages/Categories/Categories.vue
@@ -7,8 +7,8 @@
       :access="access"
       :error-message="errorMessage"
       :done-message="doneMessage"
-      :category="category"
-      @reset-message="resetMessage"
+      :category="categoryName"
+      :disabled="loading"
       @clear-message="clearMessage"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
@@ -39,8 +39,8 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
-    category() {
-      return this.$store.state.categories.category.name;
+    categoryName() {
+      return this.$store.state.categories.categoryName;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -62,16 +62,11 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    resetMessage() {
-      this.$store.dispatch('categories/resetMessage');
-    },
     updateValue(event) {
-      const { target } = event;
-      this.$store.dispatch('categories/updateValue', target.value);
+      this.$store.dispatch('categories/updateValue', event.target.value);
     },
     handleSubmit() {
-      const categoryName = this.category;
-      this.$store.dispatch('categories/createCategories', categoryName).then(() => {
+      this.$store.dispatch('categories/createCategories', this.categoryName).then(() => {
         this.$store.dispatch('categories/getAllCategories');
         this.$store.dispatch('categories/resetMessage');
       });

--- a/src/components/pages/Categories/Categories.vue
+++ b/src/components/pages/Categories/Categories.vue
@@ -6,6 +6,12 @@
       class="category-post"
       :access="access"
       :error-message="errorMessage"
+      :done-message="doneMessage"
+      :category="category"
+      @reset-message="resetMessage"
+      @clear-message="clearMessage"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       class="category-list"
@@ -30,6 +36,12 @@ export default {
     };
   },
   computed: {
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    category() {
+      return this.$store.state.categories.category.name;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -39,9 +51,31 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    resetMessage() {
+      this.$store.dispatch('categories/resetMessage');
+    },
+    updateValue(event) {
+      const { target } = event;
+      this.$store.dispatch('categories/updateValue', target.value);
+    },
+    handleSubmit() {
+      const categoryName = this.category;
+      this.$store.dispatch('categories/createCategories', categoryName).then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+        this.$store.dispatch('categories/resetMessage');
+      });
+    },
   },
 };
 </script>

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,11 +5,38 @@ export default {
   state: {
     loading: false,
     errorMessage: '',
+    doneMessage: '',
     categoryList: [],
+    category: {
+      id: null,
+      name: '',
+    },
+    value: '',
   },
   mutations: {
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
+    resetMessage(state) {
+      state.category.id = '';
+      state.category.name = '';
+      state.value = '';
+    },
+    updateValue(state, target) {
+      state.category.name = target;
+    },
+    doneCreateCategories(state, categories) {
+      state.categoryList = categories;
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
+    },
+    doneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
@@ -17,6 +44,35 @@ export default {
     },
   },
   actions: {
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
+    resetMessage({ commit }) {
+      commit('resetMessage');
+    },
+    updateValue({ commit }, target) {
+      commit('updateValue', target);
+    },
+    createCategories({ commit, rootGetters }, category) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', category);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(response => {
+          commit('doneCreateCategories', response.categories);
+          commit('doneMessage', { message: 'カテゴリーの作成が成功しました' });
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+          reject();
+        });
+      });
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,11 +7,7 @@ export default {
     errorMessage: '',
     doneMessage: '',
     categoryList: [],
-    category: {
-      id: null,
-      name: '',
-    },
-    value: '',
+    categoryName: '',
   },
   mutations: {
     clearMessage(state) {
@@ -19,12 +15,10 @@ export default {
       state.doneMessage = '';
     },
     resetMessage(state) {
-      state.category.id = '';
-      state.category.name = '';
-      state.value = '';
+      state.categoryName = '';
     },
     updateValue(state, target) {
-      state.category.name = target;
+      state.categoryName = target;
     },
     doneCreateCategories(state, categories) {
       state.categoryList = categories;
@@ -54,7 +48,7 @@ export default {
       commit('updateValue', target);
     },
     createCategories({ commit, rootGetters }, category) {
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         commit('clearMessage');
         commit('toggleLoading');
         const data = new URLSearchParams();
@@ -66,10 +60,10 @@ export default {
         }).then(response => {
           commit('doneCreateCategories', response.categories);
           commit('doneMessage', { message: 'カテゴリーの作成が成功しました' });
+          commit('toggleLoading');
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
-          reject();
         });
       });
     },


### PR DESCRIPTION
親チケット
https://gizumo.backlog.com/view/GIZFE-948


## やったこと
・作成ボタンがクリックされたら、新規作成APIを実行
・成功時、一覧画面が更新されメッセージを表示
・失敗時、APIから返ってきたエラーメッセージの表示 
・追加されたカテゴリーはカテゴリー一覧の一番上に表示
・テスト 

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-950

## 特にレビューをお願いしたい箇所
もっとわかりやすい、シンプルな書き方があれば助言いただければと思います。
