### PR TITLE
更新画面から遷移した時にカテゴリー一覧の入力欄が空になるように変更

### DIFF
--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -25,10 +25,10 @@ export default {
       return id;
     },
     categoryName() {
-      return this.$store.state.categories.targetCategory.name;
+      return this.$store.state.categories.editCategory.name;
     },
     currentCategoryName() {
-      const { name } = this.$store.state.categories.targetCategory.category;
+      const { name } = this.$store.state.categories.editCategory.category;
       return name;
     },
     loading() {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,10 +13,14 @@ export default {
       id: null,
       name: '',
     },
+    editCategory: {
+      id: null,
+      name: '',
+    },
   },
   getters: {
     deleteCategoryId: state => state.deleteCategoryId,
-    targetCategory: state => state.targetCategory,
+    editCategory: state => state.editCategory,
   },
   mutations: {
     confirmDeleteCategory(state, { categoryId, categoryName }) {
@@ -50,13 +54,13 @@ export default {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
     editedName(state, payload) {
-      state.targetCategory = { ...state.targetCategory, name: payload.name };
+      state.editCategory = { ...state.editCategory, name: payload.name };
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
     },
     doneGetCategory(state, payload) {
-      state.targetCategory = { ...state.targetCategory, ...payload.category };
+      state.editCategory = { ...state.editCategory, ...payload.category };
     },
     updateCategory(state, { name }) {
       state.targetCategory = { ...state.targetCategory, ...name };
@@ -138,10 +142,10 @@ export default {
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('name', rootGetters['categories/targetCategory'].name);
+      data.append('name', rootGetters['categories/editCategory'].name);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${rootGetters['categories/targetCategory'].id}`,
+        url: `/category/${rootGetters['categories/editCategory'].id}`,
         data,
       }).then(res => {
         const payload = {


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1163
## やったこと
更新画面から遷移してカテゴリー一覧画面にきたときに入力欄が空になるようにした

## やらないこと
なし
## テスト
https://gizumo.backlog.com/view/GIZFE-1165
## 特にレビューをお願いしたい箇所
なし