### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -15,12 +15,12 @@
 
     <app-input
       v-validate="'required'"
-      name="name"
+      name="category"
       type="text"
       placeholder="更新するカテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
-      :value="categoryName"
+      :value="category"
       @update-value="$emit('edited-name', $event)"
     />
     <app-button
@@ -61,7 +61,7 @@ export default {
       type: Number,
       default: 0,
     },
-    categoryName: {
+    category: {
       type: String,
       required: true,
     },

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -57,10 +57,6 @@ export default {
     appRouterLink: RouterLink,
   },
   props: {
-    categoryId: {
-      type: Number,
-      default: 0,
-    },
     category: {
       type: String,
       required: true,

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="edit-category">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <div class="categories-edit__back">
+      <app-router-link
+        block
+        underline
+        key-color
+        hover-opacity
+        to="/categories"
+      >
+        カテゴリー一覧へ戻る
+      </app-router-link>
+    </div>
+
+    <app-input
+      v-validate="'required'"
+      name="name"
+      type="text"
+      placeholder="更新するカテゴリー名を入力してください"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="categoryName"
+      @update-value="$emit('edited-name', $event)"
+    />
+    <app-button
+      class="category-management-post__submit"
+      button-type="submit"
+      round
+      :disabled="!disabled"
+      @click="handleSubmit"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-management-post__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-management-post__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </div>
+</template>
+<script>
+import {
+  Heading, Input, Button, Text, RouterLink,
+
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    categoryId: {
+      type: Number,
+      default: 0,
+    },
+    categoryName: {
+      type: String,
+      required: true,
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+  },
+  methods: {
+    handleSubmit() {
+      if (!this.access.edit) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.categories-edit__back {
+  margin-top: 20px;
+}
+.category-management-post {
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -8,6 +8,7 @@ import UserCreate from './UserCreate/index.vue';
 import UserTable from './UserTable/index.vue';
 import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
@@ -27,6 +28,7 @@ export {
   UserTable,
   UserDetail,
   UserList,
+  CategoryEdit,
   CategoryPost,
   CategoryList,
   ArticleEdit,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,6 +1,7 @@
 <template>
   <app-category-edit
     :category-id="categoryId"
+    :error-message="errorMessage"
     :loading="loading"
     :done-message="doneMessage"
     :access="access"
@@ -38,6 +39,9 @@ export default {
     },
     loading() {
       return this.$store.state.categories.loading;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -5,7 +5,7 @@
     :loading="loading"
     :done-message="doneMessage"
     :access="access"
-    :category-name="categoryName"
+    :category="categoryName"
     @edited-name="editedName($event)"
     @handle-submit="handleSubmit"
   />

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -18,12 +18,6 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
-  data() {
-    return {
-      id: '',
-      name: '',
-    };
-  },
   computed: {
     categoryId() {
       let { id } = this.$route.params;

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,62 @@
+<template>
+  <app-category-edit
+    :category-id="categoryId"
+    :loading="loading"
+    :done-message="doneMessage"
+    :access="access"
+    :category-name="categoryName"
+    @edited-name="editedName($event)"
+    @handle-submit="handleSubmit"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  data() {
+    return {
+      id: '',
+      name: '',
+    };
+  },
+  computed: {
+    categoryId() {
+      let { id } = this.$route.params;
+      id = parseInt(id, 10);
+      return id;
+    },
+    categoryName() {
+      return this.$store.state.categories.targetCategory.name;
+    },
+    currentCategoryName() {
+      const { name } = this.$store.state.categories.targetCategory.category;
+      return name;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategoryDetail', parseInt(this.categoryId, 10));
+  },
+  methods: {
+    editedName($event) {
+      this.$store.dispatch('categories/editedName', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
+  },
+};
+</script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,7 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryMain from '@Pages/Categories/CategoryMain.vue';
-
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 // 記事
 import Articles from '@Pages/Articles/index.vue';
 import ArticleList from '@Pages/Articles/List.vue';
@@ -119,6 +119,11 @@ const router = new VueRouter({
           name: 'categoryMain',
           path: '',
           component: CategoryMain,
+        },
+        {
+          name: 'CategoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -152,8 +152,9 @@ export default {
         commit('updateCategory', payload);
         commit('toggleLoading');
         commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
-      }).catch(() => {
+      }).catch(err => {
         commit('toggleLoading');
+        commit('failRequest', { message: err.message });
       });
     },
     // 更新画面遷移時に名前を取得

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -138,7 +138,6 @@ export default {
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/targetCategory'].id);
       data.append('name', rootGetters['categories/targetCategory'].name);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
@@ -146,8 +145,7 @@ export default {
         data,
       }).then(res => {
         const payload = {
-          id: res.data.category.id,
-          name: res.data.category.title,
+          name: res.data.category.name,
         };
         commit('updateCategory', payload);
         commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -157,23 +157,19 @@ export default {
     },
     // 更新画面遷移時に名前を取得
     getCategoryDetail({ commit, rootGetters }, categoryId) {
-      return new Promise((resolve, reject) => {
-        axios(rootGetters['auth/token'])({
-          method: 'GET',
-          url: `/category/${categoryId}`,
-        }).then(res => {
-          const payload = {
-            category: {
-              id: res.data.category.id,
-              name: res.data.category.name,
-            },
-          };
-          commit('doneGetCategory', payload);
-          resolve();
-        }).catch(err => {
-          commit('failRequest', { message: err.message });
-          reject();
-        });
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(res => {
+        const payload = {
+          category: {
+            id: res.data.category.id,
+            name: res.data.category.name,
+          },
+        };
+        commit('doneGetCategory', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1163

## やったこと
- 更新ボタンを押すと、カテゴリー更新画面に遷移する
- 選択したカテゴリー名が表示される
- 編集して更新ボタンを押すと更新される
- 更新が成功したら '更新しました' のメッセージを表示
- 更新が失敗したらエラーメッセージを表示

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1165

## 特にレビューをお願いしたい箇所
更新した後に元のカテゴリー画面に戻ると、新規カテゴリー入力の部分に更新時に入力したカテゴリー名が入ってしまいました。 CategoryEdit / index.vueを作成した際に CategoryPost / index.vueを使用したためだと思うのですが、どこを書き換えれば消えるのかがわかりませんでした。教えていただきたいです。