### PR TITLE
カテゴリ一新規作成機能実装

### DIFF
--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -74,7 +74,9 @@ export default {
       if (!this.access.create) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('handle-submit');
+        if (valid) {
+          this.$emit('handle-submit');
+        }
       });
     },
   },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -62,11 +62,15 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     buttonText() {
       if (!this.access.create) return '作成権限がありません';
-      return this.disabled ? '作成中...' : '作成';
+      return this.loading ? '作成中...' : '作成';
     },
   },
   methods: {
@@ -74,9 +78,7 @@ export default {
       if (!this.access.create) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
-        if (valid) {
-          this.$emit('handle-submit');
-        }
+        if (valid) this.$emit('handle-submit');
       });
     },
   },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -62,15 +62,11 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    loading: {
-      type: Boolean,
-      default: false,
-    },
   },
   computed: {
     buttonText() {
       if (!this.access.create) return '作成権限がありません';
-      return this.loading ? '作成中...' : '作成';
+      return this.disabled ? '作成中...' : '作成';
     },
   },
   methods: {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,8 +2,12 @@
   <div class="categories-list">
     <categoryPost
       class="post-width"
+      :done-message="doneMessage"
       :error-message="errorMessage"
       :access="access"
+      :category="category"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
     />
     <categoryList
       :categories="categories"
@@ -38,6 +42,15 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    category() {
+      return this.$store.state.categories.targetCategories.name;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
   },
   created() {
     this.getCategories();
@@ -45,6 +58,13 @@ export default {
   methods: {
     getCategories() {
       this.$store.dispatch('categories/getAllCategories');
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategories');
+    },
+    updateValue(event) {
+      this.$store.dispatch('categories/updateCategories', event.target.value);
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -7,6 +7,7 @@
       :access="access"
       :category="category"
       :loading="loading"
+      :disabled="loading ? true: false"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
     />

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -1,15 +1,16 @@
 <template>
   <div class="categories-list">
-    <categoryPost
+    <category-post
       class="post-width"
       :done-message="doneMessage"
       :error-message="errorMessage"
       :access="access"
       :category="category"
+      :loading="loading"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
     />
-    <categoryList
+    <category-list
       :categories="categories"
       :theads="theads"
       class="list-width list-border"
@@ -46,7 +47,7 @@ export default {
       return this.$store.state.categories.loading;
     },
     category() {
-      return this.$store.state.categories.targetCategories.name;
+      return this.$store.state.categories.targetCategory.name;
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
@@ -54,6 +55,7 @@ export default {
   },
   created() {
     this.getCategories();
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     getCategories() {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,16 +3,48 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    targetCategories: {
+      name: '',
+      id: null,
+    },
     categoryList: [],
     errorMessage: '',
+    doneMessage: '',
+    loading: false,
   },
   mutations: {
+    initPostCategories(state) {
+      state.targetCategories = {
+        id: null,
+        name: '',
+      };
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories.reverse()];
     },
+    doneGetCategory(state, payload) {
+      state.targetCategories = { ...payload };
+      state.categoryList.unshift(payload);
+    },
     failRequest(state, { message }) { state.errorMessage = message; },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    displayDoneMessage(state, payload) {
+      state.doneMessage = payload.message;
+    },
+    updateCategories(state, categoryName) {
+      state.targetCategories = { ...state.targetCategories, ...categoryName };
+    },
   },
   actions: {
+    initPostCategories({ commit }) {
+      commit('initPostCategories');
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -25,6 +57,30 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
+    },
+    postCategories({ commit, rootGetters, state }) {
+      const data = { name: state.targetCategories.name };
+      commit('toggleLoading');
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data,
+      }).then(res => {
+        commit('toggleLoading');
+        commit('displayDoneMessage', {
+          message: 'ドキュメントを作成しました',
+        });
+        commit('doneGetCategory', res.data.category);
+        commit('initPostCategories');
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    updateCategories({ commit }, payload) {
+      const categoryName = {
+        name: payload,
+      };
+      commit('categories/updateCategories', categoryName, { root: true });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,7 +3,7 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    targetCategories: {
+    targetCategory: {
       name: '',
       id: null,
     },
@@ -14,7 +14,7 @@ export default {
   },
   mutations: {
     initPostCategories(state) {
-      state.targetCategories = {
+      state.targetCategory = {
         id: null,
         name: '',
       };
@@ -23,7 +23,7 @@ export default {
       state.categoryList = [...payload.categories.reverse()];
     },
     doneGetCategory(state, payload) {
-      state.targetCategories = { ...payload };
+      state.targetCategory = { ...payload };
       state.categoryList.unshift(payload);
     },
     failRequest(state, { message }) { state.errorMessage = message; },
@@ -38,13 +38,10 @@ export default {
       state.doneMessage = payload.message;
     },
     updateCategories(state, categoryName) {
-      state.targetCategories = { ...state.targetCategories, ...categoryName };
+      state.targetCategory = { ...state.targetCategory, ...categoryName };
     },
   },
   actions: {
-    initPostCategories({ commit }) {
-      commit('initPostCategories');
-    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -59,8 +56,9 @@ export default {
       });
     },
     postCategories({ commit, rootGetters, state }) {
-      const data = { name: state.targetCategories.name };
+      const data = { name: state.targetCategory.name };
       commit('toggleLoading');
+      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'POST',
         url: '/category',
@@ -80,7 +78,10 @@ export default {
       const categoryName = {
         name: payload,
       };
-      commit('categories/updateCategories', categoryName, { root: true });
+      commit('updateCategories', categoryName);
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
<!-- Backlogの親チケットのリンクを記載 -->
-https://gizumo.backlog.com/view/GIZFE-1080

## やったこと
-作成ボタンクリック時に、新規作成のAPI通信を実行する
-成功時に一覧画面を更新する
-通信成功時にメッセージを表示する
-追加されたカテゴリーが一覧画面の一番上に表示されるようにする

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1082

## 特にレビューをお願いしたい箇所
なし