### PR TITLE
カテゴリー削除機能実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -68,7 +68,7 @@
           theme-color
           tag="p"
         >
-          {{ deleteName }}
+          {{ deleteCategoryName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -114,11 +114,6 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
-    },
-  },
-  computed: {
-    deleteName() {
-      return this.$store.state.categories.deleteCategoryName;
     },
   },
   methods: {

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -68,7 +68,7 @@
           theme-color
           tag="p"
         >
-          {{ deleteCategoryName }}
+          {{ deleteName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -114,6 +114,11 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
+    },
+  },
+  computed: {
+    deleteName() {
+      return this.$store.state.categories.deleteCategoryName;
     },
   },
   methods: {

--- a/src/components/pages/Categories/CategoryMain.vue
+++ b/src/components/pages/Categories/CategoryMain.vue
@@ -32,10 +32,6 @@ export default {
     appCategoryPost: CategoryPost,
   },
   mixins: [Mixins],
-  beforeRouteUpdate(to, from, next) {
-    this.fetchArticles();
-    next();
-  },
   data() {
     return {
       theads: ['カテゴリー名'],

--- a/src/components/pages/Categories/CategoryMain.vue
+++ b/src/components/pages/Categories/CategoryMain.vue
@@ -77,8 +77,8 @@ export default {
       this.$store.dispatch('categories/deleteCategory')
         .then(() => {
           this.$store.dispatch('categories/getAllCategories');
+          this.toggleModal();
         });
-      this.toggleModal();
     },
     handleSubmit() {
       if (this.loading) return;

--- a/src/components/pages/Categories/CategoryMain.vue
+++ b/src/components/pages/Categories/CategoryMain.vue
@@ -70,7 +70,10 @@ export default {
   },
   methods: {
     openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/confirmCategory', { categoryId, categoryName });
+      this.$store.dispatch('categories/confirmDeleteCategory', {
+        categoryId,
+        categoryName,
+      });
       this.toggleModal();
     },
     handleClick() {

--- a/src/components/pages/Categories/CategoryMain.vue
+++ b/src/components/pages/Categories/CategoryMain.vue
@@ -16,6 +16,7 @@
       :theads="theads"
       :access="access"
       :categories="categoryList"
+      :delete-category-name="deleteCategoryName"
       @open-modal="openModal"
       @handle-click="handleClick"
     />
@@ -38,6 +39,9 @@ export default {
     };
   },
   computed: {
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
     deleteCategoryId() {
       return this.$store.state.categories.deleteCategoryId;
     },

--- a/src/components/pages/Categories/CategoryMain.vue
+++ b/src/components/pages/Categories/CategoryMain.vue
@@ -70,7 +70,7 @@ export default {
   },
   methods: {
     openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/confirmDeleteCate', { categoryId, categoryName });
+      this.$store.dispatch('categories/confirmCategory', { categoryId, categoryName });
       this.toggleModal();
     },
     handleClick() {

--- a/src/components/pages/Categories/CategoryMain.vue
+++ b/src/components/pages/Categories/CategoryMain.vue
@@ -16,17 +16,25 @@
       :theads="theads"
       :access="access"
       :categories="categoryList"
+      @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </section>
 </template>
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
+  },
+  mixins: [Mixins],
+  beforeRouteUpdate(to, from, next) {
+    this.fetchArticles();
+    next();
   },
   data() {
     return {
@@ -34,6 +42,9 @@ export default {
     };
   },
   computed: {
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategoryId;
+    },
     loading() {
       return this.$store.state.categories.loading;
     },
@@ -58,6 +69,17 @@ export default {
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/confirmDeleteCate', { categoryId, categoryName });
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory')
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+      this.toggleModal();
+    },
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -105,13 +105,10 @@ export default {
     // カテゴリー削除
     deleteCategory({ commit, rootGetters, state }) {
       commit('clearMessage');
-      const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/deleteCategoryId']);
       return new Promise(resolve => {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `/category/${state.deleteCategoryId}`,
-          data,
         }).then(response => {
           commit('doneDeleteCategory', { categoryId: response.data.category.id });
           commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,12 +7,30 @@ export default {
     errorMessage: '',
     doneMessage: '',
     categories: [],
+    deleteCategoryId: null,
+    deleteCategoryName: '',
     targetCategory: {
       id: null,
       name: '',
     },
   },
+  getters: {
+    deleteCategoryId: state => state.deleteCategoryId,
+  },
   mutations: {
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state, { categoryId }) {
+      state.deleteArticleId = null;
+      const indexToRemove = state.categories.findIndex(
+        category => category.id === categoryId,
+      );
+      if (indexToRemove !== -1) {
+        state.categories.splice(indexToRemove, 1);
+      }
+    },
     clearMessage(state) {
       state.errorMessage = '';
       state.doneMessage = '';
@@ -85,6 +103,25 @@ export default {
         commit('failRequest', { message: err.message });
       }).finally(() => {
         commit('toggleLoading');
+      });
+    },
+    confirmDeleteCate({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
+    // カテゴリー削除
+    deleteCategory({ commit, rootGetters, state }) {
+      commit('clearMessage');
+      const data = new URLSearchParams();
+      data.append('id', rootGetters['categories/deleteCategoryId']);
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${state.deleteCategoryId}`,
+        data,
+      }).then(response => {
+        commit('doneDeleteCategory', { categoryId: response.data.category.id });
+        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -99,7 +99,7 @@ export default {
         commit('toggleLoading');
       });
     },
-    confirmCategory({ commit }, { categoryId, categoryName }) {
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
     },
     // カテゴリー削除

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -22,14 +22,8 @@ export default {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
     },
-    doneDeleteCategory(state, { categoryId }) {
+    doneDeleteCategory(state) {
       state.deleteArticleId = null;
-      const indexToRemove = state.categories.findIndex(
-        category => category.id === categoryId,
-      );
-      if (indexToRemove !== -1) {
-        state.categories.splice(indexToRemove, 1);
-      }
     },
     clearMessage(state) {
       state.errorMessage = '';
@@ -113,15 +107,18 @@ export default {
       commit('clearMessage');
       const data = new URLSearchParams();
       data.append('id', rootGetters['categories/deleteCategoryId']);
-      axios(rootGetters['auth/token'])({
-        method: 'DELETE',
-        url: `/category/${state.deleteCategoryId}`,
-        data,
-      }).then(response => {
-        commit('doneDeleteCategory', { categoryId: response.data.category.id });
-        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${state.deleteCategoryId}`,
+          data,
+        }).then(response => {
+          commit('doneDeleteCategory', { categoryId: response.data.category.id });
+          commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -99,7 +99,7 @@ export default {
         commit('toggleLoading');
       });
     },
-    confirmDeleteCate({ commit }, { categoryId, categoryName }) {
+    confirmCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
     },
     // カテゴリー削除

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -109,8 +109,8 @@ export default {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `/category/${state.deleteCategoryId}`,
-        }).then(response => {
-          commit('doneDeleteCategory', { categoryId: response.data.category.id });
+        }).then(() => {
+          commit('doneDeleteCategory');
           commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
           resolve();
         }).catch(err => {


### PR DESCRIPTION
<!-- 各項目のコメントアウトは削除すること（このコメントアウトも削除） -->
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1150

## やったこと
- 削除したいカテゴリーの削除ボタンを押すとモーダルが開く
- モーダルに削除するカテゴリー名が表示される
- モーダルの削除ボタンを押すとカテゴリーが削除される
- 削除できたらメッセージが表示される
- エラーが起こったらメッセージが表示される
- カテゴリー一覧が更新される

## やらないこと
- なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1152

## 特にレビューをお願いしたい箇所
- カテゴリーを削除し終わって一覧が更新されるところの処理なのですが、
（処理はcategories.jsのdoneDeleteCategoryに書いてあります）
更新される時と、一瞬消えるだけの時がありました。よくわからなかったです。