### PR TITLE
category一覧画面実装

### DIFF
--- a/src/components/atoms/Button/index.vue
+++ b/src/components/atoms/Button/index.vue
@@ -85,6 +85,7 @@ export default {
   line-height: 1.4;
   color: #fff;
   background-color: $theme-color;
+  white-space: nowrap;
   @include hoverOpacity;
 }
 

--- a/src/components/atoms/RouterLink/index.vue
+++ b/src/components/atoms/RouterLink/index.vue
@@ -105,6 +105,7 @@ export default {
   font-size: 16px;
   transition: all .5s;
   line-height: 1.4;
+  white-space: nowrap;
   &.is-active {
     color: $sub-theme-color;
     font-weight: bold;

--- a/src/components/atoms/Text/index.vue
+++ b/src/components/atoms/Text/index.vue
@@ -66,6 +66,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+/* Defaultスタイル */
 .text {
   font-size: 16px;
   word-break: break-all;
@@ -104,5 +105,5 @@ export default {
 .text--ex-small {
   font-size: 12px;
 }
-
+/* Unique（For Props）スタイル */
 </style>

--- a/src/components/atoms/Text/index.vue
+++ b/src/components/atoms/Text/index.vue
@@ -66,7 +66,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-/* Defaultスタイル */
 .text {
   font-size: 16px;
   word-break: break-all;
@@ -105,7 +104,5 @@ export default {
 .text--ex-small {
   font-size: 12px;
 }
-
-/* Unique（For Props）スタイル */
 
 </style>

--- a/src/components/atoms/Text/index.vue
+++ b/src/components/atoms/Text/index.vue
@@ -69,6 +69,7 @@ export default {
 /* Defaultスタイル */
 .text {
   font-size: 16px;
+  word-break: break-all;
 }
 
 .text--bold {

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -80,9 +80,6 @@
         </app-button>
       </div>
     </app-modal>
-    <div v-if="doneMessage" class="category-list-message">
-      <app-text bg-success>{{ doneMessage }}</app-text>
-    </div>
   </div>
 </template>
 
@@ -119,10 +116,6 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
-    },
-    doneMessage: {
-      type: String,
-      default: '',
     },
   },
   methods: {

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -15,9 +15,11 @@
       </thead>
       <transition-group name="fade" tag="tbody" class="category-list__table__body">
         <tr v-for="category in categories" :key="category.id">
+          <!-- categoriesのなかにはcategoryというオブジェクトが入っている -->
           <td>
             <app-text tag="span">
               {{ category.name }}
+              <!-- category = category.name -->
             </app-text>
           </td>
           <td>
@@ -80,12 +82,18 @@
         </app-button>
       </div>
     </app-modal>
+    <!-- ③エラーメッセージがpropsに渡されていたら、そのエラーメッセージを表示 -->
+    <div v-if="doneMessage" class="category-list-message">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
   </div>
 </template>
 
 <script>
 import {
-  RouterLink, Button, Text,
+  RouterLink,
+  Button,
+  Text,
 } from '@Components/atoms';
 
 export default {
@@ -115,6 +123,11 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    // ②エラーメッセージを受け取れるようにする
+    doneMessage: {
+      type: String,
+      default: '',
+    },
   },
   methods: {
     openModal(categoryId, categoryName) {
@@ -131,7 +144,7 @@ export default {
 
 <style lang="scss" scoped>
 .category-list {
-  padding: 10px 0 20px;
+  padding: 10px 20px 20px;
   height: 100%;
   overflow: scroll;
   &__table {

--- a/src/components/molecules/CategoryList/index.vue
+++ b/src/components/molecules/CategoryList/index.vue
@@ -15,11 +15,9 @@
       </thead>
       <transition-group name="fade" tag="tbody" class="category-list__table__body">
         <tr v-for="category in categories" :key="category.id">
-          <!-- categoriesのなかにはcategoryというオブジェクトが入っている -->
           <td>
             <app-text tag="span">
               {{ category.name }}
-              <!-- category = category.name -->
             </app-text>
           </td>
           <td>
@@ -82,7 +80,6 @@
         </app-button>
       </div>
     </app-modal>
-    <!-- ③エラーメッセージがpropsに渡されていたら、そのエラーメッセージを表示 -->
     <div v-if="doneMessage" class="category-list-message">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
@@ -123,7 +120,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    // ②エラーメッセージを受け取れるようにする
     doneMessage: {
       type: String,
       default: '',
@@ -147,6 +143,7 @@ export default {
   padding: 10px 20px 20px;
   height: 100%;
   overflow: scroll;
+  width: 100%;;
   &__table {
     width: 100%;
     text-align: left;

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -15,7 +15,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="!access.create"
+      :disabled="disabled || !access.create"
       @click="openModal(category.id, category.name)"
     >
       {{ buttonText }}

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -15,7 +15,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.create"
+      :disabled="disabled || access.create"
     >
       {{ buttonText }}
     </app-button>
@@ -44,6 +44,7 @@ export default {
   props: {
     category: {
       type: String,
+      default: '',
       required: true,
     },
     errorMessage: {
@@ -65,7 +66,7 @@ export default {
   },
   computed: {
     buttonText() {
-      if (!this.access.create) return '作成権限がありません';
+      if (this.access.create) return '作成権限がありません';
       return this.disabled ? '作成中...' : '作成';
     },
   },

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -15,7 +15,8 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.create"
+      :disabled="!access.create"
+      @click="openModal(category.id, category.name)"
     >
       {{ buttonText }}
     </app-button>
@@ -69,9 +70,7 @@ export default {
       if (!this.access.create) return '作成権限がありません';
       return this.disabled ? '作成中...' : '作成';
     },
-    access() {
-      return this.$store.getters['auth/access'];
-    },
+
   },
   methods: {
     addCategory() {
@@ -80,6 +79,10 @@ export default {
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('handle-submit');
       });
+    },
+    openModal(categoryId, categoryName) {
+      if (!this.access.delete) return;
+      this.$emit('open-modal', categoryId, categoryName);
     },
   },
 };

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -20,16 +20,15 @@
     >
       {{ buttonText }}
     </app-button>
-
     <div v-if="errorMessage" class="category-management-post__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
-
     <div v-if="doneMessage" class="category-management-post__notice">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
+
 <script>
 import {
   Heading, Input, Button, Text,

--- a/src/components/molecules/CategoryPost/index.vue
+++ b/src/components/molecules/CategoryPost/index.vue
@@ -15,7 +15,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || access.create"
+      :disabled="disabled || !access.create"
     >
       {{ buttonText }}
     </app-button>
@@ -66,8 +66,11 @@ export default {
   },
   computed: {
     buttonText() {
-      if (this.access.create) return '作成権限がありません';
+      if (!this.access.create) return '作成権限がありません';
       return this.disabled ? '作成中...' : '作成';
+    },
+    access() {
+      return this.$store.getters['auth/access'];
     },
   },
   methods: {

--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -61,7 +61,6 @@ export default {
               this.$router.push({ path: '/notfound' });
             }
           }).catch(() => {
-            // console.log(err);
           });
       } else {
         this.$store.dispatch('articles/getAllArticles');
@@ -77,7 +76,6 @@ export default {
               this.$router.push({ path: '/notfound' });
             }
           }).catch(() => {
-            // console.log(err);
           });
       } else {
         this.$store.dispatch('articles/getAllArticles');

--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -61,6 +61,7 @@ export default {
               this.$router.push({ path: '/notfound' });
             }
           }).catch(() => {
+            // console.log(err);
           });
       } else {
         this.$store.dispatch('articles/getAllArticles');
@@ -76,6 +77,7 @@ export default {
               this.$router.push({ path: '/notfound' });
             }
           }).catch(() => {
+            // console.log(err);
           });
       } else {
         this.$store.dispatch('articles/getAllArticles');

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="categories">
+    <!-- ④作成のコンポーネントを左に表示する（app-category-post） -->
+    <app-category-post
+      :category="category"
+    />
+    <app-category-list
+      :categories="categoryList"
+      :access="access"
+      :done-message="doneMessage"
+      :theads="theads"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryList, CategoryPost } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryList: CategoryList,
+    appCategoryPost: CategoryPost,
+  },
+  data() {
+    return {
+      theads: ['カテゴリー名'],
+    };
+  },
+  computed: {
+    categoryList() {
+      return this.$store.state.categories.categoryList;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    category() {
+      return this.$store.state.categories.category;
+    },
+  },
+  // created を定義して、Vueインスタンスの生成時にactionsを呼ぶ
+  created() {
+    this.$store.dispatch('categories/getCategories');
+  },
+};
+</script>
+<style lang="scss" scoped>
+.categories {
+  display: flex
+};
+
+.categories form {
+  width: 350px;
+  flex-shrink: 0;
+  position: relative;
+  padding-right:20px ;
+};
+
+.categories form::after {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  content: "";
+  width: 1px;
+  height: 100%;
+  background-color: rgb(181, 181, 181);;
+};
+</style>

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="categories">
-    <!-- ④作成のコンポーネントを左に表示する（app-category-post） -->
     <app-category-post
       :category="category"
     />
@@ -43,7 +42,6 @@ export default {
       return this.$store.state.categories.category;
     },
   },
-  // created を定義して、Vueインスタンスの生成時にactionsを呼ぶ
   created() {
     this.$store.dispatch('categories/getCategories');
   },

--- a/src/components/pages/Categories/List.vue
+++ b/src/components/pages/Categories/List.vue
@@ -2,6 +2,7 @@
   <div class="categories">
     <app-category-post
       :category="category"
+      :access="access"
     />
     <app-category-list
       :categories="categoryList"

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -5,6 +5,11 @@ export default [
     path: '/',
   },
   {
+    id: 2,
+    name: 'カテゴリー',
+    path: '/categories',
+  },
+  {
     id: 3,
     name: '記事',
     path: '/articles',

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -7,6 +7,10 @@ import Signout from '@Pages/Signout/index.vue';
 import NotFound from '@Pages/NotFound/index.vue';
 import Home from '@Pages/Home/index.vue';
 
+// カテゴリー
+import Categories from '@Pages/Categories/index.vue';
+import CategoryList from '@Pages/Categories/List.vue';
+
 // 記事
 import Articles from '@Pages/Articles/index.vue';
 import ArticleList from '@Pages/Articles/List.vue';
@@ -66,6 +70,17 @@ const router = new VueRouter({
       name: 'profile',
       path: '/profile',
       component: Profile,
+    },
+    {
+      path: '/categories',
+      component: Categories,
+      children: [
+        {
+          name: 'categoryList',
+          path: '',
+          component: CategoryList,
+        },
+      ],
     },
     {
       path: '/articles',

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import {
-  auth, articles, users,
+  auth, articles, users, categories,
 } from './modules';
 
 Vue.use(Vuex);
@@ -11,5 +11,6 @@ export default new Vuex.Store({
     auth,
     articles,
     users,
+    categories,
   },
 });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,12 +3,6 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    targetCategory: {
-      category: {
-        id: null,
-        name: '',
-      },
-    },
     categoryList: [],
     errorMessage: '',
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -7,12 +7,6 @@ export default {
     errorMessage: '',
   },
   getters: {
-    transformedCategories(state) {
-      return state.categoryList.map(category => ({
-        id: category.id,
-        name: category.name,
-      }));
-    },
   },
   mutations: {
     doneGetCategories(state, payload) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -1,0 +1,51 @@
+import axios from '@Helpers/axiosDefault';
+
+export default {
+  namespaced: true,
+  state: {
+    targetCategory: {
+      category: {
+        id: null,
+        name: '',
+      },
+    },
+    categoryList: [],
+    errorMessage: '',
+  },
+  getters: {
+    transformedCategories(state) {
+      return state.categoryList.map(category => ({
+        id: category.id,
+        name: category.name,
+      }));
+    },
+  },
+  mutations: {
+    doneGetCategories(state, payload) {
+      state.categoryList = [...payload.categories];
+    },
+    failRequest(state, { message }) {
+      state.errorMessage = message;
+    },
+  },
+  actions: {
+    // 一覧取得するアクションを定義する（中身の処理は不要）
+    getCategories({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      })
+      // 成功したら
+        .then(res => {
+          const payload = {
+            categories: res.data.categories,
+          };
+          commit('doneGetCategories', payload);
+        })
+      // 失敗したら
+        .catch(err => {
+          commit('failRequest', { message: err.message });
+        });
+    },
+  },
+};

--- a/src/js/_store/modules/index.js
+++ b/src/js/_store/modules/index.js
@@ -1,9 +1,11 @@
 import articles from './articles';
 import auth from './auth';
 import users from './users';
+import categories from './categories';
 
 export {
   articles,
   auth,
   users,
+  categories,
 };


### PR DESCRIPTION
##チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1194

## やったこと
サイドバーに「カテゴリー」を追加
APIから取得したカテゴリ一覧が画面右側に表示される
 最新のものが一番上に来るように順番を変更する（降順で表示）
 カテゴリー作成画面とカテゴリー一覧を横並びにさせる
 カテゴリー作成画面とカテゴリー一覧の間に線を引く
 カテゴリー名が長い場合は文を折り返しさせる

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1196

## 特にレビューをお願いしたい箇所
見た目は画面レイアウト通りですが、この書き方でいいのか見てほしいです。