### PR TITLE
カテゴリ一新規作成機能作成

### DIFF
--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -15,7 +15,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.create"
+      :disabled="disabled"
     >
       {{ buttonText }}
     </app-button>
@@ -65,7 +65,6 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '作成権限がありません';
       return this.disabled ? '作成中...' : '作成';
     },
   },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -16,6 +16,7 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
+      @click="addCategory"
     >
       {{ buttonText }}
     </app-button>
@@ -74,7 +75,7 @@ export default {
       if (!this.access.create) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('handle-submit');
+        if (valid) this.$emit('edited-category');
       });
     },
   },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -16,7 +16,6 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
-      @click="addCategory"
     >
       {{ buttonText }}
     </app-button>
@@ -64,6 +63,11 @@ export default {
       default: () => ({}),
     },
   },
+  data() {
+    return {
+      categoryName: '',
+    };
+  },
   computed: {
     buttonText() {
       if (!this.access.create) return '作成権限がありません';
@@ -75,7 +79,7 @@ export default {
       if (!this.access.create) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('edited-category');
+        if (valid) this.$emit('handle-submit');
       });
     },
   },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -15,7 +15,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled"
+      :disabled="disabled || !access.create"
     >
       {{ buttonText }}
     </app-button>
@@ -65,6 +65,7 @@ export default {
   },
   computed: {
     buttonText() {
+      if (!this.access.create) return '作成権限がありません';
       return this.disabled ? '作成中...' : '作成';
     },
   },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -63,11 +63,6 @@ export default {
       default: () => ({}),
     },
   },
-  data() {
-    return {
-      categoryName: '',
-    };
-  },
   computed: {
     buttonText() {
       if (!this.access.create) return '作成権限がありません';

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <form @submit.prevent="addCategory">
+  <form @submit.prevent="handleSubmit">
     <app-heading :level="1">カテゴリー管理</app-heading>
     <app-input
       v-validate="'required'"
@@ -70,7 +70,7 @@ export default {
     },
   },
   methods: {
-    addCategory() {
+    handleSubmit() {
       if (!this.access.create) return;
       this.$emit('clear-message');
       this.$validator.validate().then(valid => {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -4,7 +4,7 @@
       class="categories__post"
       :category="categoryName"
       :error-message="errorMessage"
-      :loading="loading"
+      :disabled="disabled"
       :done-message="doneMessage"
       :access="access"
       @clear-message="clearMessage"
@@ -15,6 +15,7 @@
       class="categories__list"
       :categories="categoryList"
       :access="access"
+      :theads="theads"
     />
   </div>
 </template>
@@ -30,6 +31,7 @@ export default {
   data() {
     return {
       category: '',
+      theads: [''],
     };
   },
   computed: {
@@ -40,8 +42,8 @@ export default {
     categoryList() {
       return this.$store.getters['categories/transformedCategories'];
     },
-    loading() {
-      return this.$store.state.categories.loading;
+    disabled() {
+      return this.$store.state.categories.disabled;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -65,7 +67,7 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/updateCategory');
+      this.$store.dispatch('categories/postCategory');
     },
   },
 };

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,10 +2,12 @@
   <div class="categories">
     <app-category-Post
       class="categories__post"
+      :category="getCategoryName"
       :error-message="errorMessage"
+      :loading="loading"
       :done-message="doneMessage"
-      :category="categoryName"
       :access="access"
+      @handle-submit="handleSubmit"
     />
     <app-category-List
       class="categories__list"
@@ -30,11 +32,14 @@ export default {
     };
   },
   computed: {
-    categoryName() {
+    getCategoryName() {
       return this.$store.getters['categories/getCategory'];
     },
     categoryList() {
       return this.$store.getters['categories/transformedCategories'];
+    },
+    loading() {
+      return this.$store.state.categories.loading;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -48,6 +53,12 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -65,7 +65,7 @@ export default {
       this.$store.dispatch('categories/editedTitle', $event.category.value);
     },
     updateValue($event) {
-      this.$store.dispatch('categories/editedTitle', $event.category.value);
+      this.$store.dispatch('categories/editedCategory', $event.target.value);
     },
     handleSubmit() {
       if (this.loading) return;

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -10,6 +10,7 @@
       @clear-message="clearMessage"
       @addCategory="editedCategory"
       @handle-submit="handleSubmit"
+      @update-value="updateValue"
     />
     <app-category-List
       class="categories__list"
@@ -61,6 +62,9 @@ export default {
       this.$store.dispatch('categories/clearMessage');
     },
     editedCategory($event) {
+      this.$store.dispatch('categories/editedTitle', $event.category.value);
+    },
+    updateValue($event) {
       this.$store.dispatch('categories/editedTitle', $event.category.value);
     },
     handleSubmit() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -30,7 +30,6 @@ export default {
   },
   data() {
     return {
-      category: '',
       theads: ['カテゴリー名'],
     };
   },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -7,7 +7,8 @@
       :loading="loading"
       :done-message="doneMessage"
       :access="access"
-      @edited-category="editedCategory"
+      @clear-message="clearMessage"
+      @addCategory="editedCategory"
       @handle-submit="handleSubmit"
     />
     <app-category-List
@@ -56,6 +57,9 @@ export default {
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
     editedCategory($event) {
       this.$store.dispatch('categories/editedTitle', $event.category.value);
     },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -8,7 +8,6 @@
       :done-message="doneMessage"
       :access="access"
       @clear-message="clearMessage"
-      @addCategory="editedCategory"
       @handle-submit="handleSubmit"
       @update-value="updateValue"
     />
@@ -60,9 +59,6 @@ export default {
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
-    },
-    editedCategory($event) {
-      this.$store.dispatch('categories/editedTitle', $event.category.value);
     },
     updateValue($event) {
       this.$store.dispatch('categories/editedCategory', $event.target.value);

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -31,7 +31,7 @@ export default {
   data() {
     return {
       category: '',
-      theads: [''],
+      theads: ['カテゴリー名'],
     };
   },
   computed: {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,18 +2,18 @@
   <div class="categories">
     <app-category-Post
       class="categories__post"
-      :category="getCategoryName"
+      :category="categoryName"
       :error-message="errorMessage"
       :loading="loading"
       :done-message="doneMessage"
       :access="access"
+      @edited-category="editedCategory"
       @handle-submit="handleSubmit"
     />
     <app-category-List
       class="categories__list"
       :categories="categoryList"
       :access="access"
-      :theads="theads"
     />
   </div>
 </template>
@@ -28,12 +28,13 @@ export default {
   },
   data() {
     return {
-      theads: ['カテゴリー名'],
+      category: '',
     };
   },
   computed: {
-    getCategoryName() {
-      return this.$store.getters['categories/getCategory'];
+    categoryName() {
+      const { name } = this.$store.state.categories.category;
+      return name;
     },
     categoryList() {
       return this.$store.getters['categories/transformedCategories'];
@@ -55,6 +56,9 @@ export default {
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
+    editedCategory($event) {
+      this.$store.dispatch('categories/editedTitle', $event.category.value);
+    },
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/updateCategory');

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -43,7 +43,7 @@ export default {
       return this.$store.getters['categories/transformedCategories'];
     },
     disabled() {
-      return this.$store.state.categories.disabled;
+      return this.$store.state.categories.loading;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -57,6 +57,7 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     clearMessage() {

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -47,10 +47,10 @@ export default {
       return this.$store.getters['auth/access'];
     },
     errorMessage() {
-      return this.$store.state.errorMessage;
+      return this.$store.state.categories.errorMessage;
     },
     doneMessage() {
-      return this.$store.state.doneMessage;
+      return this.$store.state.categories.doneMessage;
     },
   },
   created() {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -32,14 +32,12 @@ export default {
     editedCategory(state, category) {
       state.category.name = category;
     },
-    updateArticle(state, { category }) {
-      state.category = { ...state.category, ...category };
-    },
     toggleLoading(state) {
       state.loading = !state.loading;
     },
-    updateCategory(state, { article }) {
-      state.targetArticle = { ...state.targetArticle, ...article };
+    doneEditCategory(state, { name }) {
+      state.category = { ...state.category, ...name };
+      state.loading = false;
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
@@ -68,17 +66,20 @@ export default {
     editedCategory({ commit }, category) {
       commit('editedCategory', category);
     },
-    updateCategory({ commit, rootGetters }) {
+    updateCategory({ commit, rootGetters, state }) {
       return new Promise((resolve, reject) => {
         commit('toggleLoading');
-        commit('toggleLoading');
         const data = new URLSearchParams();
-        data.append('name', rootGetters['categories/category'].name);
+        data.append('name', state.category.name);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
           data,
-        }).then(() => {
+        }).then(res => {
+          const payload = {
+            category: res.data.category.name,
+          };
+          commit('doneEditCategory', { payload });
           commit('toggleLoading');
           commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
           resolve();

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -21,6 +21,10 @@ export default {
     },
   },
   mutations: {
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
       return state.categoryList.reverse();
@@ -45,6 +49,9 @@ export default {
     },
   },
   actions: {
+    clearMessage({ commit }) {
+      commit('clearMessage');
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -26,7 +26,7 @@ export default {
       return state.categoryList.reverse();
     },
     editedCategory(state, payload) {
-      state.category = { ...state.category, name: payload.name };
+      state.category = { ...state.category.name, name: payload.name };
     },
     failRequest(state, { message }) {
       state.errorMessage = message;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -32,8 +32,11 @@ export default {
     editedCategory(state, category) {
       state.category.name = category;
     },
-    toggleLoading(state) {
-      state.loading = !state.loading;
+    startLoading(state) {
+      state.loading = true;
+    },
+    endLoading(state) {
+      state.loading = false;
     },
     doneEditCategory(state, { name }) {
       state.categoryList = { ...state.category, ...name };
@@ -41,6 +44,9 @@ export default {
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
+    },
+    deletePostName(state) {
+      state.category.name = '';
     },
     failRequest(state, { message }) {
       state.errorMessage = message;
@@ -68,7 +74,7 @@ export default {
     },
     updateCategory({ commit, rootGetters, state }) {
       return new Promise((resolve, reject) => {
-        commit('toggleLoading');
+        commit('startLoading');
         const data = new URLSearchParams();
         data.append('name', state.category.name);
         axios(rootGetters['auth/token'])({
@@ -77,13 +83,15 @@ export default {
           data,
         }).then(() => {
           commit('clearMessage');
-          commit('toggleLoading');
-          this.$store.dispatch('getAllCategories');
+          this.dispatch('categories/getAllCategories');
           commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
+          commit('deletePostName');
+          commit('endLoading');
           resolve();
         }).catch(err => {
-          commit('toggleLoading');
+          commit('startLoading');
           commit('failRequest', { message: err.message });
+          commit('endLoading');
           reject();
         });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -36,7 +36,7 @@ export default {
       state.loading = !state.loading;
     },
     doneEditCategory(state, { name }) {
-      state.category = { ...state.category, ...name };
+      state.categoryList = { ...state.category, ...name };
       state.loading = false;
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
@@ -75,12 +75,10 @@ export default {
           method: 'POST',
           url: '/category',
           data,
-        }).then(res => {
-          const payload = {
-            category: res.data.category.name,
-          };
-          commit('doneEditCategory', { payload });
+        }).then(() => {
+          commit('clearMessage');
           commit('toggleLoading');
+          this.$store.dispatch('getAllCategories');
           commit('displayDoneMessage', { message: 'ドキュメントを作成しました' });
           resolve();
         }).catch(err => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -65,9 +65,10 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    editedCategory({ commit }) {
+    editedCategory({ commit }, category) {
       commit({
         type: 'editedCategory',
+        category,
       });
     },
     updateCategory({ commit, rootGetters }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,6 +8,7 @@ export default {
       name: '',
     },
     categoryList: [],
+    loading: false,
     doneMessage: '',
     errorMessage: '',
   },
@@ -24,8 +25,23 @@ export default {
       state.categoryList = [...payload.categories];
       return state.categoryList.reverse();
     },
+    editedCategory(state, payload) {
+      state.category = { ...state.category, name: payload.name };
+    },
     failRequest(state, { message }) {
       state.errorMessage = message;
+    },
+    updateArticle(state, { category }) {
+      state.category = { ...state.category, ...category };
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    updateCategory(state, { article }) {
+      state.targetArticle = { ...state.targetArticle, ...article };
+    },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
     },
   },
   actions: {
@@ -40,6 +56,34 @@ export default {
         commit('doneGetAllCategories', payload);
       }).catch(err => {
         commit('failRequest', { message: err.message });
+      });
+    },
+    editedCategory({ commit }) {
+      commit({
+        type: 'editedCategory',
+      });
+    },
+    updateCategory({ commit, rootGetters }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('id', rootGetters['categories/category'].id);
+      data.append('title', rootGetters['categories/category'].name);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/categories/${rootGetters['categories/category'].id}`,
+        data,
+      }).then(res => {
+        const payload = {
+          category: {
+            id: res.data.category.id,
+            name: res.data.category.title,
+          },
+        };
+        commit('updateCategory', payload);
+        commit('toggleLoading');
+        commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+      }).catch(() => {
+        commit('toggleLoading');
       });
     },
   },


### PR DESCRIPTION
## チケットのリンク
[<!-- Backlogの親チケットのリンクを記載 -->](https://gizumo.backlog.com/view/GIZFE-1266)

## やったこと
・ボタン押下時にカテゴリの新規作成
・ボタン押下時にデータ追加完了までのボタン無効化
・ボタン押下時にデータ追加完了後のリスト更新
・更新後、エラー時のメッセージ表示
・追加カテゴリを一番上に表示

## やらないこと
なし

## テスト
[<!-- Backlogのテストチケットのリンクを記載 -->](https://gizumo.backlog.com/view/GIZFE-1268)

## 特にレビューをお願いしたい箇所
なし
