### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -7,7 +7,7 @@
         underline
         key-color
         hover-opacity
-        to="/category"
+        to="/categories"
       >
         カテゴリー一覧へ戻る
       </app-router-link>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,6 +1,126 @@
 <template>
-  <div class="category-edit">
-    <h1>Category Edit</h1>
-    <p>Editing category with ID: {{ $route.params.id }}</p>
-  </div>
+  <section class="category-edit">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="category-edit-preview">
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        to="/category"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+    <div class="category-edit-form">
+      <app-input
+        v-validate="'required'"
+        name="name"
+        type="text"
+        white-bg
+        data-vv-as="カテゴリー名"
+        :error-messages="errors.collect('name')"
+        :value="category.name"
+        @update-value="$emit('update-value', $event.target)"
+      />
+      <app-button
+        class="category-edit-submit"
+        button-type="submit"
+        round
+        :disabled="disabled || !access.edit"
+        @click="handleSubmit"
+      >
+        {{ buttonText }}
+      </app-button>
+      <div v-if="errorMessage" class="category-edit__notice">
+        <app-text bg-error>{{ errorMessage }}</app-text>
+      </div>
+
+      <div v-if="doneMessage" class="category-edit__notice">
+        <app-text bg-success>{{ doneMessage }}</app-text>
+      </div>
+    </div>
+  </section>
 </template>
+
+<script>
+import {
+  Heading,
+  Button,
+  Input,
+  Text,
+  RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appInput: Input,
+    appText: Text,
+    appHeading: Heading,
+    appButton: Button,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    category: {
+      type: Object,
+      default: () => ({}),
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+  },
+  methods: {
+    handleSubmit() {
+      if (!this.access.edit) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-edit {
+  &__columns {
+    display: flex;
+    height: 100%;
+  }
+  &-preview {
+    width: 48%;
+    margin-top: 20px;
+    overflow-y: scroll;
+    background-color: #fff;
+  }
+  &-form {
+    margin-top: 10px;
+  }
+  &-submit {
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
+  &__notice--update {
+    margin-bottom: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="category-edit">
+    <h1>Category Edit</h1>
+    <p>Editing category with ID: {{ $route.params.id }}</p>
+  </div>
+</template>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Articles/Edit.vue
+++ b/src/components/pages/Articles/Edit.vue
@@ -65,7 +65,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/fetchCategories');
     this.$store.dispatch('articles/getArticleDetail', parseInt(this.articleId, 10));
   },
   methods: {

--- a/src/components/pages/Articles/Post.vue
+++ b/src/components/pages/Articles/Post.vue
@@ -58,7 +58,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/fetchCategories');
     this.$store.dispatch('articles/initPostArticle');
   },
   methods: {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,7 +1,7 @@
 <template>
   <app-category-edit
     :category="category"
-    :disabled="isLoading ? true : false"
+    :disabled="isLoading"
     :access="access"
     :done-message="doneMessage"
     :error-message="errorMessage"

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,20 +1,58 @@
-<!-- <template>
-  <div class="category-edit">
-    <app-category-edit />
-    <h1>Category Edit</h1>
-    <p>Editing category with ID: {{ $route.params.id }}</p>
-  </div>
+<template>
+  <app-category-edit
+    :category="category"
+    :disabled="isLoading ? true : false"
+    :access="access"
+    :done-message="doneMessage"
+    :error-message="errorMessage"
+    @clear-message="clearMessages"
+    @handle-submit="handleSubmit"
+    @update-value="updateValue"
+  />
 </template>
 
 <script>
-import CategoryEdit from '@Components/molecules/';
+import { CategoryEdit } from '@Components/molecules';
 
 export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
+  computed: {
+    category() {
+      return this.$store.state.categories.category;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    isLoading() {
+      return this.$store.state.categories.isLoading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategory', { id });
+    this.$store.commit('categories/clearMessages');
+  },
+  methods: {
+    clearMessages() {
+      this.$store.dispatch('categories/clearMessages');
+    },
+    updateValue(value) {
+      if (!this.isLoading) this.$store.dispatch('categories/updateValue', value);
+    },
+    handleSubmit() {
+      this.$store.dispatch('categories/updateCategory', this.category);
+    },
+  },
 };
 </script>
 
 <style scoped>
-</style> -->
+</style>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -37,7 +37,7 @@ export default {
   },
   created() {
     const { id } = this.$route.params;
-    this.$store.dispatch('categories/getCategory', { id });
+    this.$store.dispatch('categories/getCategory', id);
     this.$store.commit('categories/clearMessages');
   },
   methods: {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,20 @@
+<!-- <template>
+  <div class="category-edit">
+    <app-category-edit />
+    <h1>Category Edit</h1>
+    <p>Editing category with ID: {{ $route.params.id }}</p>
+  </div>
+</template>
+
+<script>
+import CategoryEdit from '@Components/molecules/';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+};
+</script>
+
+<style scoped>
+</style> -->

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -6,13 +6,13 @@ export default [
   },
   {
     id: 2,
-    name: '記事',
-    path: '/articles',
+    name: 'カテゴリー',
+    path: '/category',
   },
   {
     id: 3,
-    name: 'カテゴリー',
-    path: '/category',
+    name: '記事',
+    path: '/articles',
   },
   {
     id: 4,

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -7,7 +7,7 @@ export default [
   {
     id: 2,
     name: 'カテゴリー',
-    path: '/category',
+    path: '/categories',
   },
   {
     id: 3,

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -20,6 +20,7 @@ import Profile from '@Pages/Profile/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/List.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // ユーザー
 import Users from '@Pages/Users/index.vue';
@@ -79,6 +80,11 @@ const router = new VueRouter({
           name: 'categoryList',
           path: '/category',
           component: CategoryList,
+        },
+        {
+          name: 'categoryEdit',
+          path: '/categories/:id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -73,12 +73,12 @@ const router = new VueRouter({
       component: Profile,
     },
     {
-      path: '/category',
+      path: '/categories',
       component: Categories,
       children: [
         {
           name: 'categoryList',
-          path: '/category',
+          path: '/categories',
           component: CategoryList,
         },
         {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,11 +12,22 @@ export default {
       id: null,
       name: '',
     },
+    category: {
+      id: null,
+      name: '',
+    },
   },
   getters: {
+    category: state => state.category,
     deleteCategoryId: state => state.deleteCategory.id,
   },
   mutations: {
+    updateValue(state, { name, value }) {
+      state.category = { ...state.category, [name]: value };
+    },
+    doneGetCategory(state, { category }) {
+      state.category = { ...state.category, ...category };
+    },
     setDoneMessage(state, message) {
       state.doneMessage = message;
     },
@@ -36,8 +47,8 @@ export default {
     addCategory(state, category) {
       state.categories.unshift(category);
     },
-    setIsLoading(state, value) {
-      state.isLoading = value;
+    setIsLoading(state) {
+      state.isLoading = !state.isLoading;
     },
     confirmDeleteCategory(state, { payload }) {
       state.deleteCategory.id = payload.categoryId;
@@ -45,6 +56,39 @@ export default {
     },
   },
   actions: {
+    getCategory({ commit, rootGetters }, { id }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then(res => {
+        const category = {
+          id: res.data.category.id,
+          name: res.data.category.name,
+        };
+        commit('doneGetCategory', { category });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    updateValue({ commit }, target) {
+      commit('updateValue', target);
+    },
+    updateCategory({ commit, rootGetters }, categoryName) {
+      commit('setIsLoading');
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${rootGetters['categories/category'].id}`,
+        data: {
+          name: categoryName.name,
+        },
+      }).then(() => {
+        commit('setIsLoading');
+      }).then(() => {
+        commit('setDoneMessage', 'カテゴリー更新に成功しました');
+      }).catch(() => {
+        commit('setErrorMessage', 'カテゴリー更新に失敗しました');
+      });
+    },
     confirmDeleteCategory({ commit }, payload) {
       commit('confirmDeleteCategory', { payload });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -56,7 +56,7 @@ export default {
     },
   },
   actions: {
-    getCategory({ commit, rootGetters }, { id }) {
+    getCategory({ commit, rootGetters }, id) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${id}`,

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -25,7 +25,7 @@ export default {
     updateValue(state, { name, value }) {
       state.category = { ...state.category, [name]: value };
     },
-    doneGetCategory(state, { category }) {
+    doneGetCategory(state, category) {
       state.category = { ...state.category, ...category };
     },
     setDoneMessage(state, message) {
@@ -65,7 +65,7 @@ export default {
           id: res.data.category.id,
           name: res.data.category.name,
         };
-        commit('doneGetCategory', { category });
+        commit('doneGetCategory', category);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -85,6 +85,7 @@ export default {
         commit('setIsLoading');
         commit('setDoneMessage', 'カテゴリー更新に成功しました');
       }).catch(() => {
+        commit('setIsLoading');
         commit('setErrorMessage', 'カテゴリー更新に失敗しました');
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -83,7 +83,6 @@ export default {
         },
       }).then(() => {
         commit('setIsLoading');
-      }).then(() => {
         commit('setDoneMessage', 'カテゴリー更新に成功しました');
       }).catch(() => {
         commit('setErrorMessage', 'カテゴリー更新に失敗しました');


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1147

## やったこと
・カテゴリーの編集時に更新する対象のカテゴリー名が表示されていること
・更新ボタンを押すとAPI通信が行われて入力欄の内容が更新されること
・カテゴリ一覧へ戻るボタンをクリックするとカテゴリー管理画面が表示されること 
・更新画面がデザイン通りに実装されていること
・更新完了後に更新ボタンの下に、”更新が成功しました”と表示されること
・更新失敗後に更新ボタンの下に、”更新が失敗しました”と表示されること

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1149

## 特にレビューをお願いしたい箇所
なし
