### PR TITLE
feat: カテゴリー更新機能の実装

### DIFF
--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -29,7 +29,7 @@
         class="category-update-info__submit"
         button-type="submit"
         round
-        :disabled="disabled || !access.create"
+        :disabled="disabled || !access.edit"
       >
         {{ buttonText }}
       </app-button>
@@ -82,13 +82,13 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '更新権限がありません';
+      if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {
     updateCategory() {
-      if (!this.access.create) return;
+      if (!this.access.edit) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('update-category');

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -1,0 +1,120 @@
+<template>
+  <section class="category-update">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+
+    <div class="category-update__back">
+      <app-router-link
+        underline
+        key-color
+        hover-opacity
+        to="/categories"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+
+    <form class="category-update__info" @submit.prevent="updateCategory">
+      <app-input
+        v-validate="'required'"
+        class="category-update-info__input"
+        name="category"
+        type="text"
+        placeholder="更新するカテゴリー名を入力してください"
+        data-vv-as="カテゴリー名"
+        :error-messages="errors.collect('category')"
+        :value="category.name"
+        @update-value="$emit('update-value', $event.target)"
+      />
+      <app-button
+        class="category-update-info__submit"
+        button-type="submit"
+        round
+        :disabled="disabled || !access.create"
+      >
+        {{ buttonText }}
+      </app-button>
+
+      <div v-if="errorMessage" class="category-update-info__notice">
+        <app-text bg-error>{{ errorMessage }}</app-text>
+      </div>
+
+      <div v-if="doneMessage" class="category-update-info__notice">
+        <app-text bg-success>{{ doneMessage }}</app-text>
+      </div>
+    </form>
+  </section>
+</template>
+
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    category: {
+      type: Object,
+      default: () => ({}),
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.create) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    updateCategory() {
+      if (!this.access.create) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('update-category');
+      });
+    },
+  },
+};
+
+</script>
+
+<style lang="scss" scoped>
+.category-update {
+  &__back {
+    display: inline-block;
+    margin-top: 20px;
+  }
+  &-info {
+    &__input {
+      margin-top: 20px;
+    }
+    &__submit {
+      margin-top: 20px;
+    }
+    &__notice {
+      margin-top: 20px;
+    }
+  }
+}
+</style>

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -96,7 +96,6 @@ export default {
     },
   },
 };
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryUpdate from './CategoryUpdate/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryUpdate,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -82,7 +82,7 @@ export default {
       });
     },
     updateValue($event) {
-      this.$store.dispatch('categories/updateCategory', $event.target.value);
+      this.$store.dispatch('categories/updateValue', $event.target.value);
     },
     handleSubmit() {
       if (this.loading) return;

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -40,9 +40,6 @@ export default {
     this.$store.dispatch('categories/getCategory', id);
     this.$store.dispatch('categories/clearMessage');
   },
-  destroyed() {
-    this.$store.dispatch('categories/clearMessage');
-  },
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -1,0 +1,62 @@
+<template>
+  <app-category-update
+    :error-message="errorMessage"
+    :done-message="doneMessage"
+    :category="category"
+    :disabled="loading"
+    :access="access"
+    @clear-message="clearMessage"
+    @update-value="updateValue"
+    @update-category="updateCategory"
+  />
+</template>
+
+<script>
+import { CategoryUpdate } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryUpdate: CategoryUpdate,
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    category() {
+      return this.$store.state.categories.category;
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategory', id);
+    this.$store.dispatch('categories/clearMessage');
+  },
+  destroyed() {
+    this.$store.dispatch('categories/clearMessage');
+  },
+  methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event.value);
+    },
+    updateCategory() {
+      this.$store.dispatch('categories/updateCategory', {
+        id: this.category.id,
+        name: this.category.name,
+      });
+    },
+  },
+};
+
+</script>

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -47,8 +47,8 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    updateValue($event) {
-      this.$store.dispatch('categories/updateValue', $event.value);
+    updateValue($eventTarget) {
+      this.$store.dispatch('categories/updateValue', $eventTarget.value);
     },
     updateCategory() {
       this.$store.dispatch('categories/updateCategory', {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/List.vue';
+import CategoryUpdate from '@Pages/Categories/Update.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -64,6 +65,11 @@ const router = new VueRouter({
           name: 'CategoryList',
           path: '',
           component: CategoryList,
+        },
+        {
+          name: 'CategoryUpdate',
+          path: ':id',
+          component: CategoryUpdate,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -95,10 +95,7 @@ export default {
       commit('initCategory');
     },
     updateValue({ commit }, name) {
-      commit({
-        type: 'updateValue',
-        name,
-      });
+      commit('updateValue', { name });
     },
     clearMessage({ commit }) {
       commit('clearMessage');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -151,6 +151,7 @@ export default {
         commit('doneGetCategory', { updateCategory });
         commit('doneDisplayMessage', { message: 'カテゴリーの更新が完了しました！' });
       }).catch(err => {
+        commit('toggleLoading');
         if (err.data) {
           commit('failRequest', { message: err.response.data.message });
         } else {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -82,10 +82,9 @@ export default {
         url: `category/${id}`,
       }).then(response => {
         if (response.data.code === 0) throw new Error(response.data.message);
-        const data = response.data.category;
         const category = {
-          id: data.id,
-          name: data.name,
+          id: response.data.category.id,
+          name: response.data.category.name,
         };
         commit('doneGetCategory', category);
       }).catch(err => {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1050

## やったこと
・カテゴリを編集するための画面をデザインから作成
・カテゴリー更新機能の実装

## やらないこと
・要件に書いてあったことは満たしたが、変更前と同名のカテゴリーでも更新が可能な状態になっている

## テスト
https://gizumo.backlog.com/view/GIZFE-1052

## 特にレビューをお願いしたい箇所
・やらないことでも書いた部分、実装してみたさはあります。（必須だったりしますかね）
・loadingの処理の部分が少し曖昧な気がします。
