### PR TITLE
GIZFE-1097 ：カテゴリーの新規作成

### DIFF
--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -71,6 +71,7 @@ export default {
   },
   methods: {
     addCategory() {
+      console.log('押されました');
       if (!this.access.create) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -71,7 +71,6 @@ export default {
   },
   methods: {
     addCategory() {
-      console.log('押されました');
       if (!this.access.create) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -4,6 +4,9 @@
       class="category_post"
       :access="access"
       :category="targetCategory"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
+      :clear-message="clearMessage"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
     />
@@ -37,18 +40,27 @@ export default {
       return this.$store.getters['auth/access'];
     },
     targetCategory() {
-      return this.$store.state.categories.targetCategory.title;
-    }
+      return this.$store.state.categories.targetCategory.name;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
   },
-  method: {
+  methods: {
+    clearMessage() {
+      this.store.dispatch('categories/clearMassage');
+    },
     updateValue($event) {
       this.$store.dispatch('categories/updateValue', $event.target.value);
     },
-    // handleSubmit() {
-    //   console.log("押された");
+    handleSubmit() {
+      this.$store.dispatch('categories/postCategory');
       // if (this.loading) return;
       // this.$store.dispatch('categories/postCategory').then(() => {
       //   this.$router.push({
@@ -56,12 +68,8 @@ export default {
       //     query: { redirect: '/article/post' },
       //   });
       // });
-    // },
-    handleSubmit() {
-      console.log('実行')
     },
-  }
-
+  },
 };
 
 </script>

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -6,6 +6,7 @@
       :category="targetCategory"
       :done-message="doneMessage"
       :error-message="errorMessage"
+      :disabled="disabled"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
     />
@@ -46,6 +47,9 @@ export default {
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
     },
   },
   created() {

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -6,7 +6,6 @@
       :category="targetCategory"
       :done-message="doneMessage"
       :error-message="errorMessage"
-      :clear-message="clearMessage"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
     />
@@ -61,17 +60,9 @@ export default {
     },
     handleSubmit() {
       this.$store.dispatch('categories/postCategory');
-      // if (this.loading) return;
-      // this.$store.dispatch('categories/postCategory').then(() => {
-      //   this.$router.push({
-      //     path: '/categories',
-      //     query: { redirect: '/article/post' },
-      //   });
-      // });
     },
   },
 };
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -3,6 +3,9 @@
     <app-category-post
       class="category_post"
       :access="access"
+      :category="targetCategory"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       class="category_list"
@@ -33,10 +36,31 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    targetCategory() {
+      return this.$store.state.categories.targetCategory.title;
+    }
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
   },
+  method: {
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event.target.value);
+    },
+    // handleSubmit() {
+    //   console.log("押された");
+      // if (this.loading) return;
+      // this.$store.dispatch('categories/postCategory').then(() => {
+      //   this.$router.push({
+      //     path: '/categories',
+      //     query: { redirect: '/article/post' },
+      //   });
+      // });
+    // },
+    handleSubmit() {
+      console.log('実行')
+    },
+  }
 
 };
 

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,6 +10,7 @@ export default {
     categoriesList: [],
     doneMessage: '',
     errorMessage: '',
+    disabled: false,
   },
   getters: {
     targetCategory: state => state.targetCategory,
@@ -35,6 +36,9 @@ export default {
       state.doneMessage = '';
       state.errorMessage = '';
     },
+    toggleDisabled(state) {
+      state.disabled = !state.disabled;
+    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -59,6 +63,7 @@ export default {
     },
     postCategory({ commit, state, rootGetters }) {
       commit('clearMessage');
+      commit('toggleDisabled');
       axios(rootGetters['auth/token'])({
         method: 'POST',
         url: '/category',
@@ -68,6 +73,7 @@ export default {
           newCategories: res.data,
         };
         commit('updateCategory', payload);
+        commit('toggleDisabled');
         commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
       }).catch(err => {
         commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -21,7 +21,6 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
-      console.log(state.errorMessage);
     },
     updateValue(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
@@ -71,7 +70,6 @@ export default {
         commit('updateCategory', payload);
         commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
       }).catch(err => {
-        console.log(err);
         commit('failRequest', { message: err.message });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -16,6 +16,12 @@ export default {
     targetCategory: state => state.targetCategory,
   },
   mutations: {
+    initPostCategory(state) {
+      state.targetCategory = {
+        id: null,
+        name: '',
+      };
+    },
     doneGetAllCategories(state, payload) {
       state.categoriesList = [...payload.categories];
       state.categoriesList = state.categoriesList.reverse();
@@ -75,6 +81,7 @@ export default {
         commit('updateCategory', payload);
         commit('toggleDisabled');
         commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
+        commit('initPostCategory');
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,6 +3,15 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    targetCategory: {
+      id: null,
+      title: '',
+      content: '',
+      category: {
+        id: null,
+        name: '',
+      },
+    },
     categoriesList: [],
   },
   mutations: {
@@ -12,6 +21,9 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+    },
+    updateValue(state, payload) {
+      state.targetCategory = { ...state.targetCategory, title: payload.title };
     },
   },
   actions: {
@@ -26,6 +38,12 @@ export default {
         commit('doneGetAllCategories', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    updateValue({ commit }, title) {
+      commit({
+        type: 'updateValue',
+        title,
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,14 +5,14 @@ export default {
   state: {
     targetCategory: {
       id: null,
-      title: '',
-      content: '',
-      category: {
-        id: null,
-        name: '',
-      },
+      name: '',
     },
     categoriesList: [],
+    doneMessage: '',
+    errorMessage: '',
+  },
+  getters: {
+    targetCategory: state => state.targetCategory,
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -21,13 +21,25 @@ export default {
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
+      console.log(state.errorMessage);
     },
     updateValue(state, payload) {
-      state.targetCategory = { ...state.targetCategory, title: payload.title };
+      state.targetCategory = { ...state.targetCategory, name: payload.name };
+    },
+    updateCategory(state, payload) {
+      state.categoriesList = [payload.newCategories.category, ...state.categoriesList];
+    },
+    displayDoneMessage(state, payload) {
+      state.doneMessage = payload.message;
+    },
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
     },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
+      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/category',
@@ -40,11 +52,31 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    updateValue({ commit }, title) {
+    updateValue({ commit }, name) {
       commit({
         type: 'updateValue',
-        title,
+        name,
       });
+    },
+    postCategory({ commit, state, rootGetters }) {
+      commit('clearMessage');
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data: { name: state.targetCategory.name },
+      }).then(res => {
+        const payload = {
+          newCategories: res.data,
+        };
+        commit('updateCategory', payload);
+        commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
+      }).catch(err => {
+        console.log(err);
+        commit('failRequest', { message: err.message });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1097

## やったこと
<!-- このPRで行ったことをリスト形式で記載 -->
・作成ボタンを押した際に、APIでPOSTリクエストを行う。
・成功時にリクエストで送信したデータを既存のリストへ追加する。
・追加された項目を更新・一番上に表示する。
・カテゴリーの新規作成時に、作成メッセージを表示する。
・エラー発生時にエラーメッセージを表示する。

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1099

## 特にレビューをお願いしたい箇所
API通信を実行しているcategories.js（postCategory)での記載を調べながら記載しています。
動作は正常ですがコードに過不足がないか。

