### PR TITLE
削除済記事一覧ページ実装

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__create-link margin-left"
+    >
+      削除済記事一覧
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -169,5 +181,8 @@ export default {
     &__notice--create {
       margin-bottom: 16px;
     }
+  }
+  .margin-left {
+    margin-left: 20px;
   }
 </style>

--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -26,7 +26,7 @@
       hover-opacity
       class="article-list__create-link margin-left"
     >
-      削除済記事一覧
+      削除済み記事一覧
     </app-router-link>
     <transition-group
       class="article-list__articles"

--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -18,7 +18,6 @@
     </app-router-link>
     <app-router-link
       to="articles/trashed"
-      key-color
       white
       bg-lightgreen
       small

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="article__trashed">
+    <app-heading :level="1"> {{ articleTitle }} </app-heading>
+    <app-router-link
+      :to="'/articles'"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article__trashed margin-top"
+    >
+      記事一覧へ戻る
+    </app-router-link>
+    <table class="article-table">
+      <thead class="article-table__head">
+        <tr>
+          <th v-for="(thead, index) in theads" :key="index">
+            <app-text tag="span" theme-color bold>
+              {{ thead }}
+            </app-text>
+          </th>
+        </tr>
+      </thead>
+      <transition-group name="fade" tag="tbody" class="article-table__body">
+        <tr v-for="article in targetArray" :key="article.id">
+          <td>
+            <!-- タイトル -->
+            <app-text
+              v-if="article.title.length > 30"
+              tag="span"
+              small
+            >
+              {{ article.title.slice(0, 30) + '...' }}
+            </app-text>
+            <app-text
+              v-if="article.title.length <= 30"
+              tag="span"
+              small
+            >
+              {{ article.title.slice(0, 30) }}
+            </app-text>
+          </td>
+          <td>
+            <!-- 本文 -->
+            <app-text
+              v-if="article.content.length > 30"
+              tag="span"
+              small
+            >
+              {{ article.content.slice(0, 30) + '...' }}
+            </app-text>
+            <app-text
+              v-if="article.content.length <= 30"
+              tag="span"
+              small
+            >
+              {{ article.content.slice(0, 30) }}
+            </app-text>
+          </td>
+          <td>
+            <!-- 作成日-->
+            <app-text>
+              {{ article.created_at.slice(0, 10) }}
+            </app-text>
+          </td>
+        </tr>
+      </transition-group>
+    </table>
+  </div>
+</template>
+
+<script>
+import {
+  Heading,
+  Text,
+  RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    title: {
+      type: String,
+      default: '削除済み記事',
+    },
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    articleTitle() {
+      return `${this.title}一覧`;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.article-table {
+  width: 100%;
+  text-align: left;
+  background-color: #fff;
+  tr {
+    border-bottom: 1px solid $separator-color;
+  }
+  &__head {
+    th {
+      padding: 5px 10px;
+      vertical-align: middle;
+    }
+  }
+  &__body {
+    td {
+      padding: 10px;
+      vertical-align: middle;
+    }
+  }
+}
+.margin-top {
+  margin-top: 20px;
+}
+</style>

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="article__trashed">
+  <div>
     <div v-if="errorMessage" class="category-management-post__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
     <app-heading :level="1">削除済み記事一覧</app-heading>
     <app-router-link
-      :to="'/articles'"
+      to="/articles"
       white
       bg-lightgreen
       small
       round
       hover-opacity
-      class="article__trashed margin-top"
+      class="margin-top"
     >
       すべての記事一覧へ戻る
     </app-router-link>
@@ -65,10 +65,6 @@ export default {
     appRouterLink: RouterLink,
   },
   props: {
-    title: {
-      type: String,
-      default: '削除済み記事',
-    },
     theads: {
       type: Array,
       default: () => [],
@@ -85,7 +81,9 @@ export default {
   computed: {
     sliceString() {
       return string => {
-        if (string.length <= 30) return string;
+        if (string.length <= 30) {
+          return string;
+        }
         return `${string.slice(0, 30)}...`;
       };
     },

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -11,7 +11,7 @@
       hover-opacity
       class="article__trashed margin-top"
     >
-      記事一覧へ戻る
+      すべての記事一覧へ戻る
     </app-router-link>
     <table class="article-table">
       <thead class="article-table__head">

--- a/src/components/molecules/ArticleTrashed/index.vue
+++ b/src/components/molecules/ArticleTrashed/index.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="article__trashed">
-    <app-heading :level="1"> {{ articleTitle }} </app-heading>
+    <div v-if="errorMessage" class="category-management-post__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+    <app-heading :level="1">削除済み記事一覧</app-heading>
     <app-router-link
       :to="'/articles'"
-      key-color
       white
       bg-lightgreen
       small
@@ -27,36 +29,14 @@
         <tr v-for="article in targetArray" :key="article.id">
           <td>
             <!-- タイトル -->
-            <app-text
-              v-if="article.title.length > 30"
-              tag="span"
-              small
-            >
-              {{ article.title.slice(0, 30) + '...' }}
-            </app-text>
-            <app-text
-              v-if="article.title.length <= 30"
-              tag="span"
-              small
-            >
-              {{ article.title.slice(0, 30) }}
+            <app-text tag="span" small>
+              {{ sliceString(article.title) }}
             </app-text>
           </td>
           <td>
             <!-- 本文 -->
-            <app-text
-              v-if="article.content.length > 30"
-              tag="span"
-              small
-            >
-              {{ article.content.slice(0, 30) + '...' }}
-            </app-text>
-            <app-text
-              v-if="article.content.length <= 30"
-              tag="span"
-              small
-            >
-              {{ article.content.slice(0, 30) }}
+            <app-text tag="span" small>
+              {{ sliceString(article.content) }}
             </app-text>
           </td>
           <td>
@@ -97,10 +77,17 @@ export default {
       type: Array,
       default: () => [],
     },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
-    articleTitle() {
-      return `${this.title}一覧`;
+    sliceString() {
+      return string => {
+        if (string.length <= 30) return string;
+        return `${string.slice(0, 30)}...`;
+      };
     },
   },
 };
@@ -125,6 +112,9 @@ export default {
       padding: 10px;
       vertical-align: middle;
     }
+  }
+  &__notice--create {
+    margin-bottom: 16px;
   }
 }
 .margin-top {

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -14,6 +14,7 @@ import CategoryList from './CategoryList/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
+import ArticleTrashed from './ArticleTrashed/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
 import Paginate from './Paginate/index.vue';
@@ -35,6 +36,7 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrashed,
   DeleteModal,
   Notice,
   Paginate,

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,35 @@
+<template>
+  <app-article-trashed
+    :theads="theads"
+    :target-array="articleList"
+  />
+</template>
+
+<script>
+import { ArticleTrashed } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashed: ArticleTrashed,
+  },
+  data() {
+    return {
+      title: '削除済み記事',
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    articleList() {
+      return this.$store.state.articles.articleList;
+    },
+  },
+  created() {
+    this.fetchArticles();
+  },
+  methods: {
+    fetchArticles() {
+      this.$store.dispatch('articles/getTrashedArticles');
+    },
+  },
+};
+</script>

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -2,6 +2,7 @@
   <app-article-trashed
     :theads="theads"
     :target-array="articleList"
+    :error-message="errorMessage"
   />
 </template>
 
@@ -14,13 +15,15 @@ export default {
   },
   data() {
     return {
-      title: '削除済み記事',
       theads: ['タイトル', '本文', '作成日'],
     };
   },
   computed: {
     articleList() {
       return this.$store.state.articles.articleList;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
     },
   },
   created() {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -18,6 +18,7 @@ import ArticleList from '@Pages/Articles/List.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -115,6 +116,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -60,7 +60,6 @@ export default {
         },
         user: {
           account_name: '',
-          created_at: '',
           email: '',
           full_name: '',
           id: '',
@@ -119,7 +118,7 @@ export default {
       state.doneMessage = payload.message;
     },
     doneGetTrashedArticles(state, payload) {
-      state.articleList = [...payload.articles];
+      state.articleList = [...payload];
     },
   },
   actions: {
@@ -297,7 +296,7 @@ export default {
         method: 'GET',
         url: '/article/trashed',
       }).then(res => {
-        const payload = res.data;
+        const payload = res.data.articles;
         commit('doneGetTrashedArticles', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -118,6 +118,9 @@ export default {
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
     },
+    doneGetTrashedArticles(state, payload) {
+      state.articleList = [...payload.articles];
+    },
   },
   actions: {
     initPostArticle({ commit }) {
@@ -288,6 +291,17 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    getTrashedArticles({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(res => {
+        const payload = res.data;
+        commit('doneGetTrashedArticles', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1091

## やったこと
削除済み記事一覧の作成
- 記事一覧ページの上部に「削除済記事一覧」へ遷移するボタンの追加
- 削除済み記事一覧ページに削除された記事('タイトル', '本文', '作成日')を表示する機能の実装

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1093

## 特にレビューをお願いしたい箇所
なし