### PR TITLE
GIZFE-1123　カテゴリー削除機能の実装

### DIFF
--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -68,7 +68,7 @@
           theme-color
           tag="p"
         >
-          {{ deleteCategoryName }}
+          {{ deleteCategory.name }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -107,9 +107,9 @@ export default {
         return [];
       },
     },
-    deleteCategoryName: {
-      type: String,
-      default: '',
+    deleteCategory: {
+      type: Object,
+      default: () => ({}),
     },
     access: {
       type: Object,

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -15,18 +15,22 @@
       :categories="categoriesList"
       :access="access"
       :theads="theads"
+      :delete-category-name="deleteCategoryName"
+      @open-modal="openModal"
     />
   </div>
 </template>
 
 <script>
 import { CategoryPost, CategoryList } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
@@ -51,6 +55,9 @@ export default {
     disabled() {
       return this.$store.state.categories.disabled;
     },
+    deleteCategoryName() {
+      return this.$store.state.categories.deleteCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -64,6 +71,11 @@ export default {
     },
     handleSubmit() {
       this.$store.dispatch('categories/postCategory');
+    },
+    openModal(categoryId, categoryName) {
+      this.$store.dispatch('categories/confirmDeleteCategory', { categoryId, categoryName });
+
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -15,8 +15,11 @@
       :categories="categoriesList"
       :access="access"
       :theads="theads"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
       :delete-category-name="deleteCategoryName"
       @open-modal="openModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
@@ -58,9 +61,13 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
+    deleteCategoryId() {
+      return this.$store.state.categories.deleteCategoryId;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     clearMessage() {
@@ -73,8 +80,17 @@ export default {
       this.$store.dispatch('categories/postCategory');
     },
     openModal(categoryId, categoryName) {
-      this.$store.dispatch('categories/confirmDeleteCategory', { categoryId, categoryName });
-
+      this.$store.dispatch(
+        'categories/confirmDeleteCategory',
+        { categoryId, categoryName },
+      );
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategoryId })
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
       this.toggleModal();
     },
   },

--- a/src/components/pages/Categories/Management.vue
+++ b/src/components/pages/Categories/Management.vue
@@ -17,7 +17,7 @@
       :theads="theads"
       :error-message="errorMessage"
       :done-message="doneMessage"
-      :delete-category-name="deleteCategoryName"
+      :delete-category="deleteCategory"
       @open-modal="openModal"
       @handle-click="handleClick"
     />
@@ -58,11 +58,8 @@ export default {
     disabled() {
       return this.$store.state.categories.disabled;
     },
-    deleteCategoryName() {
-      return this.$store.state.categories.deleteCategoryName;
-    },
-    deleteCategoryId() {
-      return this.$store.state.categories.deleteCategoryId;
+    deleteCategory() {
+      return this.$store.state.categories.deleteCategory;
     },
   },
   created() {
@@ -87,7 +84,7 @@ export default {
       this.toggleModal();
     },
     handleClick() {
-      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategoryId })
+      this.$store.dispatch('categories/deleteCategory', { id: this.deleteCategory.id })
         .then(() => {
           this.$store.dispatch('categories/getAllCategories');
         });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,12 +11,14 @@ export default {
     doneMessage: '',
     errorMessage: '',
     disabled: false,
-    deleteCategoryId: null,
-    deleteCategoryName: null,
+    deleteCategory: {
+      id: null,
+      name: null,
+    },
   },
   getters: {
     targetCategory: state => state.targetCategory,
-    deleteCategoryId: state => state.deleteCategoryId,
+    deleteCategory: state => state.deleteCategory,
   },
   mutations: {
     initPostCategory(state) {
@@ -49,11 +51,11 @@ export default {
       state.disabled = !state.disabled;
     },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
-      state.deleteCategoryId = categoryId;
-      state.deleteCategoryName = categoryName;
+      state.deleteCategory.id = categoryId;
+      state.deleteCategory.name = categoryName;
     },
     doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
+      state.deleteCategory.id = null;
       state.doneMessage = 'カテゴリーを削除しました';
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -16,6 +16,7 @@ export default {
   },
   getters: {
     targetCategory: state => state.targetCategory,
+    deleteCategoryId: state => state.deleteCategoryId,
   },
   mutations: {
     initPostCategory(state) {
@@ -37,7 +38,7 @@ export default {
     updateCategory(state, payload) {
       state.categoriesList = [payload.newCategories.category, ...state.categoriesList];
     },
-    displayDoneMessage(state, payload) {
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
     },
     clearMessage(state) {
@@ -51,10 +52,13 @@ export default {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
     },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.doneMessage = 'カテゴリーを削除しました';
+    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
-      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: '/category',
@@ -97,6 +101,21 @@ export default {
     },
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
+    deleteCategory({ commit, rootGetters }, { id }) {
+      commit('clearMessage');
+      return new Promise(resolve => {
+        axios(rootGetters['auth/token'])({
+          method: 'DELETE',
+          url: `/category/${id}`,
+        }).then(res => {
+          if (res.data.code === 0) throw new Error(res.data.message);
+          commit('doneDeleteCategory');
+          resolve();
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+        });
+      });
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,6 +11,8 @@ export default {
     doneMessage: '',
     errorMessage: '',
     disabled: false,
+    deleteCategoryId: null,
+    deleteCategoryName: null,
   },
   getters: {
     targetCategory: state => state.targetCategory,
@@ -44,6 +46,10 @@ export default {
     },
     toggleDisabled(state) {
       state.disabled = !state.disabled;
+    },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
     },
   },
   actions: {
@@ -88,6 +94,9 @@ export default {
     },
     clearMessage({ commit }) {
       commit('clearMessage');
+    },
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1123

## やったこと
* カテゴリーリスト内の削除ボタンをクリック時にモーダルを表示させる
* モーダル内に対象カテゴリー名を表示させる
* モーダル内削除ボタンをクリック時に対象カテゴリーを削除させる
* カテゴリー削除時カテゴリーリストを更新しメッセージを表示させる

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1125

## 特にレビューをお願いしたい箇所
削除APIのリクエストと削除後の一覧更新についての記載に問題がないか
不要コードの追加でコードが冗長になっていないか
