### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryDetail/index.vue
+++ b/src/components/molecules/CategoryDetail/index.vue
@@ -1,0 +1,134 @@
+<template>
+  <div>
+    <app-heading :level="1">
+      カテゴリー管理
+    </app-heading>
+    <app-router-link
+      class="category-update__link"
+      block
+      underline
+      key-color
+      hover-opacity
+      :to="'/categories'"
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <form @submit.prevent="handleSubmit">
+      <app-input
+        class="category-update__input"
+        v-validate="'required'"
+        name="category"
+        type="text"
+        data-vv-as="カテゴリー名"
+        :value="category"
+        @update-value="$emit('edited-category',$event)"
+        :error-message="errors.collect('category')"
+        />
+        <app-button
+          class="category-update__button"
+          button-type="submit"
+          round
+          :disabled = "!disabled"
+        >
+          {{ buttonText }}
+        </app-button>
+  </form>
+
+    <div v-if="doneMessage"
+      class="category-update__success">
+        <app-text bg-success>
+            {{ doneMessage }}
+        </app-text>
+    </div>
+        <div v-if="errorMessage"
+          class="category-update__notice"
+         >
+        <app-text bg-error>
+          {{ errorMessage }}
+        </app-text>
+      </div>
+</div>
+</template>
+<script>
+import{
+  Heading, Button, RouterLink,Input,Text
+}from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appButton: Button,
+    appRouterLink: RouterLink,
+    appInput: Input,
+    appText: Text,
+  },
+  props: {
+    access: {
+      type:Object,
+      default:()=>({})
+    },
+    selectCategoryName: {
+      type: String,
+      default: '',
+    },
+    categoryId: {
+      type: String,
+      default: 0,
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage:{
+      type: String,
+      default: '',
+    },
+    loading:{
+      type: Boolean,
+      default: false,
+    },
+    category:{
+      type: String,
+      required: true,
+    },
+  },
+  computed:{
+    buttonText() {
+      if(!this.access.edit)return'更新権限がありません';
+      return this.loading ? '更新中...' :'更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    }
+  },
+  methods: {
+    handleSubmit() {
+      console.log(this.category)
+      if (!this.access.edit) return;
+      this.$emit('clear-message')
+      this.$validator.validate().then(valid => {
+        if(valid) this.$emit('handle-submit');
+      });
+    }
+  },
+}
+</script>
+<style lang="scss" scoped>
+.category-update{
+  &__link{
+    margin-top: 16px;
+  }
+  &__button{
+    margin-top: 16px;
+  }
+  &__input{
+    margin-top: 16px;
+  }
+  &__success{
+    margin-top: 16px;
+  }
+  &__notice{
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryDetail/index.vue
+++ b/src/components/molecules/CategoryDetail/index.vue
@@ -9,7 +9,7 @@
       underline
       key-color
       hover-opacity
-      :to="'/categories'"
+      to="/categories"
     >
       カテゴリー一覧へ戻る
     </app-router-link>
@@ -69,14 +69,6 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
-    },
-    selectCategoryName: {
-      type: String,
-      default: '',
-    },
-    categoryId: {
-      type: String,
-      default: null,
     },
     doneMessage: {
       type: String,

--- a/src/components/molecules/CategoryDetail/index.vue
+++ b/src/components/molecules/CategoryDetail/index.vue
@@ -15,44 +15,47 @@
     </app-router-link>
     <form @submit.prevent="handleSubmit">
       <app-input
-        class="category-update__input"
         v-validate="'required'"
         name="category"
         type="text"
         data-vv-as="カテゴリー名"
+        :error-messages="errors.collect('category')"
         :value="category"
-        @update-value="$emit('edited-category',$event)"
-        :error-message="errors.collect('category')"
-        />
-        <app-button
-          class="category-update__button"
-          button-type="submit"
-          round
-          :disabled = "!disabled"
-        >
-          {{ buttonText }}
-        </app-button>
-  </form>
+        class="category-update__input"
+        @update-value="$emit('edited-category', $event)"
+      />
+      <app-button
+        class="category-update__button"
+        button-type="submit"
+        round
+        :disabled="!disabled"
+      >
+        {{ buttonText }}
+      </app-button>
+    </form>
 
-    <div v-if="doneMessage"
-      class="category-update__success">
-        <app-text bg-success>
-            {{ doneMessage }}
-        </app-text>
+    <div
+      v-if="doneMessage"
+      class="category-update__success"
+    >
+      <app-text bg-success>
+        {{ doneMessage }}
+      </app-text>
     </div>
-        <div v-if="errorMessage"
-          class="category-update__notice"
-         >
-        <app-text bg-error>
-          {{ errorMessage }}
-        </app-text>
-      </div>
-</div>
+    <div
+      v-if="errorMessage"
+      class="category-update__notice"
+    >
+      <app-text bg-error>
+        {{ errorMessage }}
+      </app-text>
+    </div>
+  </div>
 </template>
 <script>
-import{
-  Heading, Button, RouterLink,Input,Text
-}from '@Components/atoms';
+import {
+  Heading, Button, RouterLink, Input, Text,
+} from '@Components/atoms';
 
 export default {
   components: {
@@ -64,8 +67,8 @@ export default {
   },
   props: {
     access: {
-      type:Object,
-      default:()=>({})
+      type: Object,
+      default: () => ({}),
     },
     selectCategoryName: {
       type: String,
@@ -73,46 +76,46 @@ export default {
     },
     categoryId: {
       type: String,
-      default: 0,
+      default: null,
     },
     doneMessage: {
       type: String,
       default: '',
     },
-    errorMessage:{
+    errorMessage: {
       type: String,
       default: '',
     },
-    loading:{
+    loading: {
       type: Boolean,
       default: false,
     },
-    category:{
+    category: {
       type: String,
       required: true,
     },
   },
-  computed:{
+  computed: {
     buttonText() {
-      if(!this.access.edit)return'更新権限がありません';
-      return this.loading ? '更新中...' :'更新';
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
     },
     disabled() {
       return this.access.edit && !this.loading;
-    }
+    },
   },
   methods: {
     handleSubmit() {
-      console.log(this.category)
       if (!this.access.edit) return;
-      this.$emit('clear-message')
+      this.$emit('clear-message');
       this.$validator.validate().then(valid => {
-        if(valid) this.$emit('handle-submit');
+        if (valid) this.$emit('handle-submit');
       });
-    }
+    },
   },
-}
+};
 </script>
+
 <style lang="scss" scoped>
 .category-update{
   &__link{

--- a/src/components/pages/Categories/Detail.vue
+++ b/src/components/pages/Categories/Detail.vue
@@ -1,0 +1,77 @@
+<template>
+  <div>
+    <category-detail
+      :access="access"
+      :loading="loading"
+      :disabled="loading ? true: false"
+      :category="category"
+      :category-id="categoryId"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
+      @clear-message="clearMessage"
+      @handle-submit="handleSubmit"
+      @edited-category="editedCategory"
+    />
+  </div>
+</template>
+
+<script>
+import CategoryDetail from '@Components/molecules/CategoryDetail/index.vue';
+
+export default {
+  components: {
+    categoryDetail: CategoryDetail,
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    selectCategoryName() {
+      const selectCategoryName = this.$store.state.categories.targetCategory.name
+      return selectCategoryName
+    },
+    categoryId() {
+      let  id =this.$route.params.id;
+      return id;
+    },
+    
+    category() {
+      // let  category =this.$store.state.categories.targetCategory.name
+      let category=''
+      return category;
+    },
+    doneMessage() {
+        return this.$store.state.categories.doneMessage;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    }
+  },
+  created() {
+    this.$store.dispatch('categories/getCategoryDetail',parseInt(this.categoryId,10))
+  },
+
+  methods: {
+    handleSubmit() {
+      if(this.loading)return;
+      this.$store.dispatch('categories/updateCategory',parseInt(this.categoryId,10));
+    },
+
+    editedCategory($event) {
+      this.$store.dispatch('categories/editedContent',$event.target.value);
+      console.log($event.target.value)
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage')
+    }
+  },
+ 
+}
+
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/pages/Categories/Detail.vue
+++ b/src/components/pages/Categories/Detail.vue
@@ -1,13 +1,11 @@
 <template>
   <div>
     <category-detail
-      :category-id="categoryId"
       :done-message="doneMessage"
       :error-message="errorMessage"
       :access="access"
       :category="category"
       :loading="loading"
-      :disabled="loading ? true: false"
       @clear-message="clearMessage"
       @handle-submit="handleSubmit"
       @edited-category="editedCategory"
@@ -26,17 +24,12 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
-    selectCategoryName() {
-      const selectCategoryName = this.$store.state.categories.targetCategory.name;
-      return selectCategoryName;
-    },
     categoryId() {
       const { id } = this.$route.params;
       return id;
     },
     category() {
-      const category = this.$store.state.categories.targetCategory.name;
-      return category;
+      return this.$store.state.categories.targetCategory.name;
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
@@ -65,6 +58,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-</style>

--- a/src/components/pages/Categories/Detail.vue
+++ b/src/components/pages/Categories/Detail.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <category-detail
-      :access="access"
-      :loading="loading"
-      :disabled="loading ? true: false"
-      :category="category"
       :category-id="categoryId"
       :done-message="doneMessage"
       :error-message="errorMessage"
+      :access="access"
+      :category="category"
+      :loading="loading"
+      :disabled="loading ? true: false"
       @clear-message="clearMessage"
       @handle-submit="handleSubmit"
       @edited-category="editedCategory"
@@ -27,50 +27,43 @@ export default {
       return this.$store.getters['auth/access'];
     },
     selectCategoryName() {
-      const selectCategoryName = this.$store.state.categories.targetCategory.name
-      return selectCategoryName
+      const selectCategoryName = this.$store.state.categories.targetCategory.name;
+      return selectCategoryName;
     },
     categoryId() {
-      let  id =this.$route.params.id;
+      const { id } = this.$route.params;
       return id;
     },
-    
     category() {
-      // let  category =this.$store.state.categories.targetCategory.name
-      let category=''
+      const category = this.$store.state.categories.targetCategory.name;
       return category;
     },
     doneMessage() {
-        return this.$store.state.categories.doneMessage;
+      return this.$store.state.categories.doneMessage;
     },
     loading() {
       return this.$store.state.categories.loading;
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
-    }
+    },
   },
   created() {
-    this.$store.dispatch('categories/getCategoryDetail',parseInt(this.categoryId,10))
+    this.$store.dispatch('categories/getCategoryDetail', parseInt(this.categoryId, 10));
   },
-
   methods: {
     handleSubmit() {
-      if(this.loading)return;
-      this.$store.dispatch('categories/updateCategory',parseInt(this.categoryId,10));
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory', parseInt(this.categoryId, 10));
     },
-
     editedCategory($event) {
-      this.$store.dispatch('categories/editedContent',$event.target.value);
-      console.log($event.target.value)
+      this.$store.dispatch('categories/editedContent', $event.target.value);
     },
     clearMessage() {
-      this.$store.dispatch('categories/clearMessage')
-    }
+      this.$store.dispatch('categories/clearMessage');
+    },
   },
- 
-}
-
+};
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -65,6 +65,7 @@ export default {
   created() {
     this.getCategories();
     this.$store.dispatch('categories/clearMessage');
+    this.$store.dispatch('categories/clearCategory');
   },
   methods: {
     getCategories() {

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -30,6 +30,7 @@ import PasswordUpdate from '@Pages/Password/update.vue';
 // カテゴリーページ
 import Categories from '@Pages/Categories/index.vue';
 import CategoriesList from '@Pages/Categories/List.vue';
+import CategoriesDetail from '@Pages/Categories/Detail.vue';
 
 import Store from '../_store';
 
@@ -118,6 +119,11 @@ const router = new VueRouter({
               name: 'categoriesList',
               path: '',
               component: CategoriesList,
+            },
+            {
+              name: 'categoriesDetail',
+              path: ':id',
+              component: CategoriesDetail,
             },
           ],
         },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -52,12 +52,8 @@ export default {
       state.targetCategory.name = payload;
     },
     doneGetCategoryDetail(state, category) {
-      state.targetCategory.name = category
+      state.targetCategory.name = category;
     },
-    clearCategory(state){
-      console.log(state.targetCategory)
-    }
-
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -128,42 +124,40 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    getCategoryDetail({commit,rootGetters},categoryId){
+    getCategoryDetail({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${categoryId}`,
-      }).then(res=>{
-        const category =res.data.category.name
-        commit('doneGetCategoryDetail',category)
-      })
+      }).then(res => {
+        const category = res.data.category.name;
+        commit('doneGetCategoryDetail', category);
+      });
     },
-
-    updateCategory({commit, rootGetters,state},categoryId){
-      commit('clearMessage')
+    updateCategory({ commit, rootGetters, state }, categoryId) {
+      commit('clearMessage');
       commit('toggleLoading');
-      const data =state.targetCategory
-      axios(rootGetters['auth/token'])
-      ({
+      const data = state.targetCategory;
+      axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url:`/category/${categoryId}`,
+        url: `/category/${categoryId}`,
         data,
-      }).then(()=>{
+      }).then(() => {
         commit('toggleLoading');
-        commit('displayDoneMessage',{
-          message: 'カテゴリーを更新しました'
+        commit('displayDoneMessage', {
+          message: 'カテゴリーを更新しました',
         });
-      }).catch(err=>{
+      }).catch(err => {
         commit('toggleLoading');
-        commit('failRequest',{
-          message: err.message
+        commit('failRequest', {
+          message: err.message,
         });
-      })
+      });
     },
-    editedContent({commit},payload){
-      commit('editedContent',payload)
+    editedContent({ commit }, payload) {
+      commit('editedContent', payload);
     },
-    clearCategory({commit}){
-      commit('initPostCategories')
-    }
+    clearCategory({ commit }) {
+      commit('initPostCategories');
+    },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -48,6 +48,16 @@ export default {
       state.deleteCategory.id = payload.categoryId;
       state.deleteCategory.name = payload.categoryName;
     },
+    editedContent(state, payload) {
+      state.targetCategory.name = payload;
+    },
+    doneGetCategoryDetail(state, category) {
+      state.targetCategory.name = category
+    },
+    clearCategory(state){
+      console.log(state.targetCategory)
+    }
+
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -118,5 +128,42 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
+    getCategoryDetail({commit,rootGetters},categoryId){
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(res=>{
+        const category =res.data.category.name
+        commit('doneGetCategoryDetail',category)
+      })
+    },
+
+    updateCategory({commit, rootGetters,state},categoryId){
+      commit('clearMessage')
+      commit('toggleLoading');
+      const data =state.targetCategory
+      axios(rootGetters['auth/token'])
+      ({
+        method: 'PUT',
+        url:`/category/${categoryId}`,
+        data,
+      }).then(()=>{
+        commit('toggleLoading');
+        commit('displayDoneMessage',{
+          message: 'カテゴリーを更新しました'
+        });
+      }).catch(err=>{
+        commit('toggleLoading');
+        commit('failRequest',{
+          message: err.message
+        });
+      })
+    },
+    editedContent({commit},payload){
+      commit('editedContent',payload)
+    },
+    clearCategory({commit}){
+      commit('initPostCategories')
+    }
   },
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1100

## やったこと
- カテゴリを編集するための画面をデザインから作成する
- カテゴリ更新機能を実装する

API通信

- カテゴリ詳細の取得
- カテゴリの更新

イベント仕様

- カテゴリー一覧へ戻るリンクを押す→カテゴリ管理画面へ遷移
- 更新ボタンを押す→入力欄の内容に更新される→処理後メッセージを表示
- 初期表示としてidに応じたカテゴリ名がinputの初期値として入っている
- APIから返されたエラーメッセージが表示される

## やらないこと
特になし

## テスト
https://gizumo.backlog.com/view/GIZFE-1102

## 特にレビューをお願いしたい箇所
確認はしてあるのですが、カテゴリー内容を取得する際の記述で冗長な箇所があるのではないかと
思うので、見ていただきたいです。