### PR TITLE
削除済み記事一覧機能実装

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__create-link"
+    >
+      削除済み記事一覧へ
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -160,6 +172,10 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+      margin-left: 10px;
+      &:first-child {
+        margin-left: 0;
+      }
     }
     &__links {
       *:not(first-child) {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -3,7 +3,6 @@
     <app-heading :level="1">削除済み記事一覧</app-heading>
     <app-router-link
       to="/articles"
-      key-color
       white
       bg-lightgreen
       small

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="Trashed">
+    <app-heading :level="1">{{ '削除済み記事一覧' }}</app-heading>
+    <app-router-link
+      to="/articles"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="Trashed__btn"
+    >
+      すべての記事一覧へ戻る
+    </app-router-link>
+    <div class="Trashed__main">
+      <table>
+        <thead>
+          <tr>
+            <th>
+              <app-text theme-color bold>タイトル</app-text>
+            </th>
+            <th>
+              <app-text theme-color bold>本文</app-text>
+            </th>
+            <th>
+              <app-text theme-color bold>作成日</app-text>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="article in targetArray" :key="article.id">
+            <td>
+              <app-text tag="span" small>
+                {{ truncateText(article.title, 30) }}
+              </app-text>
+            </td>
+            <td>
+              <app-text tag="span" small>
+                {{ truncateText(article.content, 30) }}
+              </app-text>
+            </td>
+            <td>
+              <app-text tag="span" small>
+                {{ formatDate(article.created_at) }}
+              </app-text>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  Heading,
+  RouterLink,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appRouterLink: RouterLink,
+    appText: Text,
+  },
+  props: {
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  methods: {
+    truncateText(text, maxLength) {
+      if (text.length > maxLength) {
+        return `${text.substring(0, maxLength)}...`;
+      }
+      return text;
+    },
+    formatDate(date) {
+      const formattedDate = new Date(date);
+      const year = formattedDate.getFullYear();
+      const month = String(formattedDate.getMonth() + 1).padStart(2, '0');
+      const day = String(formattedDate.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.Trashed {
+  &__btn {
+    margin-top: 16px;
+  }
+  &__main {
+    margin-top: 16px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th,
+  td {
+    padding: 10px;
+    text-align: left;
+  }
+  th {
+    border-bottom: 1px solid $separator-color;
+  }
+  tr {
+    border-bottom: 1px solid $separator-color;
+  }
+}
+</style>

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="article-trashed">
-    <app-heading :level="1">{{ '削除済み記事一覧' }}</app-heading>
+    <app-heading :level="1">削除済み記事一覧</app-heading>
     <app-router-link
       to="/articles"
       key-color

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="article-trashed">
+    <div v-if="doneMessage" class="article-trashed__notice--create">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
     <app-heading :level="1">削除済み記事一覧</app-heading>
     <app-router-link
       to="/articles"
@@ -69,6 +72,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     truncatedTitle() {
@@ -121,6 +128,9 @@ export default {
   }
   tr {
     border-bottom: 1px solid $separator-color;
+  }
+  &__notice--create {
+    margin-top: 16px;
   }
 }
 </style>

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="Trashed">
+  <div class="article-trashed">
     <app-heading :level="1">{{ '削除済み記事一覧' }}</app-heading>
     <app-router-link
       to="/articles"
@@ -9,11 +9,11 @@
       small
       round
       hover-opacity
-      class="Trashed__btn"
+      class="article-trashed__btn"
     >
       すべての記事一覧へ戻る
     </app-router-link>
-    <div class="Trashed__main">
+    <div class="article-trashed__main">
       <table>
         <thead>
           <tr>
@@ -90,7 +90,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.Trashed {
+.article-trashed {
   &__btn {
     margin-top: 16px;
   }

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -31,17 +31,17 @@
           <tr v-for="article in targetArray" :key="article.id">
             <td>
               <app-text tag="span" small>
-                {{ truncateText(article.title, 30) }}
+                {{ truncatedTitle(article.title) }}
               </app-text>
             </td>
             <td>
               <app-text tag="span" small>
-                {{ truncateText(article.content, 30) }}
+                {{ truncatedContent(article.content) }}
               </app-text>
             </td>
             <td>
               <app-text tag="span" small>
-                {{ formatDate(article.created_at) }}
+                {{ formattedDate(article.created_at) }}
               </app-text>
             </td>
           </tr>
@@ -68,6 +68,17 @@ export default {
     targetArray: {
       type: Array,
       default: () => [],
+    },
+  },
+  computed: {
+    truncatedTitle() {
+      return title => this.truncateText(title, 30);
+    },
+    truncatedContent() {
+      return content => this.truncateText(content, 30);
+    },
+    formattedDate() {
+      return date => this.formatDate(date);
     },
   },
   methods: {

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="article-trashed">
-    <div v-if="doneMessage" class="article-trashed__notice--create">
-      <app-text bg-success>{{ doneMessage }}</app-text>
+    <div v-if="errorMessage" class="category-management-list__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
     <app-heading :level="1">削除済み記事一覧</app-heading>
     <app-router-link
@@ -72,7 +72,7 @@ export default {
       type: Array,
       default: () => [],
     },
-    doneMessage: {
+    errorMessage: {
       type: String,
       default: '',
     },

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -13,6 +13,7 @@ import CategoryList from './CategoryList/index.vue';
 import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
+import ArticleTrashed from './ArticleTrashed/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
@@ -34,6 +35,7 @@ export {
   CategoryEdit,
   ArticleEdit,
   ArticlePost,
+  ArticleTrashed,
   ArticleDetail,
   DeleteModal,
   Notice,

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,7 +1,7 @@
 <template>
   <app-article-trashed
     :target-array="trashedArticleList"
-    :done-message="doneMessage"
+    :error-message="errorMessage"
   />
 </template>
 
@@ -16,8 +16,8 @@ export default {
     trashedArticleList() {
       return this.$store.state.articles.trashedArticleList;
     },
-    doneMessage() {
-      return this.$store.state.articles.doneMessage;
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
     },
   },
   created() {

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,6 +1,7 @@
 <template>
   <app-article-trashed
     :target-array="articlesList"
+    :done-message="doneMessage"
   />
 </template>
 
@@ -14,6 +15,9 @@ export default {
   computed: {
     articlesList() {
       return this.$store.state.articles.articleList;
+    },
+    doneMessage() {
+      return this.$store.state.articles.doneMessage;
     },
   },
   created() {

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,23 @@
+<template>
+  <app-article-trashed
+    :target-array="articlesList"
+  />
+</template>
+
+<script>
+import { ArticleTrashed } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashed: ArticleTrashed,
+  },
+  computed: {
+    articlesList() {
+      return this.$store.state.articles.articleList;
+    },
+  },
+  created() {
+    this.$store.dispatch('articles/getTrashedPage');
+  },
+};
+</script>

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,6 +1,6 @@
 <template>
   <app-article-trashed
-    :target-array="articlesList"
+    :target-array="trashedArticleList"
     :done-message="doneMessage"
   />
 </template>
@@ -13,8 +13,8 @@ export default {
     appArticleTrashed: ArticleTrashed,
   },
   computed: {
-    articlesList() {
-      return this.$store.state.articles.articleList;
+    trashedArticleList() {
+      return this.$store.state.articles.trashedArticleList;
     },
     doneMessage() {
       return this.$store.state.articles.doneMessage;

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -18,6 +18,7 @@ import ArticleList from '@Pages/Articles/List.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -115,6 +116,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -336,7 +336,6 @@ export default {
         const payload = {
           articles: res.data.articles,
         };
-        // commit('doneGetAllArticles', payload);
         commit('doneGetTrashedArticles', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -324,5 +324,18 @@ export default {
         });
       });
     },
+    getTrashedPage({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(res => {
+        const payload = {
+          articles: res.data.articles,
+        };
+        commit('doneGetAllArticles', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
   },
 };

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -24,6 +24,7 @@ export default {
       },
     },
     articleList: [],
+    trashedArticleList: [],
     deleteArticleId: null,
     loading: false,
     doneMessage: '',
@@ -129,6 +130,9 @@ export default {
     },
     doneGetPageData(state, metaData) {
       state.meta = metaData.meta;
+    },
+    doneGetTrashedArticles(state, payload) {
+      state.trashedArticleList = [...payload.articles];
     },
   },
   actions: {
@@ -332,7 +336,8 @@ export default {
         const payload = {
           articles: res.data.articles,
         };
-        commit('doneGetAllArticles', payload);
+        // commit('doneGetAllArticles', payload);
+        commit('doneGetTrashedArticles', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1077

## やったこと
「削除済み記事一覧へ」のボタン作成
削除済み記事一覧の画面作成
削除済み記事一覧の取得
タイトル、本文、作成日を画面に表示

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1079

## 特にレビューをお願いしたい箇所
なし
