### PR TITLE
カテゴリー更新機能実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "liveServer.settings.root": "/dist"
+  "liveServer.settings.root": "/dist",
+  "cSpell.words": [
+    "linebreak"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
-  "liveServer.settings.root": "/dist",
-  "cSpell.words": [
-    "linebreak"
-  ]
+  "liveServer.settings.root": "/dist"
 }

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -17,7 +17,6 @@
       :delete-category-name="deleteCategoryName"
       :access="access"
       @open-modal="openModal"
-      @close-modal="toggleModal"
       @handle-click="handleClick"
     />
   </div>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -65,6 +65,11 @@ export default {
     fetchCategories() {
       this.$store.dispatch('categories/getAllCategories');
     },
+    openModal(categoryId, categoryName) {
+      this.$data.deleteCategoryName = categoryName;
+      this.$store.dispatch('categories/confirmDeleteId', categoryId);
+      this.toggleModal();
+    },
     updateValue($event) {
       const categoryName = $event.target.value;
       this.$data.category = categoryName;
@@ -73,6 +78,10 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory');
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,27 +2,39 @@
   <div class="list-contents">
     <app-category-post
       :access="access"
+      :category="categoryName"
+      :disabled="loading"
+      :done-message="doneMessage"
       class="list-content list-post"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       :categories="categoriesList"
       class="list-content list-list"
       :theads="theads"
+      :delete-category-name="deleteCategoryName"
       :access="access"
+      @open-modal="openModal"
+      @close-modal="toggleModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
+      deleteCategoryName: '',
     };
   },
   computed: {
@@ -32,13 +44,44 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    categoryName() {
+      return this.$store.state.categories.targetCategory.category.name;
+    },
   },
   created() {
     this.fetchCategories();
+    this.resetView();
   },
   methods: {
+    resetView() {
+      this.$store.dispatch('categories/resetView');
+    },
     fetchCategories() {
-      this.$store.dispatch('getAllCategories');
+      this.$store.dispatch('categories/getAllCategories');
+    },
+    openModal(categoryId, categoryName) {
+      this.$data.deleteCategoryName = categoryName;
+      this.$store.dispatch('categories/confirmDeleteId', categoryId);
+      this.toggleModal();
+    },
+    updateValue($event) {
+      const categoryName = $event.target.value;
+      this.$data.category = categoryName;
+      this.$store.dispatch('categories/updateValue', categoryName);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory');
+    },
+    handleClick() {
+      this.$store.dispatch('categories/deleteCategory');
+      this.toggleModal();
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,27 +2,39 @@
   <div class="list-contents">
     <app-category-post
       :access="access"
+      :category="categoryName"
+      :disabled="loading"
+      :done-message="doneMessage"
       class="list-content list-post"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       :categories="categoriesList"
       class="list-content list-list"
       :theads="theads"
+      :delete-category-name="deleteCategoryName"
       :access="access"
+      @open-modal="openModal"
+      @close-modal="toggleModal"
+      @handle-click="handleClick"
     />
   </div>
 </template>
 <script>
 import { CategoryList, CategoryPost } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appCategoryList: CategoryList,
     appCategoryPost: CategoryPost,
   },
+  mixins: [Mixins],
   data() {
     return {
       theads: ['カテゴリー名'],
+      deleteCategoryName: '',
     };
   },
   computed: {
@@ -32,13 +44,35 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    categoryName() {
+      return this.$store.state.categories.targetCategory.category.name;
+    },
   },
   created() {
     this.fetchCategories();
+    this.resetView();
   },
   methods: {
+    resetView() {
+      this.$store.dispatch('categories/resetView');
+    },
     fetchCategories() {
-      this.$store.dispatch('getAllCategories');
+      this.$store.dispatch('categories/getAllCategories');
+    },
+    updateValue($event) {
+      const categoryName = $event.target.value;
+      this.$data.category = categoryName;
+      this.$store.dispatch('categories/updateValue', categoryName);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -5,6 +5,7 @@
       :category="categoryName"
       :disabled="loading"
       :done-message="doneMessage"
+      :error-message="errorMessage"
       class="list-content list-post"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
@@ -49,6 +50,9 @@ export default {
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
     },
     categoryName() {
       return this.$store.state.categories.targetCategory.category.name;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -65,11 +65,6 @@ export default {
     fetchCategories() {
       this.$store.dispatch('categories/getAllCategories');
     },
-    openModal(categoryId, categoryName) {
-      this.$data.deleteCategoryName = categoryName;
-      this.$store.dispatch('categories/confirmDeleteId', categoryId);
-      this.toggleModal();
-    },
     updateValue($event) {
       const categoryName = $event.target.value;
       this.$data.category = categoryName;
@@ -78,10 +73,6 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory');
-    },
-    handleClick() {
-      this.$store.dispatch('categories/deleteCategory');
-      this.toggleModal();
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -47,7 +47,6 @@ export default {
       state.doneMessage = '';
       state.errorMessage = '';
     },
- },
   actions: {
     resetView({ commit }) {
       commit('resetView');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -119,6 +119,9 @@ export default {
       }).then(() => {
         commit('doneDeleteCategory');
         commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
+        if(this.state.categories.errorMessage) {
+          this.state.categories.errorMessage = '';
+        };
         dispatch('getAllCategories');
       }).catch(() => {
         commit('displayErrorMessage', { message: 'カテゴリーの削除に失敗しました' });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -1,19 +1,98 @@
 import axios from '@Helpers/axiosDefault';
 
 export default {
+  namespaced: true,
   state: {
+    targetCategory: {
+      category: {
+        name: '',
+      },
+    },
     categoryList: [],
     errorMessage: '',
+    doneMessage: '',
+    loading: false,
+    deleteCategoryId: null,
+  },
+  getters: {
+    targetCategory: state => state.targetCategory,
+    categoryList: state => state.categoryList,
+    deleteCategoryId: state => state.deleteCategoryId,
+
   },
   mutations: {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
+      state.categoryList.reverse();
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
     },
+    clearMessage(state) {
+      state.targetCategory.category.name = '';
+    },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
+    },
+    displayErrorMessage(state, payload = { message: '失敗しました' }) {
+      state.doneMessage = payload.message;
+    },
+    updateValue(state, payload) {
+      state.targetCategory.category.name = payload.category;
+    },
+    newCategory(state, payload) {
+      state.categoryList.unshift(payload);
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    resetView(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
+    },
+    confirmDeleteId(state, { categoryId }) {
+      state.deleteCategoryId = categoryId;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+    },
+    deletedCategoryList(state, payload) {
+      return state.categoryList.splice(payload, 1);
+    },
   },
   actions: {
+    resetView({ commit }) {
+      commit('resetView');
+    },
+    updateValue({ commit }, categoryName) {
+      const name = categoryName;
+      const payload = {
+        category: name,
+      };
+      commit('updateValue', payload);
+    },
+    postCategory({ commit, rootGetters }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', rootGetters['categories/targetCategory'].category.name);
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data,
+      }).then(res => {
+        commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
+        commit('newCategory', res.data.category);
+        commit('toggleLoading');
+        commit('clearMessage');
+      }).catch(() => {
+        commit('displayErrorMessage', { message: 'カテゴリー取得に失敗しました' });
+        commit('toggleLoading');
+        commit('clearMessage');
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -23,6 +102,24 @@ export default {
           categories: res.data.categories,
         };
         commit('doneGetAllCategories', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+    confirmDeleteId({ commit }, categoryId) {
+      commit('confirmDeleteId', { categoryId });
+    },
+    deleteCategory({ commit, rootGetters }) {
+      const data = new URLSearchParams();
+      data.append('id', rootGetters['categories/deleteCategoryId']);
+      axios(rootGetters['auth/token'])({
+        method: 'DELETE',
+        url: `/category/${rootGetters['categories/deleteCategoryId']}`,
+        data,
+      }).then(() => {
+        commit('doneDeleteCategory');
+        commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
+        commit('deletedCategoryList', rootGetters['categories/deleteCategoryId']);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -13,12 +13,13 @@ export default {
     doneMessage: '',
     loading: false,
     deleteCategoryId: null,
+    deleteErrorMessage: '',
+    deleteDoneMessage: '',
   },
   getters: {
     targetCategory: state => state.targetCategory,
     categoryList: state => state.categoryList,
     deleteCategoryId: state => state.deleteCategoryId,
-
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -35,7 +36,9 @@ export default {
       state.doneMessage = payload.message;
     },
     displayErrorMessage(state, payload = { message: '失敗しました' }) {
-      state.doneMessage = payload.message;
+      console.log(payload)
+      state.errorMessage = payload.message;
+      console.log(state.errorMessage)
     },
     updateValue(state, payload) {
       state.targetCategory.category.name = payload.category;
@@ -114,12 +117,10 @@ export default {
         url: `/category/${rootGetters['categories/deleteCategoryId']}`,
         data,
       }).then(() => {
-        console.log('seikou')
         commit('doneDeleteCategory');
         commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
         dispatch('getAllCategories');
       }).catch(() => {
-        console.log('shippai')
         commit('displayErrorMessage', { message: 'カテゴリーの削除に失敗しました' });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -51,6 +51,7 @@ export default {
     resetView({ commit }) {
       commit('resetView');
     },
+  },
     updateValue({ commit }, categoryName) {
       const name = categoryName;
       const payload = {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -123,6 +123,9 @@ export default {
         dispatch('getAllCategories');
       }).catch(() => {
         commit('displayErrorMessage', { message: 'カテゴリーの削除に失敗しました' });
+        if(this.state.categories.doneMessage) {
+          this.state.categories.doneMessage = '';
+        };
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,13 +12,10 @@ export default {
     errorMessage: '',
     doneMessage: '',
     loading: false,
-    deleteCategoryId: null,
   },
   getters: {
     targetCategory: state => state.targetCategory,
     categoryList: state => state.categoryList,
-    deleteCategoryId: state => state.deleteCategoryId,
-
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -50,16 +47,7 @@ export default {
       state.doneMessage = '';
       state.errorMessage = '';
     },
-    confirmDeleteId(state, { categoryId }) {
-      state.deleteCategoryId = categoryId;
-    },
-    doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
-    },
-    deletedCategoryList(state, payload) {
-      return state.categoryList.splice(payload, 1);
-    },
-  },
+ },
   actions: {
     resetView({ commit }) {
       commit('resetView');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -117,15 +117,15 @@ export default {
       }).then(() => {
         commit('doneDeleteCategory');
         commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
-        if(this.state.categories.errorMessage) {
+        if (this.state.categories.errorMessage) {
           this.state.categories.errorMessage = '';
-        };
+        }
         dispatch('getAllCategories');
       }).catch(() => {
         commit('displayErrorMessage', { message: 'カテゴリーの削除に失敗しました' });
-        if(this.state.categories.doneMessage) {
+        if (this.state.categories.doneMessage) {
           this.state.categories.doneMessage = '';
-        };
+        }
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -114,11 +114,13 @@ export default {
         url: `/category/${rootGetters['categories/deleteCategoryId']}`,
         data,
       }).then(() => {
+        console.log('seikou')
         commit('doneDeleteCategory');
-        commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
+        commit('displayDoneMessage', { message: 'カテゴリーを削除しました' });
         dispatch('getAllCategories');
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
+      }).catch(() => {
+        console.log('shippai')
+        commit('displayErrorMessage', { message: 'カテゴリーの削除に失敗しました' });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -36,9 +36,7 @@ export default {
       state.doneMessage = payload.message;
     },
     displayErrorMessage(state, payload = { message: '失敗しました' }) {
-      console.log(payload)
       state.errorMessage = payload.message;
-      console.log(state.errorMessage)
     },
     updateValue(state, payload) {
       state.targetCategory.category.name = payload.category;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,10 +12,13 @@ export default {
     errorMessage: '',
     doneMessage: '',
     loading: false,
+    deleteCategoryId: null,
   },
   getters: {
     targetCategory: state => state.targetCategory,
     categoryList: state => state.categoryList,
+    deleteCategoryId: state => state.deleteCategoryId,
+
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -47,11 +50,20 @@ export default {
       state.doneMessage = '';
       state.errorMessage = '';
     },
+    confirmDeleteId(state, { categoryId }) {
+      state.deleteCategoryId = categoryId;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+    },
+    deletedCategoryList(state, payload) {
+      return state.categoryList.splice(payload, 1);
+    },
+  },
   actions: {
     resetView({ commit }) {
       commit('resetView');
     },
-  },
     updateValue({ commit }, categoryName) {
       const name = categoryName;
       const payload = {
@@ -109,7 +121,7 @@ export default {
         commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
         commit('deletedCategoryList', rootGetters['categories/deleteCategoryId']);
       }).catch(err => {
-        commit('displayErrorMessage', { message: 'カテゴリー削除に失敗しました' });
+        commit('failRequest', { message: err.message });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,10 +12,13 @@ export default {
     errorMessage: '',
     doneMessage: '',
     loading: false,
+    deleteCategoryId: null,
   },
   getters: {
     targetCategory: state => state.targetCategory,
     categoryList: state => state.categoryList,
+    deleteCategoryId: state => state.deleteCategoryId,
+
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -46,6 +49,15 @@ export default {
     resetView(state) {
       state.doneMessage = '';
       state.errorMessage = '';
+    },
+    confirmDeleteId(state, { categoryId }) {
+      state.deleteCategoryId = categoryId;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+    },
+    deletedCategoryList(state, payload) {
+      return state.categoryList.splice(payload, 1);
     },
   },
   actions: {
@@ -109,7 +121,7 @@ export default {
         commit('displayDoneMessage', { message: 'ドキュメントを削除しました' });
         commit('deletedCategoryList', rootGetters['categories/deleteCategoryId']);
       }).catch(err => {
-        commit('failRequest', { message: err.message });
+        commit('displayErrorMessage', { message: 'カテゴリー削除に失敗しました' });
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -12,13 +12,10 @@ export default {
     errorMessage: '',
     doneMessage: '',
     loading: false,
-    deleteCategoryId: null,
   },
   getters: {
     targetCategory: state => state.targetCategory,
     categoryList: state => state.categoryList,
-    deleteCategoryId: state => state.deleteCategoryId,
-
   },
   mutations: {
     doneGetAllCategories(state, payload) {
@@ -49,15 +46,6 @@ export default {
     resetView(state) {
       state.doneMessage = '';
       state.errorMessage = '';
-    },
-    confirmDeleteId(state, { categoryId }) {
-      state.deleteCategoryId = categoryId;
-    },
-    doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
-    },
-    deletedCategoryList(state, payload) {
-      return state.categoryList.splice(payload, 1);
     },
   },
   actions: {


### PR DESCRIPTION
https://gizumo.backlog.com/view/GIZFE-1372

## やったこと
・カテゴリーリストから「更新」を押下するとカテゴリー変更ページに遷移
・カテゴリー変更ページに遷移するとデフォルトでform内に該当カテゴリーが入力されている状態にする
・「更新」ボタンを押下するとカテゴリー名が変更される

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1374

## 特にレビューをお願いしたい箇所
<!--
「完成はしたけど冗長になってしまった」
「もっと良い書き方がある気がする」 
など特に重点的に見て欲しい箇所、アドバイスが欲しい箇所があれば記載。
なければ「なし」と記載
-->
