### PR TITLE
カテゴリー新規作成機能の追加

### DIFF
--- a/src/components/pages/Categories/Categories.vue
+++ b/src/components/pages/Categories/Categories.vue
@@ -59,9 +59,6 @@ export default {
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {
-    clearMessage() {
-      this.$store.dispatch('categories/clearMessage');
-    },
     addCategory() {
       if (this.disabled) return;
       this.$store.dispatch('categories/addCategory').then(() => {

--- a/src/components/pages/Categories/Categories.vue
+++ b/src/components/pages/Categories/Categories.vue
@@ -1,9 +1,14 @@
 <template>
   <div class="category">
     <app-category-Post
+      :category="targetCategory"
       :access="access"
       :error-message="errorMessage"
+      :done-message="doneMessage"
+      :disabled="disabled"
       class="category-form"
+      @handle-submit="addCategory"
+      @update-value="updatedCategory"
     />
     <app-category-list
       :theads="theads"
@@ -36,12 +41,36 @@ export default {
     categories() {
       return this.$store.state.categories.categoryList;
     },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    targetCategory() {
+      return this.$store.state.categories.targetCategory;
+    },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
     },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/clearMessage');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    addCategory() {
+      if (this.disabled) return;
+      this.$store.dispatch('categories/addCategory').then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+    },
+    updatedCategory($event) {
+      this.$store.dispatch('categories/updatedCategory', $event.target.value);
+    },
   },
 };
 </script>

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,18 +3,68 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    categories: [],
+    targetCategory: '',
     categoryList: [],
+    disabled: false,
+    loading: false,
     errorMessage: '',
+    doneMessage: '',
   },
   mutations: {
+    initTargetCategory(state) {
+      state.targetCategory = '';
+    },
+    resetMessage(state) {
+      state.targetCategory = '';
+    },
+    addCategory(state, addCategory) {
+      state.categories.unshift(addCategory);
+    },
+    setTargetCategory(state, category) {
+      state.targetCategory = category;
+    },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
+    },
+    doneAddCategory(state) {
+      state.loading = false;
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
+    },
+    updateCategory(state, payload) {
+      state.targetCategory = payload;
+    },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
+    toggleLoading(state) {
+      state.disabled = !state.disabled;
+    },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
   },
+  getters: {
+    targetCategory: state => state.targetCategory,
+    categoryList: state => state.categoryList,
+  },
   actions: {
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
+    initTargetCategory({ commit }) {
+      commit('initTargetCategory');
+    },
+    resetMessage({ commit }) {
+      commit('resetMessage');
+    },
+    updatedCategory({ commit }, category) {
+      commit('updateCategory', category);
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -23,6 +73,30 @@ export default {
         commit('doneGetAllCategories', data.categories);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+
+    addCategory({ commit, rootGetters }) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+
+        const data = new URLSearchParams();
+        data.append('name', rootGetters['categories/targetCategory']);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('resetMessage');
+          commit('toggleLoading');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          resolve();
+        }).catch(err => {
+          commit('toggleLoading');
+          commit('failRequest', { message: err.message });
+          reject();
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -6,7 +6,6 @@ export default {
     targetCategory: '',
     categoryList: [],
     disabled: false,
-    loading: false,
     errorMessage: '',
     doneMessage: '',
   },
@@ -19,10 +18,6 @@ export default {
     },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
-    },
-    doneAddCategory(state) {
-      state.loading = false;
-      state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
     updateCategory(state, payload) {
       state.targetCategory = payload;
@@ -70,7 +65,7 @@ export default {
     },
 
     addCategory({ commit, rootGetters }) {
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         commit('clearMessage');
         commit('toggleLoading');
 
@@ -88,7 +83,6 @@ export default {
         }).catch(err => {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });
-          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,7 +3,6 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    categories: [],
     targetCategory: '',
     categoryList: [],
     disabled: false,
@@ -17,12 +16,6 @@ export default {
     },
     resetMessage(state) {
       state.targetCategory = '';
-    },
-    addCategory(state, addCategory) {
-      state.categories.unshift(addCategory);
-    },
-    setTargetCategory(state, category) {
-      state.targetCategory = category;
     },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();


### PR DESCRIPTION
<!-- 各項目のコメントアウトは削除すること（このコメントアウトも削除） -->
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-951

## やったこと
・作成ボタンがクリックされたら、新規作成APIを実行
・成功時、一覧画面が更新されメッセージを表示
・失敗時、APIから返ってきたエラーメッセージの表示
・追加されたカテゴリーはカテゴリー一覧の一番上に表示
・テスト

## やらないこと
なし
## テスト
<!-- Backlogのテストチケットのリンクを記載 -->
https://gizumo.backlog.com/view/GIZFE-953

## 特にレビューをお願いしたい箇所
コードの間違いやわかりやすいコードの書き方がありましたら、教えて頂きたいです。