### PR TITLE
GIZFE-1132　カテゴリー更新機能実装

### DIFF
--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -13,6 +13,7 @@
       class="category-update__input"
       name="category"
       type="text"
+      :value="categoryName"
     />
     <app-button
       class="category-update__button"
@@ -34,6 +35,16 @@ export default {
     appHeading: Heading,
     appInput: Input,
     appButton: Button,
+  },
+  props: {
+    updateCategory: {
+      type: String,
+      default: '',
+    },
+    categoryName: {
+      type: String,
+      default: '',
+    },
   },
 };
 </script>

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="category-update">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      :to="`/categories`"
+      underline
+      hover-opacity
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      class="category-update__input"
+      name="category"
+      type="text"
+    />
+    <app-button
+      class="category-update__button"
+      round
+    >
+      更新
+    </app-button>
+  </div>
+</template>
+
+<script>
+import {
+  RouterLink, Heading, Input, Button,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appRouterLink: RouterLink,
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-update {
+  .router-link {
+    padding-top: 16px;
+  }
+  &__input {
+    margin-top: 16px;
+  }
+  &__button {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -11,22 +11,35 @@
     <app-input
       v-validate="'required'"
       class="category-update__input"
-      name="category"
-      type="text"
+      name="name"
+      type="formData"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('name')"
       :value="categoryName"
+      @update-value="$emit('edit-name', $event)"
     />
     <app-button
       class="category-update__button"
+      :disabled="!disabled"
       round
+      @click="handleSubmit"
     >
-      更新
+      {{ buttonText }}
     </app-button>
+
+    <div v-if="errorMessage" class="category-update__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-update__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
   </div>
 </template>
 
 <script>
 import {
-  RouterLink, Heading, Input, Button,
+  RouterLink, Heading, Input, Button, Text,
 } from '@Components/atoms';
 
 export default {
@@ -35,15 +48,49 @@ export default {
     appHeading: Heading,
     appInput: Input,
     appButton: Button,
+    appText: Text,
   },
   props: {
     updateCategory: {
-      type: String,
-      default: '',
+      type: Object,
+      default: () => ({}),
     },
     categoryName: {
       type: String,
       default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+  },
+  methods: {
+    handleSubmit(updateCategory) {
+      if (!this.access.edit) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit', updateCategory.id);
+      });
     },
   },
 };
@@ -51,6 +98,10 @@ export default {
 
 <style lang="scss" scoped>
 .category-update {
+  &__notice {
+    display:flex;
+    margin-top: 16px;
+  }
   .router-link {
     padding-top: 16px;
   }

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -22,7 +22,7 @@
       class="category-update__button"
       :disabled="disabled || !access.edit"
       round
-      @click="putCategory"
+      @click="handleSubmit"
     >
       {{ buttonText }}
     </app-button>
@@ -79,10 +79,10 @@ export default {
     },
   },
   methods: {
-    putCategory() {
+    handleSubmit() {
       if (!this.access.edit) return;
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('put-category');
+        if (valid) this.$emit('handle-submit');
       });
     },
   },

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -20,7 +20,7 @@
     />
     <app-button
       class="category-update__button"
-      :disabled="!disabled"
+      :disabled="disabled || !access.edit"
       round
       @click="handleSubmit"
     >
@@ -51,10 +51,6 @@ export default {
     appText: Text,
   },
   props: {
-    updateCategory: {
-      type: Object,
-      default: () => ({}),
-    },
     categoryName: {
       type: String,
       default: '',
@@ -71,7 +67,7 @@ export default {
       type: String,
       default: '',
     },
-    loading: {
+    disabled: {
       type: Boolean,
       default: false,
     },
@@ -79,10 +75,7 @@ export default {
   computed: {
     buttonText() {
       if (!this.access.edit) return '更新権限がありません';
-      return this.loading ? '更新中...' : '更新';
-    },
-    disabled() {
-      return this.access.edit && !this.loading;
+      return this.disabled ? '更新中...' : '更新';
     },
   },
   methods: {

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -22,7 +22,7 @@
       class="category-update__button"
       :disabled="disabled || !access.edit"
       round
-      @click="handleSubmit"
+      @click="putCategory"
     >
       {{ buttonText }}
     </app-button>
@@ -79,10 +79,10 @@ export default {
     },
   },
   methods: {
-    handleSubmit(updateCategory) {
+    putCategory() {
       if (!this.access.edit) return;
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('handle-submit', updateCategory.id);
+        if (valid) this.$emit('put-category');
       });
     },
   },

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryUpdate from './CategoryUpdate/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryUpdate,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -5,8 +5,7 @@
       :category-id="categoryId"
       :category-name="categoryName"
       :access="access"
-      :loading="loading"
-      :update-category="updateCategory"
+      :disabled="disabled"
       :done-message="doneMessage"
       :error-message="errorMessage"
       @edit-name="editName"
@@ -27,11 +26,10 @@ export default {
       return this.$store.state.categories.updateCategory.name;
     },
     categoryId() {
-      const id = parseInt(this.$route.params.id, 10);
-      return id;
+      return parseInt(this.$route.params.id, 10);
     },
-    loading() {
-      return this.$store.state.categories.loading;
+    disabled() {
+      return this.$store.state.categories.disabled;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -47,15 +45,16 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getUpdateCategory', parseInt(this.categoryId, 10));
+    this.$store.dispatch('categories/getUpdateCategory', this.categoryId);
   },
   methods: {
     editName($event) {
       this.$store.dispatch('categories/editName', $event.target.value);
     },
     handleSubmit() {
+      console.log(this.access);
       this.$store.dispatch(
-        'categories/updateName',
+        'categories/updateCategory',
         {
           id: this.updateCategory.id,
           name: this.updateCategory.name,

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <app-category-update>
+      class="category-update"
+      :category="targetCategory"
+    </app-category-update>
+  </div>
+</template>
+
+<script>
+import { CategoryUpdate } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryUpdate: CategoryUpdate,
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+  },
+};
+</script>

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -52,7 +52,6 @@ export default {
       this.$store.dispatch('categories/editName', $event.target.value);
     },
     handleSubmit() {
-      console.log(this.access);
       this.$store.dispatch(
         'categories/updateCategory',
         {

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -2,14 +2,13 @@
   <div>
     <app-category-update
       class="category-update"
-      :category-id="categoryId"
       :category-name="categoryName"
       :access="access"
       :disabled="disabled"
       :done-message="doneMessage"
       :error-message="errorMessage"
       @edit-name="editName"
-      @handle-submit="handleSubmit"
+      @put-category="putCategory"
     />
   </div>
 </template>
@@ -51,7 +50,7 @@ export default {
     editName($event) {
       this.$store.dispatch('categories/editName', $event.target.value);
     },
-    handleSubmit() {
+    putCategory() {
       this.$store.dispatch(
         'categories/updateCategory',
         {

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -8,7 +8,7 @@
       :done-message="doneMessage"
       :error-message="errorMessage"
       @edit-name="editName"
-      @put-category="putCategory"
+      @handle-submit="handleSubmit"
     />
   </div>
 </template>
@@ -50,7 +50,7 @@ export default {
     editName($event) {
       this.$store.dispatch('categories/editName', $event.target.value);
     },
-    putCategory() {
+    handleSubmit() {
       this.$store.dispatch(
         'categories/updateCategory',
         {

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <app-category-update>
+    <app-category-update
       class="category-update"
-      :category="targetCategory"
-    </app-category-update>
+      :category-name="categoryName"
+    />
   </div>
 </template>
 
@@ -14,8 +14,17 @@ export default {
   components: {
     appCategoryUpdate: CategoryUpdate,
   },
+  computed: {
+    categoryName() {
+      return this.$store.state.categories.updateCategory.name;
+    },
+    categoryId() {
+      const id = parseInt(this.$route.params.id, 10);
+      return id;
+    },
+  },
   created() {
-    this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/getUpdateCategory', parseInt(this.categoryId, 10));
   },
 };
 </script>

--- a/src/components/pages/Categories/Update.vue
+++ b/src/components/pages/Categories/Update.vue
@@ -2,7 +2,15 @@
   <div>
     <app-category-update
       class="category-update"
+      :category-id="categoryId"
       :category-name="categoryName"
+      :access="access"
+      :loading="loading"
+      :update-category="updateCategory"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
+      @edit-name="editName"
+      @handle-submit="handleSubmit"
     />
   </div>
 </template>
@@ -22,9 +30,38 @@ export default {
       const id = parseInt(this.$route.params.id, 10);
       return id;
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    updateCategory() {
+      return this.$store.state.categories.updateCategory;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
   },
   created() {
     this.$store.dispatch('categories/getUpdateCategory', parseInt(this.categoryId, 10));
+  },
+  methods: {
+    editName($event) {
+      this.$store.dispatch('categories/editName', $event.target.value);
+    },
+    handleSubmit() {
+      this.$store.dispatch(
+        'categories/updateName',
+        {
+          id: this.updateCategory.id,
+          name: this.updateCategory.name,
+        },
+      );
+    },
   },
 };
 </script>

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -8,6 +8,7 @@ import NotFound from '@Pages/NotFound/index.vue';
 import Home from '@Pages/Home/index.vue';
 import Categories from '@Pages/Categories/index.vue';
 import Management from '@Pages/Categories/Management.vue';
+import Update from '@Pages/Categories/Update.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -63,6 +64,11 @@ const router = new VueRouter({
           name: 'management',
           path: '',
           component: Management,
+        },
+        {
+          name: 'update',
+          path: ':id',
+          component: Update,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -15,7 +15,6 @@ export default {
     doneMessage: '',
     errorMessage: '',
     disabled: false,
-    loading: false,
     deleteCategory: {
       id: null,
       name: null,
@@ -82,8 +81,7 @@ export default {
     },
     doneEditCategory(state, { updateCategory }) {
       state.updateCategory = { ...state.updateCategory, ...updateCategory };
-      state.loading = false;
-      state.doneMessage = 'ユーザーの更新が完了しました。';
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
   },
   actions: {
@@ -168,8 +166,9 @@ export default {
         name,
       });
     },
-    updateName({ commit, rootGetters }, updateCategory) {
-      commit('toggleLoading');
+    updateCategory({ commit, rootGetters }, updateCategory) {
+      commit('toggleDisabled');
+      commit('clearMessage');
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${updateCategory.id}`,
@@ -179,8 +178,10 @@ export default {
           id: res.data.category.id,
           name: res.data.category.name,
         };
+        commit('toggleDisabled');
         commit('doneEditCategory', { editCategory });
       }).catch(err => {
+        commit('toggleDisabled');
         commit('failRequest', { message: err.message });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -59,9 +59,6 @@ export default {
     toggleDisabled(state) {
       state.disabled = !state.disabled;
     },
-    toggleLoading(state) {
-      state.loading = !state.loading;
-    },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategory.id = categoryId;
       state.deleteCategory.name = categoryName;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,6 +7,10 @@ export default {
       id: null,
       name: '',
     },
+    updateCategory: {
+      id: null,
+      name: '',
+    },
     categoriesList: [],
     doneMessage: '',
     errorMessage: '',
@@ -57,6 +61,9 @@ export default {
     doneDeleteCategory(state) {
       state.deleteCategory.id = null;
       state.doneMessage = 'カテゴリーを削除しました';
+    },
+    doneUpdateCategory(state, payload) {
+      state.updateCategory = payload.updateCategory;
     },
   },
   actions: {
@@ -117,6 +124,22 @@ export default {
         }).catch(err => {
           commit('failRequest', { message: err.message });
         });
+      });
+    },
+    getUpdateCategory({ commit, rootGetters }, categoryId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(res => {
+        const payload = {
+          updateCategory: {
+            id: res.data.category.id,
+            name: res.data.category.name,
+          },
+        };
+        commit('doneUpdateCategory', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
       });
     },
   },


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1132

## やったこと
* 新規コンポーネントとして更新画面を作成する。
* 更新画面へ遷移。
* 管理画面の更新ボタンをクリック時に該当カテゴリーの詳細をAPI通信で取得。
* カテゴリー一覧へ戻るボタンをクリック時にカテゴリー管理画面へ遷移。
* カテゴリー更新画面の更新ボタンをクリック時入力欄の内容に変更させる。
* 更新ボタンをAPI通信中に非表示状態にさせる。
* API通信の処理後にAPI通信で返されたメッセージを表示させる。

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1134

## 特にレビューをお願いしたい箇所
新しく命名したコンポーネントや関数名の命名について、何をしているかわかりずらいようにも
感じたため、命名に問題がないか。

