### PR TITLE
カテゴリー削除機能実装

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -76,7 +76,11 @@ export default {
     },
     handleClick() {
       this.$store.dispatch('categories/deleteCategory').then(() => {
-        this.toggleModal();
+        this.$store.dispatch('categories/fetchCategories')
+          .then(() => {
+            this.$store.commit('categories/setDoneMessage', 'カテゴリーを削除しました');
+            this.toggleModal();
+          });
       });
     },
     updateNewCategoryName(event) {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -18,6 +18,9 @@
         :theads="theads"
         :categories="categories"
         :access="access"
+        :delete-category-name="deleteCategoryName"
+        @open-modal="openModal"
+        @handle-click="handleClick"
       />
     </div>
   </div>
@@ -25,12 +28,14 @@
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -53,12 +58,27 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategory.name;
+    },
   },
   created() {
     this.$store.dispatch('categories/fetchCategories');
     this.$store.commit('categories/clearMessages');
   },
   methods: {
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch(
+        'categories/confirmDeleteCategory',
+        { categoryId, categoryName },
+      );
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.toggleModal();
+      });
+    },
     updateNewCategoryName(event) {
       this.newCategoryName = event.target.value;
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -57,19 +57,10 @@ export default {
           url: `/category/${rootGetters['categories/deleteCategoryId']}`,
           data,
         }).then(() => {
-          axios(rootGetters['auth/token'])({
-            method: 'GET',
-            url: '/category',
-          }).then(res => {
-            commit('setCategories', res.data.categories);
-            commit('displayDoneMessage', {
-              message: 'カテゴリーの削除が完了しました',
-            });
-            resolve();
-          });
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
         });
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
       });
     },
     fetchCategories({ commit, rootGetters }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,17 +7,12 @@ export default {
     errorMessage: '',
     doneMessage: '',
     newCategoryName: '',
-    deleteCategoryName: '',
     isLoading: false,
     deleteCategory: {
       id: null,
       name: '',
     },
     deleteCategoryId: null,
-    categoryList: [],
-  },
-  getters: {
-    deleteCategoryId: state => state.deleteCategoryId,
   },
   mutations: {
     setDoneMessage(state, message) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,6 +13,9 @@ export default {
       name: '',
     },
   },
+  getters: {
+    deleteCategoryId: state => state.deleteCategory.id,
+  },
   mutations: {
     setDoneMessage(state, message) {
       state.doneMessage = message;
@@ -45,20 +48,23 @@ export default {
     confirmDeleteCategory({ commit }, payload) {
       commit('confirmDeleteCategory', { payload });
     },
-    deleteCategory({ commit, rootGetters, state }) {
+    deleteCategory({ commit, rootGetters }) {
       return new Promise(resolve => {
         commit('clearMessages');
-        const data = parseInt(state.deleteCategory.id, 10);
+        const data = parseInt(rootGetters['categories/deleteCategoryId'], 10);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${data}`,
+          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+          data,
         }).then(() => {
           axios(rootGetters['auth/token'])({
             method: 'GET',
             url: '/category',
           }).then(res => {
             commit('setCategories', res.data.categories);
-            commit('setDoneMessage', 'カテゴリーの削除が完了しました');
+            commit('displayDoneMessage', {
+              message: 'カテゴリーの削除が完了しました',
+            });
             resolve();
           });
         });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -40,9 +40,6 @@ export default {
       state.deleteCategory.id = payload.categoryId;
       state.deleteCategory.name = payload.categoryName;
     },
-    displayDoneMessage(state, payload) {
-      state.doneMessage = payload.message;
-    },
   },
   actions: {
     confirmDeleteCategory({ commit }, payload) {
@@ -61,9 +58,7 @@ export default {
             url: '/category',
           }).then(res => {
             commit('setCategories', res.data.categories);
-            commit('displayDoneMessage', {
-              message: 'カテゴリーの削除が完了しました',
-            });
+            commit('setDoneMessage', 'カテゴリーの削除が完了しました');
             resolve();
           });
         });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,7 +12,6 @@ export default {
       id: null,
       name: '',
     },
-    deleteCategoryId: null,
   },
   mutations: {
     setDoneMessage(state, message) {
@@ -40,9 +39,6 @@ export default {
     confirmDeleteCategory(state, { payload }) {
       state.deleteCategory.id = payload.categoryId;
       state.deleteCategory.name = payload.categoryName;
-    },
-    doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
     },
     displayDoneMessage(state, payload) {
       state.doneMessage = payload.message;


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1144

## やったこと
・削除確認用のモーダルが表示されること
・削除確認用のモーダル内には正しいカテゴリー名が表示されていること
・削除ボタンを実行した際にAPI通信が行われること
・通信成功時にはモーダルが閉じること
・通信が成功した場合は、一覧の更新が行われてリストから該当のカテゴリーが削除されること
・成功時のメッセージが画面上に表示されていること

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1146

## 特にレビューをお願いしたい箇所
なし
