### PR TITLE
feat: カテゴリー削除機能の追加

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -69,7 +69,10 @@ export default {
   },
   methods: {
     openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/confirmDeleteCategory', { id: categoryId, name: categoryName });
+      this.$store.dispatch('categories/confirmDeleteCategory', {
+        id: categoryId,
+        name: categoryName,
+      });
       this.toggleModal();
     },
     handleClick() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -69,8 +69,7 @@ export default {
   },
   methods: {
     openModal(categoryId, categoryName) {
-      const categoryData = { id: categoryId, name: categoryName };
-      this.$store.dispatch('categories/confirmDeleteCategory', categoryData);
+      this.$store.dispatch('categories/confirmDeleteCategory', { id: categoryId, name: categoryName });
       this.toggleModal();
     },
     handleClick() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,6 +16,9 @@
         :access="access"
         :categories="categories"
         :theads="theads"
+        :delete-category-name="deleteCategoryName"
+        @open-modal="openModal"
+        @handle-click="handleClick"
       />
     </div>
   </div>
@@ -23,12 +26,14 @@
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -53,6 +58,9 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategory.name;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -60,6 +68,17 @@ export default {
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {
+    openModal(categoryId, categoryName) {
+      const categoryData = { id: categoryId, name: categoryName };
+      this.$store.dispatch('categories/confirmDeleteCategory', categoryData);
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+      this.toggleModal();
+    },
     updateValue($event) {
       this.$store.dispatch('categories/updateCategory', $event.target.value);
     },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -75,8 +75,8 @@ export default {
     handleClick() {
       this.$store.dispatch('categories/deleteCategory').then(() => {
         this.$store.dispatch('categories/getAllCategories');
+        this.toggleModal();
       });
-      this.toggleModal();
     },
     updateValue($event) {
       this.$store.dispatch('categories/updateCategory', $event.target.value);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -119,12 +119,9 @@ export default {
     deleteCategory({ commit, rootGetters }) {
       return new Promise((resolve, reject) => {
         commit('clearMessage');
-        const data = new URLSearchParams();
-        data.append('id', rootGetters['categories/deleteCategory']);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `category/${rootGetters['categories/deleteCategory']}`,
-          data,
         }).then(() => {
           commit('doneDeleteCategory');
           commit('doneDisplayMessage', { message: 'カテゴリーを削除しました！' });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -38,7 +38,6 @@ export default {
       state.deleteCategory = { ...state.deleteCategory, ...categoryData };
     },
     donePostCategory(state, payload) {
-      state.doneMessage = '新規カテゴリの追加が完了しました。';
       state.categoryList.unshift(payload);
     },
     doneDeleteCategory(state) {
@@ -56,7 +55,7 @@ export default {
         name: '',
       };
     },
-    displayDoneMessage(state, payload) {
+    doneDisplayMessage(state, payload) {
       state.doneMessage = payload.message;
     },
   },
@@ -105,6 +104,7 @@ export default {
           commit('initCategory');
           commit('toggleLoading');
           commit('donePostCategory', postCategory);
+          commit('doneDisplayMessage', { message: 'カテゴリーを追加しました！' });
           resolve();
         }).catch(err => {
           commit('toggleLoading');
@@ -127,7 +127,7 @@ export default {
           data,
         }).then(() => {
           commit('doneDeleteCategory');
-          commit('displayDoneMessage', { message: 'カテゴリーを削除しました！' });
+          commit('doneDisplayMessage', { message: 'カテゴリーを削除しました！' });
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -34,8 +34,8 @@ export default {
     updateCategory(state, payload) {
       state.category = { ...state.category, name: payload.name };
     },
-    confirmDeleteCategory(state, { categoryData }) {
-      state.deleteCategory = { ...state.deleteCategory, ...categoryData };
+    confirmDeleteCategory(state, { category }) {
+      state.deleteCategory = { ...state.deleteCategory, ...category };
     },
     donePostCategory(state, payload) {
       state.categoryList.unshift(payload);
@@ -85,8 +85,8 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
-    confirmDeleteCategory({ commit }, categoryData) {
-      commit('confirmDeleteCategory', { categoryData });
+    confirmDeleteCategory({ commit }, category) {
+      commit('confirmDeleteCategory', { category });
     },
     postCategory({ commit, rootGetters }) {
       return new Promise(resolve => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -21,7 +21,6 @@ export default {
     deleteCategory: state => state.deleteCategory.id,
   },
   mutations: {
-
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
     },


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1041

## やったこと
・削除ボタンを押すと削除確認用のモーダルが出現する
・削除確認用のモーダルに、削除対象のカテゴリ名を表示する
・削除確認用のモーダル内部の削除ボタンをクリックすると削除APIの実行
・削除完了後、一覧が更新されて、メッセージを表示する。

## やらないこと
特になし。

## テスト
https://gizumo.backlog.com/view/GIZFE-1043

## 特にレビューをお願いしたい箇所
・モーダルのイベントから値を持ってくる際の、値の持って行き方
・Promiseの使い方