### PR TITLE
feature: 削除済み記事一覧画面の実装

### DIFF
--- a/src/components/molecules/ArticleList/index.vue
+++ b/src/components/molecules/ArticleList/index.vue
@@ -16,6 +16,18 @@
     >
       新しいドキュメントを作る
     </app-router-link>
+    <app-router-link
+      to="articles/trashed"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__trashed-link"
+    >
+      削除済み記事一覧へ
+    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -176,6 +188,10 @@ export default {
     }
     &__create-link {
       margin-top: 16px;
+    }
+    &__trashed-link {
+      margin-top: 16px;
+      margin-left: 16px;
     }
     &__links {
       *:not(first-child) {

--- a/src/components/molecules/ArticleTrashList/index.vue
+++ b/src/components/molecules/ArticleTrashList/index.vue
@@ -25,7 +25,6 @@ export default {
     appHeading: Heading,
   },
 };
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/molecules/ArticleTrashList/index.vue
+++ b/src/components/molecules/ArticleTrashList/index.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="article-trashed">
+    <appHeading :level="1">削除済み記事一覧</appHeading>
+    <div class="article-trashed__back">
+      <appRouterLink
+        :to="{ path: '/articles', query: { page: 1 } }"
+        hover-opacity
+        small
+        white
+        round
+        bg-lightgreen
+      >
+        全ての記事一覧へ戻る
+      </appRouterLink>
+    </div>
+  </div>
+</template>
+
+<script>
+import { RouterLink, Heading } from '@Components/atoms';
+
+export default {
+  components: {
+    appRouterLink: RouterLink,
+    appHeading: Heading,
+  },
+};
+
+</script>
+
+<style lang="scss" scoped>
+.article-trashed {
+  &__back {
+    margin-top: 20px;
+  }
+}
+</style>

--- a/src/components/molecules/ArticleTrashList/index.vue
+++ b/src/components/molecules/ArticleTrashList/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="article-trashed">
-    <appHeading :level="1">削除済み記事一覧</appHeading>
+    <app-heading :level="1">削除済み記事一覧</app-heading>
     <div class="article-trashed__back">
-      <appRouterLink
+      <app-router-link
         :to="{ path: '/articles', query: { page: 1 } }"
         hover-opacity
         small
@@ -11,7 +11,7 @@
         bg-lightgreen
       >
         全ての記事一覧へ戻る
-      </appRouterLink>
+      </app-router-link>
     </div>
   </div>
 </template>

--- a/src/components/molecules/ArticleTrashTable/index.vue
+++ b/src/components/molecules/ArticleTrashTable/index.vue
@@ -13,12 +13,12 @@
       <tr v-for="article in targetArray" :key="article.id">
         <td>
           <app-text tag="span" small>
-            {{ truncate(article.title,30) }}
+            {{ truncate(article.title, 30) }}
           </app-text>
         </td>
         <td>
           <app-text tag="span" small>
-            {{ truncate(article.content,30) }}
+            {{ truncate(article.content, 30) }}
           </app-text>
         </td>
         <td>
@@ -66,7 +66,6 @@ export default {
     },
   },
 };
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/molecules/ArticleTrashTable/index.vue
+++ b/src/components/molecules/ArticleTrashTable/index.vue
@@ -13,12 +13,12 @@
       <tr v-for="article in targetArray" :key="article.id">
         <td>
           <app-text tag="span" small>
-            {{ article.title | truncate(30) }}
+            {{ truncate(article.title,30) }}
           </app-text>
         </td>
         <td>
           <app-text tag="span" small>
-            {{ article.content | truncate(30) }}
+            {{ truncate(article.content,30) }}
           </app-text>
         </td>
         <td>
@@ -38,14 +38,6 @@ export default {
   components: {
     appText: Text,
   },
-  filters: {
-    truncate(value, length) {
-      if (value.length > length) {
-        return `${value.slice(0, length)}...`;
-      }
-      return value;
-    },
-  },
   props: {
     targetArray: {
       type: Array,
@@ -54,6 +46,14 @@ export default {
     theads: {
       type: Array,
       default: () => [],
+    },
+  },
+  computed: {
+    truncate: () => (value, length) => {
+      if (value.length > length) {
+        return `${value.slice(0, length)}...`;
+      }
+      return value;
     },
   },
   methods: {

--- a/src/components/molecules/ArticleTrashTable/index.vue
+++ b/src/components/molecules/ArticleTrashTable/index.vue
@@ -1,0 +1,93 @@
+<template>
+  <table class="article-trashed-table">
+    <thead class="article-trashed-table__head">
+      <tr>
+        <th v-for="(thead, index) in theads" :key="index">
+          <app-text tag="span" theme-color bold>
+            {{ thead }}
+          </app-text>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="article-trashed-table__body">
+      <tr v-for="article in targetArray" :key="article.id">
+        <td>
+          <app-text tag="span" small>
+            {{ article.title | truncate(30) }}
+          </app-text>
+        </td>
+        <td>
+          <app-text tag="span" small>
+            {{ article.content | truncate(30) }}
+          </app-text>
+        </td>
+        <td>
+          <app-text tag="span" small>
+            {{ formattedDate(article.created_at) }}
+          </app-text>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import { Text } from '@Components/atoms';
+
+export default {
+  components: {
+    appText: Text,
+  },
+  filters: {
+    truncate(value, length) {
+      if (value.length > length) {
+        return `${value.slice(0, length)}...`;
+      }
+      return value;
+    },
+  },
+  props: {
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+    theads: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  methods: {
+    formattedDate(targetDate) {
+      const date = new Date(targetDate);
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    },
+  },
+};
+
+</script>
+
+<style lang="scss" scoped>
+.article-trashed-table {
+  width: 100%;
+  text-align: left;
+  background-color: $white;
+  tr {
+    border-bottom: 1px solid $separator-color;
+  }
+  &__head {
+    th {
+      padding: 5px 10px;
+      vertical-align: middle;
+    }
+  }
+  &__body {
+    td {
+      padding: 10px;
+      vertical-align: middle;
+    }
+  }
+}
+</style>

--- a/src/components/molecules/ArticleTrashTable/index.vue
+++ b/src/components/molecules/ArticleTrashTable/index.vue
@@ -59,10 +59,7 @@ export default {
   methods: {
     formattedDate(targetDate) {
       const date = new Date(targetDate);
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
+      return date.toLocaleDateString();
     },
   },
 };

--- a/src/components/molecules/UserTable/index.vue
+++ b/src/components/molecules/UserTable/index.vue
@@ -105,6 +105,8 @@ export default {
     td {
       padding: 10px;
       vertical-align: middle;
+      overflow: hidden;
+      text-overflow: ellipsis;
       &.is-disabled {
         color: $disabled-color;
         font-size: 12px;

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -14,6 +14,8 @@ import CategoryUpdate from './CategoryUpdate/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
+import ArticleTrashList from './ArticleTrashList/index.vue';
+import ArticleTrashTable from './ArticleTrashTable/index.vue';
 import DeleteModal from './Modal/Delete.vue';
 import Notice from './Notice/index.vue';
 
@@ -34,6 +36,8 @@ export {
   ArticleEdit,
   ArticlePost,
   ArticleDetail,
+  ArticleTrashList,
+  ArticleTrashTable,
   DeleteModal,
   Notice,
 };

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
-    <appArticleTrashList />
-    <appArticleTrashTable
+    <app-article-trash-list />
+    <app-article-trash-table
       :target-array="articleTrashed"
       :theads="theads"
     />

--- a/src/components/pages/Articles/Trashed.vue
+++ b/src/components/pages/Articles/Trashed.vue
@@ -1,0 +1,34 @@
+<template>
+  <section>
+    <appArticleTrashList />
+    <appArticleTrashTable
+      :target-array="articleTrashed"
+      :theads="theads"
+    />
+  </section>
+</template>
+
+<script>
+import { ArticleTrashList, ArticleTrashTable } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticleTrashList: ArticleTrashList,
+    appArticleTrashTable: ArticleTrashTable,
+  },
+  data() {
+    return {
+      theads: ['タイトル', '本文', '作成日'],
+    };
+  },
+  computed: {
+    articleTrashed() {
+      return this.$store.state.articles.trashedArticleList;
+    },
+  },
+  created() {
+    return this.$store.dispatch('articles/getTrashArticles');
+  },
+};
+
+</script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -18,6 +18,7 @@ import ArticleList from '@Pages/Articles/List.vue';
 import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
+import ArticleTrashed from '@Pages/Articles/Trashed.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -115,6 +116,11 @@ const router = new VueRouter({
           name: 'articlePost',
           path: 'post',
           component: ArticlePost,
+        },
+        {
+          name: 'articleTrashed',
+          path: 'trashed',
+          component: ArticleTrashed,
         },
         {
           name: 'articleDetail',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -130,7 +130,7 @@ export default {
     setCurrentPage(state, payload) {
       state.pagination.current_page = payload;
     },
-    doneGetTrashArticles(state, { trashedArticles }) {
+    doneGetTrashArticles(state, trashedArticles) {
       state.trashedArticleList = trashedArticles;
       state.loading = false;
     },
@@ -318,7 +318,7 @@ export default {
           content: data.content,
           created_at: data.created_at,
         }));
-        commit('doneGetTrashArticles', { trashedArticles });
+        commit('doneGetTrashArticles', trashedArticles);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -132,7 +132,6 @@ export default {
     },
     doneGetTrashArticles(state, trashedArticles) {
       state.trashedArticleList = trashedArticles;
-      state.loading = false;
     },
   },
   actions: {
@@ -319,8 +318,10 @@ export default {
           created_at: data.created_at,
         }));
         commit('doneGetTrashArticles', trashedArticles);
+        commit('toggleLoading');
       }).catch(err => {
         commit('failRequest', { message: err.message });
+        commit('toggleLoading');
       });
     },
   },

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -32,6 +32,7 @@ export default {
       current_page: null,
       last_page: null,
     },
+    trashedArticleList: [],
   },
   getters: {
     transformedArticles(state) {
@@ -128,6 +129,10 @@ export default {
     },
     setCurrentPage(state, payload) {
       state.pagination.current_page = payload;
+    },
+    doneGetTrashArticles(state, { trashedArticles }) {
+      state.trashedArticleList = trashedArticles;
+      state.loading = false;
     },
   },
   actions: {
@@ -301,6 +306,22 @@ export default {
     },
     setCurrentPage({ commit }, currentPage) {
       commit('setCurrentPage', currentPage);
+    },
+    getTrashArticles({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/article/trashed',
+      }).then(res => {
+        if (res.data.code === 0) throw new Error(res.data.message);
+        const trashedArticles = res.data.articles.map(data => ({
+          title: data.title,
+          content: data.content,
+          created_at: data.created_at,
+        }));
+        commit('doneGetTrashArticles', { trashedArticles });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
   },
 };

--- a/src/js/_store/modules/users.js
+++ b/src/js/_store/modules/users.js
@@ -77,7 +77,6 @@ export default {
       }).then(response => {
         // NOTE: エラー時はresponse.data.codeが0で返ってくる。
         if (response.data.code === 0) throw new Error(response.data.message);
-
         const users = response.data.users.map(data => ({
           id: data.id,
           fullName: data.full_name,

--- a/src/js/_store/modules/users.js
+++ b/src/js/_store/modules/users.js
@@ -98,7 +98,6 @@ export default {
       }).then(response => {
         // NOTE: エラー時はresponse.data.codeが0で返ってくる。
         if (response.data.code === 0) throw new Error(response.data.message);
-
         const data = response.data.user;
         const user = {
           id: data.id,
@@ -125,7 +124,6 @@ export default {
         }).then(response => {
           // NOTE: エラー時はresponse.data.codeが0で返ってくる。
           if (response.data.code === 0) throw new Error(response.data.message);
-
           commit('doneCreateUser');
           resolve();
         }).catch(err => {
@@ -145,7 +143,6 @@ export default {
       }).then(response => {
         // NOTE: エラー時はresponse.data.codeが0で返ってくる。
         if (response.data.code === 0) throw new Error(response.data.message);
-
         const editedUser = {
           id: response.data.user.id,
           fullName: response.data.user.full_name,
@@ -175,7 +172,6 @@ export default {
         }).then(response => {
           // NOTE: エラー時はresponse.data.codeが0で返ってくる。
           if (response.data.code === 0) throw new Error(response.data.message);
-
           commit('doneDeleteUser');
           resolve();
         }).catch(err => {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1135

## やったこと
・削除済み記事一覧ページの作成
・削除済み記事の取得

## やらないこと
・ページネーション

## テスト
https://gizumo.backlog.com/view/GIZFE-1137

## 特にレビューをお願いしたい箇所
今回の実装と直接は関係ないのかもしれないのですが、記事一覧のページに飛んだ時に、propsのエラーが出てしまって、それがどこで起こっているのかがいまいちわかりません。。
ページネーションや表示等は問題ないのですが、コンソールでエラーだけ出てしまっている状態です。。
