### PR TITLE
カテゴリー更新機能の実装

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "MY_SESSION_STORAGE_KEY": true
   },
   "rules": {
+    "linebreak-style": "off",
     "arrow-parens": ["error", "as-needed"],
     "no-new": "off",
     "no-console": "error",

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -1,0 +1,116 @@
+<template>
+  <form>
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+    class="category-management-edit__return"
+      :to="`/categories`"
+      hover-opacity
+    >
+      カテコリ一ー覧へ戻る
+    </app-router-link>
+    <app-input
+    class="category-management-edit__input"
+      v-validate="'required'"
+      name="category"
+      type="text"
+      placeholder="カテゴリー名を入力してください"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('title')"
+      :value="categoryName"
+      @update-value="$emit('edited-category', $event)"
+    />
+    <app-button
+      class="category-management-edit__submit"
+      button-type="submit"
+      round
+      :disabled="!disabled"
+      @click.prevent="handleSubmit"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+  
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </form>
+</template>
+
+<script>
+import {
+  Heading, Input, Button, Text,RouterLink,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appButton: Button,
+    appText: Text,
+    appRouterLink: RouterLink,
+  },
+  props: {
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+    categoryName: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.loading ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+  },
+  methods: {
+    handleSubmit() {
+      if (!this.access.edit) return;
+      this.$emit('clear-message');
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+
+.category-management-edit {
+  &__return {
+    margin-top: 16px;
+    text-decoration:underline;
+  }
+  &__input {
+    margin-top: 16px;
+  }
+  &__submit {
+    margin-top: 16px;
+  }
+  &__notice {
+    margin-top: 16px;
+  }
+}
+
+</style>

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -2,23 +2,24 @@
   <form>
     <app-heading :level="1">カテゴリー管理</app-heading>
     <app-router-link
-    class="category-management-edit__return"
+      class="category-management-edit__return"
       :to="`/categories`"
       hover-opacity
     >
       カテコリ一ー覧へ戻る
     </app-router-link>
-    <app-input
-    class="category-management-edit__input"
-      v-validate="'required'"
-      name="category"
-      type="text"
-      placeholder="カテゴリー名を入力してください"
-      data-vv-as="カテゴリー名"
-      :error-messages="errors.collect('title')"
-      :value="categoryName"
-      @update-value="$emit('edited-category', $event)"
-    />
+    <div class="category-management-edit__input">
+      <app-input
+        v-validate="'required'"
+        name="title"
+        type="text"
+        placeholder="カテゴリー名を入力してください"
+        data-vv-as="カテゴリー名"
+        :error-messages="errors.collect('title')"
+        :value="categoryName"
+        @update-value="$emit('edited-category', $event)"
+      />
+    </div>
     <app-button
       class="category-management-edit__submit"
       button-type="submit"
@@ -32,7 +33,6 @@
     <div v-if="errorMessage" class="category-management-edit__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
-  
     <div v-if="doneMessage" class="category-management-edit__notice">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
@@ -41,7 +41,7 @@
 
 <script>
 import {
-  Heading, Input, Button, Text,RouterLink,
+  Heading, Input, Button, Text, RouterLink,
 } from '@Components/atoms';
 
 export default {

--- a/src/components/molecules/CategoryEdit/index.vue
+++ b/src/components/molecules/CategoryEdit/index.vue
@@ -3,7 +3,7 @@
     <app-heading :level="1">カテゴリー管理</app-heading>
     <app-router-link
       class="category-management-edit__return"
-      :to="`/categories`"
+      :to="'/categories'"
       hover-opacity
     >
       カテコリ一ー覧へ戻る

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -32,8 +32,11 @@
           </td>
           <td>
             <app-router-link
+              white
+              bg-lightgreen
+              small
+              round
               theme-color
-              underline
               hover-opacity
               :to="`/categories/${category.id}`"
             >

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryEdit from './CategoryEdit/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryEdit,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -1,0 +1,60 @@
+<template>
+  <app-category-edit
+    :access="access"
+    :loading="loading"
+    :done-message="doneMessage"
+    :error-message="errorMessage"
+    :category-name="categoryName"
+    @handle-submit="handleSubmit"
+    @edited-category="editedCategory"
+  />
+</template>
+
+<script>
+import { CategoryEdit } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryEdit: CategoryEdit,
+  },
+  data() {
+    return {
+      category: '',
+    };
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    categoryId() {
+      const id = parseInt(this.$route.params.id, 10);
+      return id;
+    },
+    categoryName() {
+      const name = this.$store.state.categories.updateCategory.name;
+      return name;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategoryDetail', parseInt(this.categoryId, 10));
+  },
+  methods: {
+    editedCategory($event) {
+      this.$store.dispatch('categories/editedCategory', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
+  },
+};
+</script>

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -40,12 +40,12 @@ export default {
       return id;
     },
     categoryName() {
-      const name = this.$store.state.categories.updateCategory.name;
-      return name;
+      return this.$store.state.categories.updateCategory.name;
     },
   },
   created() {
-    this.$store.dispatch('categories/getCategoryDetail', parseInt(this.categoryId, 10));
+    this.$store.dispatch('categories/getCategoryDetail', this.categoryId, 10);
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     editedCategory($event) {

--- a/src/components/pages/Categories/Edit.vue
+++ b/src/components/pages/Categories/Edit.vue
@@ -44,7 +44,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getCategoryDetail', this.categoryId, 10);
+    this.$store.dispatch('categories/getCategoryDetail', this.categoryId);
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {

--- a/src/components/pages/Categories/list.vue
+++ b/src/components/pages/Categories/list.vue
@@ -87,7 +87,7 @@ export default {
 .category {
   &__post {
     float: left;
-    width: 35%;
+    width: 32%;
     padding-right: 20px;
   }
   &__list {

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -7,7 +7,7 @@ export default [
   {
     id: 2,
     name: 'カテゴリー',
-    path: '/category',
+    path: '/categories',
   },
   {
     id: 3,

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -10,6 +10,7 @@ import Home from '@Pages/Home/index.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/list.vue';
+import CategoryEdit from '@Pages/Categories/Edit.vue';
 
 // 記事
 import Articles from '@Pages/Articles/index.vue';
@@ -112,13 +113,18 @@ const router = new VueRouter({
       ],
     },
     {
-      path: '/category',
+      path: '/categories',
       component: Categories,
       children: [
         {
           name: 'categoryList',
           path: '',
           component: CategoryList,
+        },
+        {
+          name: 'categoryEdit',
+          path: ':id',
+          component: CategoryEdit,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -46,10 +46,10 @@ export default {
       state.updateCategory.name = categoryName;
     },
     editedCategory(state, payload) {
-      state.updateCategory.name = payload.name ;
+      state.updateCategory.name = payload.name;
     },
-    updateCategory(state, { category }) {
-      state.updateCategory = { ...state.updateCategory, ...category };
+    updateCategory(state, newCategoryName) {
+      state.updateCategory = { ...state.updateCategory, ...newCategoryName };
     },
   },
   actions: {
@@ -115,7 +115,10 @@ export default {
           method: 'GET',
           url: `/category/${categoryId}`,
         }).then(res => {
-          commit('doneGetCategory', {categoryId: res.data.category.id , categoryName: res.data.category.name });
+          commit('doneGetCategory', {
+            categoryId: res.data.category.id,
+            categoryName: res.data.category.name,
+          });
           resolve();
         }).catch(err => {
           commit('failRequest', { message: err.message });
@@ -133,20 +136,13 @@ export default {
       dispatch('clearMessage');
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/updateCategory'].id);
       data.append('name', rootGetters['categories/updateCategory'].name);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${rootGetters['categories/updateCategory'].id}`,
-        data
-      }).then( res => {
-        const payload = {
-          category: {
-            id: res.data.category.id,
-            name: res.data.category.name,
-          },
-        };
-        commit('updateCategory', payload);
+        data,
+      }).then(res => {
+        commit('updateCategory', { newCategoryName: res.data.category.name });
         commit('toggleLoading');
         commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
       }).catch(err => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,11 +19,11 @@ export default (({ mode }) => {
         targets: ['ie >= 11'],
         additionalLegacyPolyfills: ['regenerator-runtime/runtime'],
       }),
-      checker({
-        eslint: {
-          lintCommand: `eslint "${rootDirPath}/src/{js,components}/**/*.{js,vue}"`,
-        },
-      }),
+      // checker({
+      //   eslint: {
+      //     lintCommand: `eslint "${rootDirPath}/src/{js,components}/**/*.{js,vue}"`,
+      //   },
+      // }),
     ],
     resolve: {
       alias: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,11 +19,11 @@ export default (({ mode }) => {
         targets: ['ie >= 11'],
         additionalLegacyPolyfills: ['regenerator-runtime/runtime'],
       }),
-      // checker({
-      //   eslint: {
-      //     lintCommand: `eslint "${rootDirPath}/src/{js,components}/**/*.{js,vue}"`,
-      //   },
-      // }),
+      checker({
+        eslint: {
+          lintCommand: `eslint "${rootDirPath}/src/{js,components}/**/*.{js,vue}"`,
+        },
+      }),
     ],
     resolve: {
       alias: {


### PR DESCRIPTION

## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1430

## やったこと
- カテゴリー更新機能実装
- カテゴリーの更新画面のコンポーネントを新規作成
- カテゴリーポストの幅を少し縮小
- ルートのパスの修正

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1432

## 特にレビューをお願いしたい箇所
categoryEditは新規作成で1から実装したものの、不要な記述だったり至らぬ点があるかもしれませんので確認いただければと思います。
