### PR TITLE
カテゴリー新規作成機能実装

### DIFF
--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -60,7 +60,7 @@ export default {
             if (this.$store.state.articles.articleList.length === 0) {
               this.$router.push({ path: '/notfound' });
             }
-          })
+          });
       } else {
         this.$store.dispatch('articles/getAllArticles');
       }
@@ -74,7 +74,7 @@ export default {
             if (this.$store.state.articles.articleList.length === 0) {
               this.$router.push({ path: '/notfound' });
             }
-          })
+          });
       } else {
         this.$store.dispatch('articles/getAllArticles');
       }

--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -60,9 +60,7 @@ export default {
             if (this.$store.state.articles.articleList.length === 0) {
               this.$router.push({ path: '/notfound' });
             }
-          }).catch(() => {
-            // console.log(err);
-          });
+          })
       } else {
         this.$store.dispatch('articles/getAllArticles');
       }
@@ -76,9 +74,7 @@ export default {
             if (this.$store.state.articles.articleList.length === 0) {
               this.$router.push({ path: '/notfound' });
             }
-          }).catch(() => {
-            // console.log(err);
-          });
+          })
       } else {
         this.$store.dispatch('articles/getAllArticles');
       }

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -32,16 +32,15 @@ export default {
     return {
       theads: ['カテゴリー名'],
       category: '',
-      doneMessage: '',
     };
   },
   computed: {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
-    // doneMessage() {
-    //   return this.$store.state.categories.doneMessage;
-    // },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -60,15 +59,13 @@ export default {
     clearMessage() {
       this.store.dispatch('categories/clearMessage');
     },
-    updateValue($event) {
-      this.category = $event.target.value;
+    updateValue(event) {
+      this.category = event.target.value;
     },
     handleSubmit() {
-      if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
         this.category = '';
         this.doneMessage = 'カテゴリーを追加しました。';
-      }).catch(() => {
       });
     },
   },

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -32,6 +32,7 @@ export default {
     return {
       theads: ['カテゴリー名'],
       category: '',
+      doneMessage: '',
     };
   },
   computed: {
@@ -64,20 +65,24 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      // this.$store.dispatch('categories/postCategory').then(() => {
-      //   this.$router.push({
-      //     path: '/categories',
-      //     query: { redirect: '/category/post' },
-      //   });
-      // });
-      const Promise = new Promise((resolve, reject) => {
+      this.$store.dispatch('categories/postCategory', this.category).then(() => {
+        this.category = '';
         
-      })
-      this.category = '';
+      }).catch(() => {
+
+      });
     },
   },
 };
 </script>
+
+
+<!-- this.$store.dispatch('articles/postArticle').then(() => {
+  this.$router.push({
+    path: '/articles',
+    query: { redirect: '/article/post' },
+  });
+}); -->
 
 <style lang="scss" scoped>
   .articles {

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -64,8 +64,8 @@ export default {
     },
     handleSubmit() {
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
-      this.category = '';
-      this.doneMessage = 'カテゴリーを追加しました。';
+        this.category = '';
+        this.doneMessage = 'カテゴリーを追加しました。';
       });
     },
   },

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -63,6 +63,7 @@ export default {
       this.category = event.target.value;
     },
     handleSubmit() {
+      if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
         this.category = '';
         this.doneMessage = 'カテゴリーを追加しました。';

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -4,6 +4,9 @@
       class="form"
       :loading="loading"
       :access="access"
+      :error-message="errorMessage"
+      :category="getCategoryName"
+      @handle-submit="handleSubmit"
     />
     <app-category-list
       class="list"
@@ -27,6 +30,7 @@ export default {
   data() {
     return {
       theads: ['カテゴリー名'],
+      category: '',
     };
   },
   computed: {
@@ -39,14 +43,28 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    getCategoryName() {
+      return this.$store.getters['categories/getCategory'];
+    },
     loading() {
       return this.$store.state.categories.loading;
     },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
+    clearMessage() {
+      this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue($event) {
+      this.$store.dispatch('categories/editedCategory', $event.target.value);
+    },
   },
 };
 </script>

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -7,6 +7,7 @@
       :error-message="errorMessage"
       :category="category"
       :done-message="doneMessage"
+      @update-value="updateValue"
       @handle-submit="handleSubmit"
     />
     <app-category-list

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -39,9 +39,9 @@ export default {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
-    doneMessage() {
-      return this.$store.state.categories.doneMessage;
-    },
+    // doneMessage() {
+    //   return this.$store.state.categories.doneMessage;
+    // },
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -67,22 +67,13 @@ export default {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
         this.category = '';
-        
+        this.doneMessage = 'カテゴリーを追加しました。';
       }).catch(() => {
-
       });
     },
   },
 };
 </script>
-
-
-<!-- this.$store.dispatch('articles/postArticle').then(() => {
-  this.$router.push({
-    path: '/articles',
-    query: { redirect: '/article/post' },
-  });
-}); -->
 
 <style lang="scss" scoped>
   .articles {

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -57,14 +57,22 @@ export default {
   },
   methods: {
     clearMessage() {
-      this.$store.dispatch('categories/clearMessage');
+      this.store.dispatch('categories/clearMessage');
     },
     updateValue($event) {
       this.category = $event.target.value;
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/postCategory', this.category);
+      // this.$store.dispatch('categories/postCategory').then(() => {
+      //   this.$router.push({
+      //     path: '/categories',
+      //     query: { redirect: '/category/post' },
+      //   });
+      // });
+      const Promise = new Promise((resolve, reject) => {
+        
+      })
       this.category = '';
     },
   },

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -63,10 +63,9 @@ export default {
       this.category = event.target.value;
     },
     handleSubmit() {
-      if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
-        this.category = '';
-        this.doneMessage = 'カテゴリーを追加しました。';
+      this.category = '';
+      this.doneMessage = 'カテゴリーを追加しました。';
       });
     },
   },

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -63,9 +63,9 @@ export default {
       this.category = event.target.value;
     },
     handleSubmit() {
+      if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
         this.category = '';
-        this.doneMessage = 'カテゴリーを追加しました。';
       });
     },
   },

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -2,17 +2,17 @@
   <div class="articles">
     <app-category-post
       class="form"
-      :loading="loading"
+      :disabled="loading"
       :access="access"
       :error-message="errorMessage"
-      :category="getCategoryName"
+      :category="category"
+      :done-message="doneMessage"
       @handle-submit="handleSubmit"
     />
     <app-category-list
       class="list"
       :theads="theads"
       :categories="categoryList"
-      :done-message="doneMessage"
       :loading="loading"
       :access="access"
     />
@@ -43,11 +43,11 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
-    getCategoryName() {
-      return this.$store.getters['categories/getCategory'];
-    },
     loading() {
       return this.$store.state.categories.loading;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
     },
   },
   created() {
@@ -55,15 +55,16 @@ export default {
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {
-    handleSubmit() {
-      if (this.loading) return;
-      this.$store.dispatch('categories/updateCategory');
-    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
     updateValue($event) {
-      this.$store.dispatch('categories/editedCategory', $event.target.value);
+      this.category = $event.target.value;
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory', this.category);
+      this.category = '';
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,6 +4,7 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
+    doneMessage: '',
     errorMessage: '',
     loading: false,
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,21 +11,16 @@ export default {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
-    doneGetArticle(state, payload) {
-      state.categoryList = { ...state.categoryList, ...payload.categories };
-    },
     failRequest(state, { message }) {
       state.errorMessage = message;
       state.loading = false;
     },
-    updateArticle(state, { category }) {
-      state.category = { ...state.category, ...category };
+    clearMessage(state) {
+      state.doneMessage = '';
+      state.errorMessage = '';
     },
     toggleLoading(state) {
       state.loading = !state.loading;
-    },
-    updateCategory(state, { article }) {
-      state.targetArticle = { ...state.targetArticle, ...article };
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -53,14 +53,14 @@ export default {
           url: '/category',
           data,
         }).then(() => {
-          commit('toggleLoading');
           commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
           dispatch('getAllCategories');
           resolve();
         }).catch(err => {
-          commit('toggleLoading');
           commit('failRequest', { message: err.message });
           reject();
+        }).finally(() => {
+          commit('toggleLoading');
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -5,14 +5,30 @@ export default {
   state: {
     categoryList: [],
     errorMessage: '',
+    loading: false,
   },
   mutations: {
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
+    doneGetArticle(state, payload) {
+      state.categoryList = { ...state.categoryList, ...payload.categories };
+    },
     failRequest(state, { message }) {
       state.errorMessage = message;
       state.loading = false;
+    },
+    updateArticle(state, { category }) {
+      state.category = { ...state.category, ...category };
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    updateCategory(state, { article }) {
+      state.targetArticle = { ...state.targetArticle, ...article };
+    },
+    displayDoneMessage(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
     },
   },
   actions: {
@@ -29,6 +45,31 @@ export default {
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });
+    },
+    postCategory({ commit, rootGetters, dispatch }, categoryName) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', categoryName);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('displayDoneMessage', { message: 'カテゴリーを作成しました' });
+          dispatch('getAllCategories');
+          resolve();
+        }).catch(err => {
+          commit('toggleLoading');
+          commit('failRequest', { message: err.message });
+          reject();
+        });
+      });
+    },
+    clearMessage({ commit }) {
+      commit('clearMessage');
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1438#comment-305113807

## やったこと
・新規でカテゴリーをAPI通信を用いて追加できるようにする。
・新規で追加したカテゴリーは一覧の一番上に表示される。
・API通信成功後、完了しましたという文字列が表示される。
・API通信失敗後、エラーが表示される。

## やらないこと
なし

## テスト
(https://gizumo.backlog.com/view/GIZFE-1436)

## 特にレビューをお願いしたい箇所
今回の実装にあたり、不要な記述。
もっと簡易的に表現できるような追求できていない部分があると思うので確認をお願いしたいです。