### PR TITLE
カテゴリ一削除機能実装

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,11 +16,9 @@
       :theads="theads"
       class="list-width list-border"
       :access="access"
-      :category="category"
       :delete-category-name="deleteCategoryName"
       @handle-click="handleClick"
       @open-modal="openModal"
-      @toggle-modal="toggleModal"
     />
   </div>
 </template>
@@ -61,7 +59,7 @@ export default {
       return this.$store.state.categories.doneMessage;
     },
     deleteCategoryName() {
-      return this.$store.state.categories.deleteCategoryName;
+      return this.$store.state.categories.deleteCategory.name;
     },
   },
   created() {
@@ -80,11 +78,10 @@ export default {
       this.$store.dispatch('categories/updateCategories', event.target.value);
     },
     openModal(categoryId, categoryName) {
-      const payload = {
-        categoryId,
-        categoryName,
-      };
-      this.$store.dispatch('categories/confirmDeleteCategory', payload);
+      this.$store.dispatch(
+        'categories/confirmDeleteCategory',
+        { categoryId, categoryName },
+      );
       this.toggleModal();
     },
     handleClick() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -16,6 +16,11 @@
       :theads="theads"
       class="list-width list-border"
       :access="access"
+      :category="category"
+      :delete-category-name="deleteCategoryName"
+      @handle-click="handleClick"
+      @open-modal="openModal"
+      @toggle-modal="toggleModal"
     />
   </div>
 </template>
@@ -23,12 +28,14 @@
 <script>
 import CategoryList from '@Components/molecules/CategoryList/index.vue';
 import CategoryPost from '@Components/molecules/CategoryPost/index.vue';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     categoryList: CategoryList,
     categoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -53,6 +60,9 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.getCategories();
@@ -68,6 +78,19 @@ export default {
     },
     updateValue(event) {
       this.$store.dispatch('categories/updateCategories', event.target.value);
+    },
+    openModal(categoryId, categoryName) {
+      const payload = {
+        categoryId,
+        categoryName,
+      };
+      this.$store.dispatch('categories/confirmDeleteCategory', payload);
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.toggleModal();
+      });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,8 +11,10 @@ export default {
     errorMessage: '',
     doneMessage: '',
     loading: false,
-    deleteCategoryId: null,
-    deleteCategoryName: '',
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     initPostCategories(state) {
@@ -43,11 +45,8 @@ export default {
       state.targetCategory = { ...state.targetCategory, ...categoryName };
     },
     confirmDeleteCategory(state, { payload }) {
-      state.deleteCategoryId = payload;
-      state.deleteCategoryName = payload.categoryName;
-    },
-    doneDeleteCategory(state) {
-      state.doneMessage = 'カテゴリーの削除が完了しました。';
+      state.deleteCategory.id = payload.categoryId;
+      state.deleteCategory.name = payload.categoryName;
     },
   },
   actions: {
@@ -98,7 +97,7 @@ export default {
     deleteCategory({ commit, rootGetters, state }) {
       return new Promise(resolve => {
         commit('clearMessage');
-        const data = parseInt(state.deleteCategoryId.categoryId, 10);
+        const data = parseInt(state.deleteCategory.id, 10);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `/category/${data}`,
@@ -109,7 +108,9 @@ export default {
           }).then(res => {
             const payload = { categories: res.data.categories };
             commit('doneGetAllCategories', payload);
-            commit('doneDeleteCategory');
+            commit('displayDoneMessage', {
+              message: 'カテゴリーの削除が完了しました',
+            });
             resolve();
           });
         });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,6 +11,8 @@ export default {
     errorMessage: '',
     doneMessage: '',
     loading: false,
+    deleteCategoryId: null,
+    deleteCategoryName: '',
   },
   mutations: {
     initPostCategories(state) {
@@ -39,6 +41,13 @@ export default {
     },
     updateCategories(state, categoryName) {
       state.targetCategory = { ...state.targetCategory, ...categoryName };
+    },
+    confirmDeleteCategory(state, { payload }) {
+      state.deleteCategoryId = payload;
+      state.deleteCategoryName = payload.categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.doneMessage = 'カテゴリーの削除が完了しました。';
     },
   },
   actions: {
@@ -82,6 +91,31 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    confirmDeleteCategory({ commit }, payload) {
+      commit('confirmDeleteCategory', { payload });
+    },
+    deleteCategory({ commit, rootGetters, state }) {
+      return new Promise(resolve => {
+        commit('clearMessage');
+        const data = parseInt(state.deleteCategoryId.categoryId, 10);
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${data}`,
+        }).then(() => {
+          axios(rootGetters['auth/token'])({
+            method: 'GET',
+            url: '/category',
+          }).then(res => {
+            const payload = { categories: res.data.categories };
+            commit('doneGetAllCategories', payload);
+            commit('doneDeleteCategory');
+            resolve();
+          });
+        });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };


### PR DESCRIPTION
<!-- 各項目のコメントアウトは削除すること（このコメントアウトも削除） -->
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1094

## やったこと
- 削除ボタンを押した際の挙動の実装
    - 削除確認用のモーダル実装
    - 削除確認用のモーダルのカテゴリー名を表示
    
- モーダル内の削除ボタンの実装
    - モーダル内の削除ボタンを押した際に、APIが実行
    - 成功した場合、一覧の更新を行い、リストから該当の名前が消える
    - 成功時のメッセージを表示する

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1096

## 特にレビューをお願いしたい箇所
特になし