### PR TITLE
カテゴリー削除機能

### DIFF
--- a/src/components/pages/Categories/Categories.vue
+++ b/src/components/pages/Categories/Categories.vue
@@ -18,9 +18,9 @@
       :theads="theads"
       :categories="categories"
       :access="access"
-      :delete-category-name="deleteCategoryName"
+      :delete-category-name="deleteCategory.name"
       @open-modal="openDeleteModal"
-      @handle-click="deleteCategory"
+      @handle-click="deleteInCategory"
     />
   </div>
 </template>
@@ -38,7 +38,6 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
-      categoryId: null,
     };
   },
   computed: {
@@ -60,11 +59,8 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
-    deleteCategoryName() {
-      return this.$store.state.categories.deleteCategory.name;
-    },
-    deleteCategoryId() {
-      return this.$store.state.categories.deleteCategory.id;
+    deleteCategory() {
+      return this.$store.state.categories.deleteCategory;
     },
   },
   created() {
@@ -88,9 +84,9 @@ export default {
       this.$store.dispatch('categories/clearMessage');
       this.$store.dispatch('categories/openDeleteModal', { categoryName, categoryId });
     },
-    deleteCategory() {
+    deleteInCategory() {
       this.toggleModal();
-      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategory)
         .then(() => {
           this.$store.dispatch('categories/getAllCategories');
           this.$store.dispatch('categories/resetMessage');

--- a/src/components/pages/Categories/Categories.vue
+++ b/src/components/pages/Categories/Categories.vue
@@ -18,21 +18,27 @@
       :theads="theads"
       :categories="categories"
       :access="access"
+      :delete-category-name="deleteCategoryName"
+      @open-modal="openDeleteModal"
+      @handle-click="deleteCategory"
     />
   </div>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
+      categoryId: null,
     };
   },
   computed: {
@@ -54,6 +60,12 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategory.name;
+    },
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategory.id;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -70,6 +82,19 @@ export default {
         this.$store.dispatch('categories/getAllCategories');
         this.$store.dispatch('categories/resetMessage');
       });
+    },
+    openDeleteModal(categoryId, categoryName) {
+      this.toggleModal();
+      this.$store.dispatch('categories/clearMessage');
+      this.$store.dispatch('categories/openDeleteModal', { categoryName, categoryId });
+    },
+    deleteCategory() {
+      this.toggleModal();
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+          this.$store.dispatch('categories/resetMessage');
+        });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -96,9 +96,8 @@ export default {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `/category/${id}`,
-        }).then(response => {
+        }).then(() => {
           commit('doneMessage', { message: 'カテゴリーの削除が成功しました' });
-          commit('deleteCategory', response.categories);
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,6 +8,10 @@ export default {
     doneMessage: '',
     categoryList: [],
     categoryName: '',
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -28,6 +32,13 @@ export default {
     },
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
+    },
+    openDeleteModal(state, { categoryId, categoryName }) {
+      state.deleteCategory.id = categoryId;
+      state.deleteCategory.name = categoryName;
+    },
+    deleteCategory(state, categories) {
+      state.categoryList = categories;
     },
     doneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
@@ -75,6 +86,23 @@ export default {
         commit('doneGetAllCategories', data.categories);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    openDeleteModal({ commit }, { categoryId, categoryName }) {
+      commit('openDeleteModal', { categoryName, categoryId });
+    },
+    deleteCategory({ commit, rootGetters }, id) {
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${id}`,
+        }).then(response => {
+          commit('doneMessage', { message: 'カテゴリーの削除が成功しました' });
+          commit('deleteCategory', response.categories);
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -91,7 +91,7 @@ export default {
     openDeleteModal({ commit }, { categoryId, categoryName }) {
       commit('openDeleteModal', { categoryName, categoryId });
     },
-    deleteCategory({ commit, rootGetters }, id) {
+    deleteCategory({ commit, rootGetters }, { id }) {
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-973

## やったこと
・削除ボタンを押したら、削除確認用のモーダルが出現
・削除確認用のモーダルに、削除対象のカテゴリ名が表示
・削除確認用のモーダル内部の削除ボタンをクリックした場合削除APIが実行
・成功したら一覧が更新され、メッセージを表示

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-975

## 特にレビューをお願いしたい箇所
もっと効率的かつシンプルな記述方法があれば助言いただければと思います。
