### PR TITLE
カテゴリ一削除機能実装完了

### DIFF
--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -67,11 +67,10 @@ export default {
   },
   methods: {
     openModal(categoryId, categoryName) {
-      const payload = {
+      this.$store.dispatch('category/confirmDeleteCategory', {
         categoryId,
         categoryName,
-      };
-      this.$store.dispatch('category/confirmDeleteCategory', payload);
+      });
       this.toggleModal();
     },
     handleClick() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -75,8 +75,9 @@ export default {
     },
     handleClick() {
       this.$store.dispatch('category/deleteCategory').then(() => {
-        this.toggleModal();
+        this.$store.dispatch('category/getAllCategories');
       });
+      this.toggleModal();
     },
     createCategory() {
       this.$store.dispatch('category/loading', true);

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -17,6 +17,9 @@
         :theads="theads"
         :categories="categoriesList"
         :access="access"
+        :delete-category-name="deleteCategoryName"
+        @open-modal="openModal"
+        @handle-click="handleClick"
       />
     </div>
   </div>
@@ -24,12 +27,14 @@
 
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -52,12 +57,28 @@ export default {
     errorMessage() {
       return this.$store.state.category.errorMessage;
     },
+    deleteCategoryName() {
+      return this.$store.state.category.deleteCategory.name;
+    },
   },
   created() {
     this.$store.dispatch('category/getAllCategories');
     this.$store.dispatch('category/clearMessage');
   },
   methods: {
+    openModal(categoryId, categoryName) {
+      const payload = {
+        categoryId,
+        categoryName,
+      };
+      this.$store.dispatch('category/confirmDeleteCategory', payload);
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('category/deleteCategory').then(() => {
+        this.toggleModal();
+      });
+    },
     createCategory() {
       this.$store.dispatch('category/loading', true);
       this.$store.dispatch('category/createCategory', this.newCategoryName)

--- a/src/js/_store/modules/category.js
+++ b/src/js/_store/modules/category.js
@@ -42,7 +42,7 @@ export default {
       commit('confirmDeleteCategory', { payload });
     },
     deleteCategory({ commit, rootGetters, state }) {
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         commit('clearMessage');
         const data = parseInt(state.deleteCategory.id.categoryId, 10);
         axios(rootGetters['auth/token'])({
@@ -53,7 +53,6 @@ export default {
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
-          reject(err);
         });
       });
     },

--- a/src/js/_store/modules/category.js
+++ b/src/js/_store/modules/category.js
@@ -7,6 +7,10 @@ export default {
     loading: false,
     doneMessage: '',
     errorMessage: '',
+    deleteCategory: {
+      id: null,
+      name: '',
+    },
   },
   mutations: {
     addCategory(state, category) {
@@ -28,8 +32,37 @@ export default {
       state.doneMessage = '';
       state.errorMessage = '';
     },
+    confirmDeleteCategory(state, { payload }) {
+      state.deleteCategory.id = payload;
+      state.deleteCategory.name = payload.categoryName;
+    },
   },
   actions: {
+    confirmDeleteCategory({ commit }, payload) {
+      commit('confirmDeleteCategory', { payload });
+    },
+    deleteCategory({ commit, rootGetters, state }) {
+      return new Promise(resolve => {
+        commit('clearMessage');
+        const data = parseInt(state.deleteCategory.id.categoryId, 10);
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${data}`,
+        }).then(() => {
+          axios(rootGetters['auth/token'])({
+            method: 'GET',
+            url: '/category',
+          }).then(res => {
+            const payload = { categories: res.data.categories };
+            commit('doneAllCategories', payload);
+            commit('doneMessage', 'カテゴリーの削除が完了しました。');
+            resolve();
+          });
+        });
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
     clearMessage({ commit }) {
       commit('clearMessage');
     },

--- a/src/js/_store/modules/category.js
+++ b/src/js/_store/modules/category.js
@@ -42,25 +42,19 @@ export default {
       commit('confirmDeleteCategory', { payload });
     },
     deleteCategory({ commit, rootGetters, state }) {
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         commit('clearMessage');
         const data = parseInt(state.deleteCategory.id.categoryId, 10);
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `/category/${data}`,
         }).then(() => {
-          axios(rootGetters['auth/token'])({
-            method: 'GET',
-            url: '/category',
-          }).then(res => {
-            const payload = { categories: res.data.categories };
-            commit('doneAllCategories', payload);
-            commit('doneMessage', 'カテゴリーの削除が完了しました。');
-            resolve();
-          });
+          commit('doneMessage', 'カテゴリーの削除が完了しました。');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+          reject(err);
         });
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
       });
     },
     clearMessage({ commit }) {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1188

## やったこと
・削除ボタンを押したのち、削除確認用モーダルが出現する
・A削除確認用のモーダルに削除対象のカテゴリ名の表示する
・削除確認用のモーダル内部の削除ボタンをクリックしたら削除APIが実行する
・削除APIが成功した場合に一覧の更新とメッセージ表示する
・失敗した場合、エラーメッセージが表示される

## やらないこと
なし

## テスト
<!-- Backlogのテストチケットのリンクを記載 -->

## 特にレビューをお願いしたい箇所
特にはありません！
