### PR TITLE
カテゴリ一更新機能実装

### DIFF
--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -16,7 +16,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="categoryName"
-      @update-value="$emit('edited-name', $event)"
+      @update-value="$emit('edit-name', $event)"
     />
     <app-button
       class="category-management-post__submit"

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -90,11 +90,15 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    // disabled: {
+    //   type: Boolean,
+    //   default: false,
+    // },
   },
   computed: {
     buttonText() {
       if (!this.access.edit) return '更新権限がありません';
-      return this.disabled ? '更新中...' : '更新';
+      return this.loading ? '更新中...' : '更新';
     },
     disabled() {
       return this.access.edit && !this.loading;

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -66,10 +66,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    // editedName: {
-    //   type: String,
-    //   default: '',
-    // },
+    editName: {
+      type: String,
+      default: '',
+    },
     doneMessage: {
       type: String,
       default: '',
@@ -86,10 +86,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    // categoryList: {
-    //   type: Array,
-    //   default: () => [],
-    // },
     loading: {
       type: Boolean,
       default: false,

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -16,7 +16,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="categoryName"
-      @update-value="$emit('update-value', $event)"
+      @update-value="$emit('edited-name', $event)"
     />
     <app-button
       class="category-management-post__submit"
@@ -58,11 +58,15 @@ export default {
         return [];
       },
     },
+    categoryName: {
+      type: String,
+      default: '',
+    },
     updateCategory: {
       type: String,
       default: '',
     },
-    categoryName: {
+    editedName: {
       type: String,
       default: '',
     },
@@ -81,6 +85,10 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
+    },
+    categoryList: {
+      type: Array,
+      default: () => [],
     },
     loading: {
       type: Boolean,

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -22,7 +22,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.edit"
+      :disabled="!disabled"
       @click="handleSubmit"
     >
       {{ buttonText }}
@@ -52,24 +52,24 @@ export default {
     appText: Text,
   },
   props: {
-    categories: {
-      type: Array,
-      default() {
-        return [];
-      },
-    },
+    // categories: {
+    //   type: Array,
+    //   default() {
+    //     return [];
+    //   },
+    // },
     categoryName: {
       type: String,
       default: '',
     },
     updateCategory: {
-      type: String,
-      default: '',
+      type: Object,
+      default: () => ({}),
     },
-    editedName: {
-      type: String,
-      default: '',
-    },
+    // editedName: {
+    //   type: String,
+    //   default: '',
+    // },
     doneMessage: {
       type: String,
       default: '',
@@ -78,18 +78,18 @@ export default {
       type: String,
       default: '',
     },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
+    // disabled: {
+    //   type: Boolean,
+    //   default: false,
+    // },
     access: {
       type: Object,
       default: () => ({}),
     },
-    categoryList: {
-      type: Array,
-      default: () => [],
-    },
+    // categoryList: {
+    //   type: Array,
+    //   default: () => [],
+    // },
     loading: {
       type: Boolean,
       default: false,
@@ -100,12 +100,15 @@ export default {
       if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
     },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
   },
   methods: {
-    handleSubmit() {
+    handleSubmit(updateCategory) {
       if (!this.access.edit) return;
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('handle-submit');
+        if (valid) this.$emit('handle-submit', updateCategory.id);
       });
     },
   },

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -2,7 +2,7 @@
   <div class="category-update">
     <app-heading :level="1">カテゴリー管理</app-heading>
     <app-router-link
-      class="category-management-post__detail"
+      class="category-management-update__detail"
       :to="`/categories`"
       underline
       hover-opacity
@@ -11,7 +11,7 @@
     </app-router-link>
     <app-input
       v-validate="'required'"
-      class="category-management-post__text"
+      class="category-management-update__text"
       name="category"
       type="text"
       data-vv-as="カテゴリー名"
@@ -20,7 +20,7 @@
       @update-value="$emit('edit-name', $event)"
     />
     <app-button
-      class="category-management-post__submit"
+      class="category-management-update__submit"
       button-type="submit"
       round
       :disabled="!disabled"
@@ -29,11 +29,11 @@
       {{ buttonText }}
     </app-button>
 
-    <div v-if="errorMessage" class="category-management-post__notice">
+    <div v-if="errorMessage" class="category-management-update__notice">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div v-if="doneMessage" class="category-management-post__notice">
+    <div v-if="doneMessage" class="category-management-update__notice">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </div>
@@ -56,10 +56,6 @@ export default {
     categoryName: {
       type: String,
       default: '',
-    },
-    targetCategory: {
-      type: Object,
-      default: () => ({}),
     },
     editName: {
       type: String,
@@ -103,7 +99,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.category-management-post {
+.category-management-update {
   &__input {
     margin-top: 20px;
   }

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -58,6 +58,10 @@ export default {
         return [];
       },
     },
+    updateCategory: {
+      type: String,
+      default: '',
+    },
     categoryName: {
       type: String,
       default: '',

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -11,6 +11,7 @@
     </app-router-link>
     <app-input
       v-validate="'required'"
+      class="category-management-post__text"
       name="category"
       type="text"
       data-vv-as="カテゴリー名"
@@ -52,19 +53,9 @@ export default {
     appText: Text,
   },
   props: {
-    // categories: {
-    //   type: Array,
-    //   default() {
-    //     return [];
-    //   },
-    // },
     categoryName: {
       type: String,
       default: '',
-    },
-    updateCategory: {
-      type: Object,
-      default: () => ({}),
     },
     targetCategory: {
       type: Object,
@@ -90,10 +81,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    // disabled: {
-    //   type: Boolean,
-    //   default: false,
-    // },
   },
   computed: {
     buttonText() {
@@ -128,7 +115,9 @@ export default {
   }
   &__detail {
     margin-top: 20px;
-    margin-bottom: 20px;
+  }
+  &__text {
+    margin-top: 20px;
   }
 }
 </style>

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="category-update">
+    <app-heading :level="1">カテゴリー管理</app-heading>
+    <app-router-link
+      class="category-management-post__detail"
+      :to="`/categories`"
+      underline
+      hover-opacity
+    >
+      カテゴリー一覧へ戻る
+    </app-router-link>
+    <app-input
+      v-validate="'required'"
+      name="category"
+      type="text"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('category')"
+      :value="categoryName"
+      @update-value="$emit('update-value', $event)"
+    />
+    <app-button
+      class="category-management-post__submit"
+      button-type="submit"
+      round
+      :disabled="disabled || !access.update"
+      @click="handleSubmit"
+    >
+      {{ buttonText }}
+    </app-button>
+
+    <div v-if="errorMessage" class="category-management-post__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+
+    <div v-if="doneMessage" class="category-management-post__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  Heading, Input, RouterLink, Button, Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appRouterLink: RouterLink,
+    appButton: Button,
+    appText: Text,
+  },
+  props: {
+    categories: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+    categoryName: {
+      type: String,
+      default: '',
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.update) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
+    },
+    disabled() {
+      return this.access.update && !this.loading;
+    },
+  },
+  methods: {
+    handleSubmit() {
+      if (!this.access.update) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.category-management-post {
+  &__input {
+    margin-top: 20px;
+  }
+  &__submit {
+    margin-top: 20px;
+  }
+  &__notice {
+    margin-top: 20px;
+  }
+  &__detail {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+}
+</style>

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -66,6 +66,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    targetCategory: {
+      type: Object,
+      default: () => ({}),
+    },
     editName: {
       type: String,
       default: '',
@@ -78,17 +82,13 @@ export default {
       type: String,
       default: '',
     },
-    // disabled: {
-    //   type: Boolean,
-    //   default: false,
-    // },
-    access: {
-      type: Object,
-      default: () => ({}),
-    },
     loading: {
       type: Boolean,
       default: false,
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
     },
   },
   computed: {
@@ -101,10 +101,10 @@ export default {
     },
   },
   methods: {
-    handleSubmit(updateCategory) {
+    handleSubmit(targetCategory) {
       if (!this.access.edit) return;
       this.$validator.validate().then(valid => {
-        if (valid) this.$emit('handle-submit', updateCategory.id);
+        if (valid) this.$emit('handle-submit', targetCategory.id);
       });
     },
   },

--- a/src/components/molecules/CategoryUpdate/index.vue
+++ b/src/components/molecules/CategoryUpdate/index.vue
@@ -22,7 +22,7 @@
       class="category-management-post__submit"
       button-type="submit"
       round
-      :disabled="disabled || !access.update"
+      :disabled="disabled || !access.edit"
       @click="handleSubmit"
     >
       {{ buttonText }}
@@ -62,31 +62,36 @@ export default {
       type: String,
       default: '',
     },
-    loading: {
-      type: Boolean,
-      default: false,
-    },
     doneMessage: {
       type: String,
       default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
     access: {
       type: Object,
       default: () => ({}),
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     buttonText() {
-      if (!this.access.update) return '更新権限がありません';
+      if (!this.access.edit) return '更新権限がありません';
       return this.disabled ? '更新中...' : '更新';
-    },
-    disabled() {
-      return this.access.update && !this.loading;
     },
   },
   methods: {
     handleSubmit() {
-      if (!this.access.update) return;
+      if (!this.access.edit) return;
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('handle-submit');
       });

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import UserDetail from './UserDetail/index.vue';
 import UserList from './UserList/index.vue';
 import CategoryPost from './CategoryPost/index.vue';
 import CategoryList from './CategoryList/index.vue';
+import CategoryUpdate from './CategoryUpdate/index.vue';
 import ArticleEdit from './ArticleEdit/index.vue';
 import ArticlePost from './ArticlePost/index.vue';
 import ArticleDetail from './ArticleDetail/index.vue';
@@ -29,6 +30,7 @@ export {
   UserList,
   CategoryPost,
   CategoryList,
+  CategoryUpdate,
   ArticleEdit,
   ArticlePost,
   ArticleDetail,

--- a/src/components/pages/Categories/CategoryList.vue
+++ b/src/components/pages/Categories/CategoryList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="articles">
+  <div class="category">
     <app-category-post
       class="form"
       :disabled="loading"
@@ -90,7 +90,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .articles {
+  .category {
     display: flex;
     writing-mode: lr-tb;
   }

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -2,14 +2,11 @@
   <div class="articles">
     <app-category-update
       class="list"
-      :category-id="categoryId"
-      :category-title="categoryTitle"
-      :category-content="categoryContent"
-      :disabled="loading"
       :access="access"
       :error-message="errorMessage"
-      :category="category"
+      :category-name="categoryName"
       :done-message="doneMessage"
+      :disabled="disabled"
       @update-value="updateValue"
       @handle-submit="handleSubmit"
     />
@@ -25,6 +22,37 @@ export default {
     appCategoryUpdate: CategoryUpdate,
   },
   mixins: [Mixins],
+  data() {
+    return {
+      categoryName: '',
+    };
+  },
+  computed: {
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    disabled() {
+      return this.$store.state.categories.disabled;
+    },
+    loading() {
+      return this.$store.state.categories.loading;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+  },
+  methods: {
+    updateValue(event) {
+      this.category = event.target.value;
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('category/updateCategory');
+    },
+  },
 };
 </script>
 

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -2,13 +2,14 @@
   <div class="articles">
     <app-category-update
       class="list"
+      :category-id="categoryId"
+      :category-name="categoryName"
       :access="access"
       :loading="loading"
       :error-message="errorMessage"
-      :category-name="categoryName"
       :done-message="doneMessage"
       :disabled="disabled"
-      @update-value="$emit('update-value', $event)"
+      @edited-name="editedName"
       @handle-submit="handleSubmit"
     />
   </div>
@@ -25,7 +26,7 @@ export default {
   mixins: [Mixins],
   computed: {
     categoryName() {
-      return this.$store.state.categories.updateCategory.name;
+      return this.$store.state.categories.targetCategory.name;
     },
     categoryId() {
       return parseInt(this.$route.params.id, 10);
@@ -50,7 +51,8 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getAllCategories', this.categoryId);
+    this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/getUpdateCategories', this.categoryId);
   },
   methods: {
     buttonText() {
@@ -62,6 +64,12 @@ export default {
       this.$validator.validate().then(valid => {
         if (valid) this.$emit('handle-submit');
       });
+    },
+    editedName($event) {
+      this.$store.dispatch('categories/editedName', $event.target.value);
+    },
+    editValue(event) {
+      this.$store.dispatch('categories/editValue', event.target.value);
     },
   },
 };

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -25,14 +25,11 @@ export default {
   },
   mixins: [Mixins],
   computed: {
-    categoryName() {
-      return this.$store.state.categories.targetCategory.name;
-    },
     categoryId() {
       return parseInt(this.$route.params.id, 10);
     },
-    updateCategory() {
-      return this.$store.state.categories.updateCategory;
+    categoryName() {
+      return this.$store.state.categories.targetCategory.name;
     },
     access() {
       return this.$store.getters['auth/access'];
@@ -51,8 +48,8 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getAllCategories');
-    this.$store.dispatch('categories/getUpdateCategories', this.categoryId);
+    this.$store.dispatch('categories/getAllCategories', this.categoryName);
+    this.$store.dispatch('categories/getUpdateCategory', this.categoryId);
   },
   methods: {
     buttonText() {

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -6,9 +6,9 @@
       :category-name="categoryName"
       :access="access"
       :loading="loading"
-      :error-message="errorMessage"
+      :update-category="updateCategory"
       :done-message="doneMessage"
-      :disabled="disabled"
+      :error-message="errorMessage"
       @edited-name="editedName"
       @handle-submit="handleSubmit"
     />
@@ -34,6 +34,9 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
+    updateCategory() {
+      return this.$store.state.categories.updateCategory;
+    },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
@@ -52,22 +55,25 @@ export default {
     this.$store.dispatch('categories/getUpdateCategory', this.categoryId);
   },
   methods: {
-    buttonText() {
-      if (!this.access.edit) return '更新権限がありません';
-      return this.disabled ? '更新中...' : '更新';
-    },
-    handleSubmit() {
-      if (!this.access.edit) return;
-      this.$validator.validate().then(valid => {
-        if (valid) this.$emit('handle-submit');
-      });
-    },
+    // handleSubmit() {
+    //   if (this.loading) return;
+    //   this.$store.dispatch('categories/updateCategory');
+    // },
     editedName($event) {
       this.$store.dispatch('categories/editedName', $event.target.value);
     },
-    editValue(event) {
-      this.$store.dispatch('categories/editValue', event.target.value);
+    handleSubmit() {
+      this.$store.dispatch(
+        'categories/updateCategory',
+        {
+          id: this.updateCategory.id,
+          name: this.updateCategory.name,
+        },
+      );
     },
+    // editValue(event) {
+    //   this.$store.dispatch('categories/editValue', event.target.value);
+    // },
   },
 };
 </script>

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -7,6 +7,7 @@
       :access="access"
       :loading="loading"
       :update-category="updateCategory"
+      :disabled="loading ? true : false"
       :done-message="doneMessage"
       :error-message="errorMessage"
       @edit-name="editName"

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -7,7 +7,7 @@
       :category-name="categoryName"
       :done-message="doneMessage"
       :disabled="disabled"
-      @update-value="updateValue"
+      @update-value="$emit('update-value', $event)"
       @handle-submit="handleSubmit"
     />
   </div>
@@ -28,6 +28,15 @@ export default {
     };
   },
   computed: {
+    categoryName() {
+      return this.$store.state.categories.updateCategory.name;
+    },
+    categoryId() {
+      return parseInt(this.$route.params.id, 10);
+    },
+    updateCategory() {
+      return this.$store.state.categories.updateCategory;
+    },
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -45,12 +54,15 @@ export default {
     },
   },
   methods: {
-    updateValue(event) {
-      this.category = event.target.value;
+    buttonText() {
+      if (!this.access.edit) return '更新権限がありません';
+      return this.disabled ? '更新中...' : '更新';
     },
     handleSubmit() {
-      if (this.loading) return;
-      this.$store.dispatch('category/updateCategory');
+      if (!this.access.edit) return;
+      this.$validator.validate().then(valid => {
+        if (valid) this.$emit('handle-submit');
+      });
     },
   },
 };

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="articles">
+    <app-category-update
+      class="list"
+      :category-id="categoryId"
+      :category-title="categoryTitle"
+      :category-content="categoryContent"
+      :disabled="loading"
+      :access="access"
+      :error-message="errorMessage"
+      :category="category"
+      :done-message="doneMessage"
+      @update-value="updateValue"
+      @handle-submit="handleSubmit"
+    />
+  </div>
+</template>
+
+<script>
+import { CategoryUpdate } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appCategoryUpdate: CategoryUpdate,
+  },
+  mixins: [Mixins],
+};
+</script>
+
+<style lang="scss" scoped>
+  .articles {
+    display: flex;
+    writing-mode: lr-tb;
+  }
+  .list {
+    flex-basis: 60%;
+    padding-left: 2%;
+  }
+</style>

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -55,21 +55,12 @@ export default {
     this.$store.dispatch('categories/getUpdateCategory', this.categoryId);
   },
   methods: {
-    // handleSubmit() {
-    //   if (this.loading) return;
-    //   this.$store.dispatch('categories/updateCategory');
-    // },
     editName($event) {
       this.$store.dispatch('categories/editName', $event.target.value);
     },
     handleSubmit() {
-      this.$store.dispatch(
-        'categories/updateName',
-        {
-          id: this.updateCategory.id,
-          name: this.updateCategory.name,
-        },
-      );
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateName', this.categoryId);
     },
     // editValue(event) {
     //   this.$store.dispatch('categories/editValue', event.target.value);

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -35,7 +35,7 @@ export default {
       return this.$store.getters['auth/access'];
     },
     updateCategory() {
-      return this.$store.state.categories.updateCategory;
+      return this.$store.state.categories.targetCategory;
     },
     doneMessage() {
       return this.$store.state.categories.doneMessage;

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -34,9 +34,6 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
-    updateCategory() {
-      return this.$store.state.categories.targetCategory;
-    },
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
@@ -67,11 +64,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .articles {
-    display: flex;
-    writing-mode: lr-tb;
-  }
-  .list {
+   .list {
     flex-basis: 60%;
     padding-left: 2%;
   }

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -3,6 +3,7 @@
     <app-category-update
       class="list"
       :access="access"
+      :loading="loading"
       :error-message="errorMessage"
       :category-name="categoryName"
       :done-message="doneMessage"
@@ -22,11 +23,6 @@ export default {
     appCategoryUpdate: CategoryUpdate,
   },
   mixins: [Mixins],
-  data() {
-    return {
-      categoryName: '',
-    };
-  },
   computed: {
     categoryName() {
       return this.$store.state.categories.updateCategory.name;
@@ -52,6 +48,9 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories', this.categoryId);
   },
   methods: {
     buttonText() {

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -7,7 +7,6 @@
       :access="access"
       :loading="loading"
       :update-category="updateCategory"
-      :disabled="loading ? true : false"
       :done-message="doneMessage"
       :error-message="errorMessage"
       @edit-name="editName"
@@ -63,9 +62,6 @@ export default {
       if (this.loading) return;
       this.$store.dispatch('categories/updateName', this.categoryId);
     },
-    // editValue(event) {
-    //   this.$store.dispatch('categories/editValue', event.target.value);
-    // },
   },
 };
 </script>

--- a/src/components/pages/Categories/CategoryUpdate.vue
+++ b/src/components/pages/Categories/CategoryUpdate.vue
@@ -9,7 +9,7 @@
       :update-category="updateCategory"
       :done-message="doneMessage"
       :error-message="errorMessage"
-      @edited-name="editedName"
+      @edit-name="editName"
       @handle-submit="handleSubmit"
     />
   </div>
@@ -59,12 +59,12 @@ export default {
     //   if (this.loading) return;
     //   this.$store.dispatch('categories/updateCategory');
     // },
-    editedName($event) {
-      this.$store.dispatch('categories/editedName', $event.target.value);
+    editName($event) {
+      this.$store.dispatch('categories/editName', $event.target.value);
     },
     handleSubmit() {
       this.$store.dispatch(
-        'categories/updateCategory',
+        'categories/updateName',
         {
           id: this.updateCategory.id,
           name: this.updateCategory.name,

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -33,7 +33,6 @@ import PasswordInit from '@Pages/Password/init.vue';
 import PasswordUpdate from '@Pages/Password/update.vue';
 
 import Store from '../_store';
-//import { component } from 'vue/types/umd';
 
 Vue.use(VueRouter);
 const router = new VueRouter({

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -17,6 +17,7 @@ import ArticlePost from '@Pages/Articles/Post.vue';
 // カテゴリー
 import Categories from '@Pages/Categories/index.vue';
 import CategoryList from '@Pages/Categories/CategoryList.vue';
+import CategoryUpdate from '@Pages/Categories/CategoryUpdate.vue';
 
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
@@ -32,6 +33,7 @@ import PasswordInit from '@Pages/Password/init.vue';
 import PasswordUpdate from '@Pages/Password/update.vue';
 
 import Store from '../_store';
+//import { component } from 'vue/types/umd';
 
 Vue.use(VueRouter);
 const router = new VueRouter({
@@ -79,6 +81,11 @@ const router = new VueRouter({
           name: 'CategoryList',
           path: '/categories',
           component: CategoryList,
+        },
+        {
+          name: 'CategoryUpdate',
+          path: ':id',
+          component: CategoryUpdate,
         },
       ],
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -18,6 +18,7 @@ export default {
     },
     doneMessage: '',
     errorMessage: '',
+    disabled: false,
     loading: false,
   },
   getters: {
@@ -66,6 +67,12 @@ export default {
       state.deleteCategory.id = null;
       state.deleteCategory.name = null;
     },
+    doneUpdateCategory(state, payload) {
+      state.updateCategory = payload.updateCategory;
+    },
+    categoryEdit(state, payload) {
+      state.updateCategory = { ...state.updateCategory, name: payload.name };
+    },
   },
   actions: {
     getAllCategories({ commit, rootGetters }) {
@@ -104,9 +111,6 @@ export default {
         });
       });
     },
-
-    //ここから更新に関する記述
-    //情報取得側の記述
     getUpdateCategory({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -123,35 +127,6 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    updateName({ commit }, name) {
-      commit({
-        type: 'updateName',
-        name,
-      });
-    },
-    //更新側の記述
-    updateCategory({ commit, rootGetters }, updateCategory) {
-      commit('toggleDisabled');
-      commit('clearMessage');
-      axios(rootGetters['auth/token'])({
-        method: 'PUT',
-        url: `/category/${updateCategory.id}`,
-        data: updateCategory,
-      }).then(res => {
-        const updateCategory = {
-          id: res.data.category.id,
-          name: res.data.category.name,
-        };
-        commit('toggleDisabled');
-        commit('doneUpdateCategory', { updateCategory });
-      }).catch(err => {
-        commit('toggleDisabled');
-        commit('failRequest', { message: err.message });
-      });
-    },
-    // ここまで
-
-
     confirmDeleteCategoryId({ commit }, categoryId) {
       commit('confirmDeleteCategoryId', { categoryId });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -121,7 +121,6 @@ export default {
     updateName({ commit, rootGetters }, categoryId) {
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/targetCategory'].id);
       data.append('name', rootGetters['categories/targetCategory'].name);
       axios(rootGetters['auth/token'])({
         method: 'PUT',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,10 +8,6 @@ export default {
       id: null,
       name: '',
     },
-    // updateCategory: {
-    //   id: null,
-    //   name: '',
-    // },
     deleteCategory: {
       name: null,
       id: null,
@@ -21,28 +17,11 @@ export default {
     loading: false,
   },
   getters: {
-    // transformedCategories(state) {
-    //   return state.categoryList.map(category => ({
-    //     id: category.id,
-    //     name: category.name,
-    //   }));
-    // },
-    updateCategory: state => state.updateCategory,
     targetCategory: state => state.targetCategory,
     deleteCategoryId: state => state.deleteCategory.id,
     deleteCategoryName: state => state.deleteCategory.name,
   },
   mutations: {
-    initPostCategory(state) {
-      state.targetCategory = {
-        id: null,
-        name: '',
-      };
-      state.updateCategory = {
-        id: null,
-        name: '',
-      };
-    },
     doneGetAllCategories(state, payload) {
       state.categoryList = [...payload.categories];
     },
@@ -61,7 +40,7 @@ export default {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
     updateCategory(state, { category }) {
-      state.categoriesList = [...state.categoriesList, ...category]
+      state.categoriesList = [...state.categoriesList, ...category];
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
@@ -82,22 +61,11 @@ export default {
     editName(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
-    // doneEditCategory(state, { updateCategory }) {
-    //   state.updateCategory = { ...state.updateCategory, ...updateCategory };
-    // },
     doneEditCategory(state, { category }) {
       state.category = { ...state.targetCategory, ...category };
-      state.loading = false;
-      //state.doneMessage = 'ユーザーの更新が完了しました。';
     },
-    // updateCategoryName(state, payload) {
-    //   state.categoriesList = [payload.updateCategory.category, ...state.categoriesList];
-    // },
   },
   actions: {
-    initPostCategory({ commit }) {
-      commit('initPostCategory');
-    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -135,75 +103,42 @@ export default {
       });
     },
     getUpdateCategory({ commit, rootGetters }, categoryId) {
-        axios(rootGetters['auth/token'])({
-          method: 'GET',
-          url: `/category/${categoryId}`,
-        }).then(res => {
-          const payload = {
-            targetCategory: {
-              id: res.data.category.id,
-              name: res.data.category.name,
-            },
-          };
-          commit('doneUpdateCategory', payload);
-        }).catch(err => {
-          commit('failRequest', { message: err.message });
-        });
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then(res => {
+        const payload = {
+          targetCategory: {
+            id: res.data.category.id,
+            name: res.data.category.name,
+          },
+        };
+        commit('doneUpdateCategory', payload);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
     },
     updateName({ commit, rootGetters }, categoryId) {
-      console.log(rootGetters['categories/targetCategory'].name);
       commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('id', rootGetters['categories/targetCategory'].id);
       data.append('name', rootGetters['categories/targetCategory'].name);
-        axios(rootGetters['auth/token'])({
-          method: 'PUT',
-          url: `/category/${categoryId}`,
-          data,
-        }).then(res => {
-          const payload = {
-            id: res.data.category.id,
-            name: res.data.category.name,
-          };
-          commit('doneEditCategory', payload);
-          commit('toggleLoading');
-          commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
-          console.log(disabled);
-        }).catch(() => {
-          commit('toggleLoading');
-        });
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${categoryId}`,
+        data,
+      }).then(res => {
+        const payload = {
+          id: res.data.category.id,
+          name: res.data.category.name,
+        };
+        commit('doneEditCategory', payload);
+        commit('toggleLoading');
+        commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+      }).catch(() => {
+        commit('toggleLoading');
+      });
     },
-    // updateArticle({ commit, rootGetters }) {
-    //   commit('toggleLoading');
-    //   const data = new URLSearchParams();
-    //   data.append('id', rootGetters['articles/targetArticle'].id);
-    //   data.append('title', rootGetters['articles/targetArticle'].title);
-    //   data.append('content', rootGetters['articles/targetArticle'].content);
-    //   data.append('user_id', rootGetters['articles/targetArticle'].user.id);
-    //   data.append('category_id', rootGetters['articles/targetArticle'].category.id);
-    //   axios(rootGetters['auth/token'])({
-    //     method: 'PUT',
-    //     url: `/article/${rootGetters['articles/targetArticle'].id}`,
-    //     data,
-    //   }).then(res => {
-    //     const payload = {
-    //       article: {
-    //         id: res.data.article.id,
-    //         title: res.data.article.title,
-    //         content: res.data.article.content,
-    //         updated_at: res.data.article.updated_at,
-    //         created_at: res.data.article.created_at,
-    //         user: res.data.article.user,
-    //         category: res.data.article.category,
-    //       },
-    //     };
-    //     commit('updateArticle', payload);
-    //     commit('toggleLoading');
-    //     commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
-    //   }).catch(() => {
-    //     commit('toggleLoading');
-    //   });
-    // },
     editName({ commit }, name) {
       commit({
         type: 'editName',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -31,6 +31,9 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
+    // updateCategory(state, { category }) {
+    //   state.targetCategory = { ...state.targetCategory, ...category };
+    // },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
     },
@@ -82,6 +85,41 @@ export default {
         });
       });
     },
+    // updateCategory({ commit, rootGetters }) {
+    //   commit('toggleLoading');
+    //   const data = new URLSearchParams();
+    //   data.append('name', rootGetters['categories/targetCategory'].name);
+    //   data.append('id', rootGetters['categories/targetCategory'].id);
+    //   data.append('title', rootGetters['categories/targetCategory'].title);
+    //   data.append('content', rootGetters['categories/targetCategory'].content);
+    //   data.append('user_id', rootGetters['categories/targetCategory'].user.id);
+    //   data.append('category_id', rootGetters['categories/targetCategory'].category.id);
+    //   axios(rootGetters['auth/token'])({
+    //     method: 'PUT',
+    //     url: `/category/${rootGetters['categories/targetCategory'].id}`,
+    //     data,
+    //   }).then(res => {
+    //     const payload = {
+    //       category: {
+    //         name: res.data.category.name,
+    //       },
+    //       article: {
+    //         id: res.data.article.id,
+    //         title: res.data.article.title,
+    //         content: res.data.article.content,
+    //         updated_at: res.data.article.updated_at,
+    //         created_at: res.data.article.created_at,
+    //         user: res.data.article.user,
+    //         category: res.data.article.category,
+    //       },
+    //     };
+    //     commit('updateCategory', payload);
+    //     commit('toggleLoading');
+    //     commit('displayDoneMessage', { message: 'カテゴリーを更新しました' });
+    //   }).catch(() => {
+    //     commit('toggleLoading');
+    //   });
+    // },
     confirmDeleteCategoryId({ commit }, categoryId) {
       commit('confirmDeleteCategoryId', { categoryId });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -106,6 +106,7 @@ export default {
     },
 
     //ここから更新に関する記述
+    //情報取得側の記述
     getUpdateCategory({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -122,12 +123,13 @@ export default {
         commit('failRequest', { message: err.message });
       });
     },
-    editName({ commit }, name) {
+    updateName({ commit }, name) {
       commit({
-        type: 'editName',
+        type: 'updateName',
         name,
       });
     },
+    //更新側の記述
     updateCategory({ commit, rootGetters }, updateCategory) {
       commit('toggleDisabled');
       commit('clearMessage');
@@ -136,12 +138,12 @@ export default {
         url: `/category/${updateCategory.id}`,
         data: updateCategory,
       }).then(res => {
-        const editCategory = {
+        const updateCategory = {
           id: res.data.category.id,
           name: res.data.category.name,
         };
         commit('toggleDisabled');
-        commit('doneEditCategory', { editCategory });
+        commit('doneUpdateCategory', { updateCategory });
       }).catch(err => {
         commit('toggleDisabled');
         commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -18,7 +18,7 @@ export default {
     },
     doneMessage: '',
     errorMessage: '',
-    disabled: false,
+    loading: false,
   },
   getters: {
     // transformedCategories(state) {
@@ -87,7 +87,7 @@ export default {
     // },
     doneEditCategory(state, { category }) {
       state.category = { ...state.targetCategory, ...category };
-      //state.loading = false;
+      state.loading = false;
       //state.doneMessage = 'ユーザーの更新が完了しました。';
     },
     // updateCategoryName(state, payload) {
@@ -168,6 +168,7 @@ export default {
           commit('doneEditCategory', payload);
           commit('toggleLoading');
           commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+          console.log(disabled);
         }).catch(() => {
           commit('toggleLoading');
         });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -8,10 +8,10 @@ export default {
       id: null,
       name: '',
     },
-    updateCategory: {
-      id: null,
-      //name: '',
-    },
+    // updateCategory: {
+    //   id: null,
+    //   name: '',
+    // },
     deleteCategory: {
       name: null,
       id: null,
@@ -40,7 +40,7 @@ export default {
       };
       state.updateCategory = {
         id: null,
-        //name: '',
+        name: '',
       };
     },
     doneGetAllCategories(state, payload) {
@@ -80,15 +80,16 @@ export default {
       state.targetCategory = payload.targetCategory;
     },
     editName(state, payload) {
-      state.updateCategory = { ...state.updateCategory, name: payload.name };
+      state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
-    doneEditCategory(state, { updateCategory }) {
-      state.updateCategory = { ...state.updateCategory, ...updateCategory };
-    },
-    // doneEditUser(state, { user }) {
-    //   state.user = { ...state.user, ...user };
-    //   state.loading = false;
+    // doneEditCategory(state, { updateCategory }) {
+    //   state.updateCategory = { ...state.updateCategory, ...updateCategory };
     // },
+    doneEditCategory(state, { category }) {
+      state.category = { ...state.targetCategory, ...category };
+      //state.loading = false;
+      //state.doneMessage = 'ユーザーの更新が完了しました。';
+    },
     // updateCategoryName(state, payload) {
     //   state.categoriesList = [payload.updateCategory.category, ...state.categoriesList];
     // },
@@ -150,21 +151,21 @@ export default {
         });
     },
     updateName({ commit, rootGetters }, categoryId) {
-      console.log(rootGetters['categories/updateCategory'].name);
+      console.log(rootGetters['categories/targetCategory'].name);
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', rootGetters['categories/updateCategory'].id);
-      data.append('name', rootGetters['categories/updateCategory'].name);
+      data.append('id', rootGetters['categories/targetCategory'].id);
+      data.append('name', rootGetters['categories/targetCategory'].name);
         axios(rootGetters['auth/token'])({
           method: 'PUT',
           url: `/category/${categoryId}`,
           data,
         }).then(res => {
-          const detailName = {
+          const payload = {
             id: res.data.category.id,
-            //name: res.data.category.name,
+            name: res.data.category.name,
           };
-          commit('doneEditCategory', { detailName })
+          commit('doneEditCategory', payload);
           commit('toggleLoading');
           commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
         }).catch(() => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -137,6 +137,7 @@ export default {
         });
     },
     updateName({ commit, rootGetters }, categoryId) {
+      console.log(categoryName);
       return new Promise((resolve, reject) => {
         commit('toggleLoading');
         axios(rootGetters['auth/token'])({
@@ -145,7 +146,7 @@ export default {
           //data: updateCategory,
         }).then(res => {
           const payload = {
-            editCategory: {
+            updateCategory: {
               id: res.data.category.id,
               name: res.data.category.name,
             },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -76,6 +76,9 @@ export default {
     editedName(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
+    doneEditCategory(state, { updateCategory }) {
+      state.updateCategory = { ...state.updateCategory, ...updateCategory };
+    },
     updateCategoryName(state, payload) {
       state.categoriesList = [payload.updateCategory.category, ...state.categoriesList];
     },
@@ -133,32 +136,32 @@ export default {
           commit('failRequest', { message: err.message });
         });
     },
-    updateCategory({ commit, rootGetters }, updateCategory) {
-      commit('toggleLoading');
-      axios(rootGetters['auth/token'])({
-        method: 'PUT',
-        url: `/category/${rootGetters['categories/targetCategory'].id}`,
-        data: updateCategory,
-      }).then(res => {
-        const payload = {
-          updateCategory: {
-            id: res.data.category.id,
-            name: res.data.category.name,
-            // content: res.data.category.content,
-            // updated_at: res.data.category.updated_at,
-            // created_at: res.data.category.created_at,
-          },
-        };
-        commit('updateCategory', payload);
+    updateName({ commit, rootGetters }, categoryId) {
+      return new Promise((resolve, reject) => {
         commit('toggleLoading');
-        commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
-      }).catch(() => {
-        commit('toggleLoading');
+        axios(rootGetters['auth/token'])({
+          method: 'PUT',
+          url: `/category/${categoryId}`,
+          //data: updateCategory,
+        }).then(res => {
+          const payload = {
+            editCategory: {
+              id: res.data.category.id,
+              name: res.data.category.name,
+            },
+          };
+          commit('doneEditCategory', payload);
+          commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+          resolve();
+        }).catch(() => {
+          commit('toggleLoading');
+          reject();
+        });
       });
     },
-    editedName({ commit }, name) {
+    editName({ commit }, name) {
       commit({
-        type: 'editedName',
+        type: 'editName',
         name,
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -22,6 +22,7 @@ export default {
     loading: false,
   },
   getters: {
+    updateCategory: state => state.updateCategory,
     targetCategory: state => state.targetCategory,
     deleteCategoryId: state => state.deleteCategory.id,
     deleteCategoryName: state => state.deleteCategory.name,
@@ -51,8 +52,11 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
-    updateCategory(state, { category }) {
-      state.targetCategory = { ...state.targetCategory, ...category };
+    updateValue(state, payload) {
+      state.targetCategory = { ...state.targetCategory, name: payload.name };
+    },
+    updateCategory(state, payload) {
+      state.categoriesList = [payload.newCategories.category, ...state.categoriesList];
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
@@ -69,6 +73,9 @@ export default {
     },
     doneUpdateCategory(state, payload) {
       state.updateCategory = payload.updateCategory;
+    },
+    editedName(state, payload) {
+      state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
     categoryEdit(state, payload) {
       state.updateCategory = { ...state.updateCategory, name: payload.name };
@@ -112,19 +119,30 @@ export default {
       });
     },
     getUpdateCategory({ commit, rootGetters }, categoryId) {
-      axios(rootGetters['auth/token'])({
-        method: 'GET',
-        url: `/category/${categoryId}`,
-      }).then(res => {
-        const payload = {
-          updateCategory: {
-            id: res.data.category.id,
-            name: res.data.category.name,
-          },
-        };
-        commit('doneUpdateCategory', payload);
-      }).catch(err => {
-        commit('failRequest', { message: err.message });
+      return new Promise((resolve, reject) => {
+        axios(rootGetters['auth/token'])({
+          method: 'GET',
+          url: `/category/${categoryId}`,
+        }).then(res => {
+          const payload = {
+            updateCategory: {
+              id: res.data.category.id,
+              name: res.data.category.name,
+            },
+          };
+          commit('doneUpdateCategory', payload);
+          resolve();
+          console.log(hoge);
+        }).catch(err => {
+          commit('failRequest', { message: err.message });
+          reject();
+        });
+      });
+    },
+    editedName({ commit }, name) {
+      commit({
+        type: 'editedName',
+        name,
       });
     },
     confirmDeleteCategoryId({ commit }, categoryId) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -72,7 +72,7 @@ export default {
       state.deleteCategory.name = null;
     },
     doneUpdateCategory(state, payload) {
-      state.updateCategory = payload.updateCategory;
+      state.targetCategory = payload.targetCategory;
     },
     editedName(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
@@ -119,25 +119,20 @@ export default {
       });
     },
     getUpdateCategory({ commit, rootGetters }, categoryId) {
-      return new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
           method: 'GET',
           url: `/category/${categoryId}`,
         }).then(res => {
           const payload = {
-            updateCategory: {
+            targetCategory: {
               id: res.data.category.id,
               name: res.data.category.name,
             },
           };
           commit('doneUpdateCategory', payload);
-          resolve();
-          console.log(hoge);
         }).catch(err => {
           commit('failRequest', { message: err.message });
-          reject();
         });
-      });
     },
     editedName({ commit }, name) {
       commit({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,7 +19,6 @@ export default {
     doneMessage: '',
     errorMessage: '',
     disabled: false,
-    loading: false,
   },
   getters: {
     updateCategory: state => state.updateCategory,
@@ -77,8 +76,8 @@ export default {
     editedName(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
-    categoryEdit(state, payload) {
-      state.updateCategory = { ...state.updateCategory, name: payload.name };
+    updateCategoryName(state, payload) {
+      state.categoriesList = [payload.updateCategory.category, ...state.categoriesList];
     },
   },
   actions: {
@@ -133,6 +132,29 @@ export default {
         }).catch(err => {
           commit('failRequest', { message: err.message });
         });
+    },
+    updateCategory({ commit, rootGetters }, updateCategory) {
+      commit('toggleLoading');
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${rootGetters['categories/targetCategory'].id}`,
+        data: updateCategory,
+      }).then(res => {
+        const payload = {
+          updateCategory: {
+            id: res.data.category.id,
+            name: res.data.category.name,
+            // content: res.data.category.content,
+            // updated_at: res.data.category.updated_at,
+            // created_at: res.data.category.created_at,
+          },
+        };
+        commit('updateCategory', payload);
+        commit('toggleLoading');
+        commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+      }).catch(() => {
+        commit('toggleLoading');
+      });
     },
     editedName({ commit }, name) {
       commit({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -10,8 +10,7 @@ export default {
     },
     updateCategory: {
       id: null,
-      name: '',
-      editName: '',
+      //name: '',
     },
     deleteCategory: {
       name: null,
@@ -22,14 +21,13 @@ export default {
     disabled: false,
   },
   getters: {
-    transformedCategories(state) {
-      return state.categoryList.map(category => ({
-        id: category.id,
-        name: category.name,
-      }));
-    },
+    // transformedCategories(state) {
+    //   return state.categoryList.map(category => ({
+    //     id: category.id,
+    //     name: category.name,
+    //   }));
+    // },
     updateCategory: state => state.updateCategory,
-    editName: state => state.updateCategory.name,
     targetCategory: state => state.targetCategory,
     deleteCategoryId: state => state.deleteCategory.id,
     deleteCategoryName: state => state.deleteCategory.name,
@@ -38,11 +36,11 @@ export default {
     initPostCategory(state) {
       state.targetCategory = {
         id: null,
-        title: '',
+        name: '',
       };
       state.updateCategory = {
         id: null,
-        title: '',
+        //name: '',
       };
     },
     doneGetAllCategories(state, payload) {
@@ -82,7 +80,7 @@ export default {
       state.targetCategory = payload.targetCategory;
     },
     editName(state, payload) {
-      state.targetCategory = { ...state.targetCategory, name: payload.name };
+      state.updateCategory = { ...state.updateCategory, name: payload.name };
     },
     doneEditCategory(state, { updateCategory }) {
       state.updateCategory = { ...state.updateCategory, ...updateCategory };
@@ -91,11 +89,14 @@ export default {
     //   state.user = { ...state.user, ...user };
     //   state.loading = false;
     // },
-    updateCategoryName(state, payload) {
-      state.categoriesList = [payload.updateCategory.category, ...state.categoriesList];
-    },
+    // updateCategoryName(state, payload) {
+    //   state.categoriesList = [payload.updateCategory.category, ...state.categoriesList];
+    // },
   },
   actions: {
+    initPostCategory({ commit }) {
+      commit('initPostCategory');
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -148,21 +149,20 @@ export default {
           commit('failRequest', { message: err.message });
         });
     },
-    updateName({ commit, rootGetters }, updateCategory) {
+    updateName({ commit, rootGetters }, categoryId) {
       console.log(rootGetters['categories/updateCategory'].name);
       commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('id', rootGetters['categories/updateCategory'].id);
       data.append('name', rootGetters['categories/updateCategory'].name);
-      //data.append('editName', rootGetters['categories/updateCategory'].editName);
         axios(rootGetters['auth/token'])({
           method: 'PUT',
-          url: `/category/${updateCategory.Id}`,
-          data: updateCategory,
+          url: `/category/${categoryId}`,
+          data,
         }).then(res => {
           const detailName = {
             id: res.data.category.id,
-            name: res.data.category.name,
+            //name: res.data.category.name,
           };
           commit('doneEditCategory', { detailName })
           commit('toggleLoading');
@@ -207,7 +207,6 @@ export default {
         type: 'editName',
         name,
       });
-      console.log(name);
     },
     confirmDeleteCategoryId({ commit }, categoryId) {
       commit('confirmDeleteCategoryId', { categoryId });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -54,8 +54,8 @@ export default {
     updateValue(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
-    updateCategory(state, payload) {
-      state.categoriesList = [payload.newCategories.category, ...state.categoriesList];
+    updateCategory(state, { category }) {
+      state.categoriesList = [...state.categoriesList, ...category]
     },
     displayDoneMessage(state, payload = { message: '成功しました' }) {
       state.doneMessage = payload.message;
@@ -73,7 +73,7 @@ export default {
     doneUpdateCategory(state, payload) {
       state.targetCategory = payload.targetCategory;
     },
-    editedName(state, payload) {
+    editName(state, payload) {
       state.targetCategory = { ...state.targetCategory, name: payload.name };
     },
     doneEditCategory(state, { updateCategory }) {
@@ -137,13 +137,15 @@ export default {
         });
     },
     updateName({ commit, rootGetters }, categoryId) {
-      console.log(categoryName);
-      return new Promise((resolve, reject) => {
-        commit('toggleLoading');
+      //console.log(categoryId);
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('id', rootGetters['categories/updateCategory'].id);
+      data.append('name', rootGetters['categories/updateCategory'].name);
         axios(rootGetters['auth/token'])({
           method: 'PUT',
           url: `/category/${categoryId}`,
-          //data: updateCategory,
+          data,
         }).then(res => {
           const payload = {
             updateCategory: {
@@ -151,15 +153,44 @@ export default {
               name: res.data.category.name,
             },
           };
-          commit('doneEditCategory', payload);
+          commit('updateCategory', payload);
+          commit('toggleLoading');
           commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
-          resolve();
         }).catch(() => {
           commit('toggleLoading');
-          reject();
         });
-      });
     },
+    // updateArticle({ commit, rootGetters }) {
+    //   commit('toggleLoading');
+    //   const data = new URLSearchParams();
+    //   data.append('id', rootGetters['articles/targetArticle'].id);
+    //   data.append('title', rootGetters['articles/targetArticle'].title);
+    //   data.append('content', rootGetters['articles/targetArticle'].content);
+    //   data.append('user_id', rootGetters['articles/targetArticle'].user.id);
+    //   data.append('category_id', rootGetters['articles/targetArticle'].category.id);
+    //   axios(rootGetters['auth/token'])({
+    //     method: 'PUT',
+    //     url: `/article/${rootGetters['articles/targetArticle'].id}`,
+    //     data,
+    //   }).then(res => {
+    //     const payload = {
+    //       article: {
+    //         id: res.data.article.id,
+    //         title: res.data.article.title,
+    //         content: res.data.article.content,
+    //         updated_at: res.data.article.updated_at,
+    //         created_at: res.data.article.created_at,
+    //         user: res.data.article.user,
+    //         category: res.data.article.category,
+    //       },
+    //     };
+    //     commit('updateArticle', payload);
+    //     commit('toggleLoading');
+    //     commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+    //   }).catch(() => {
+    //     commit('toggleLoading');
+    //   });
+    // },
     editName({ commit }, name) {
       commit({
         type: 'editName',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,6 +11,7 @@ export default {
     updateCategory: {
       id: null,
       name: '',
+      editName: '',
     },
     deleteCategory: {
       name: null,
@@ -21,7 +22,14 @@ export default {
     disabled: false,
   },
   getters: {
+    transformedCategories(state) {
+      return state.categoryList.map(category => ({
+        id: category.id,
+        name: category.name,
+      }));
+    },
     updateCategory: state => state.updateCategory,
+    editName: state => state.updateCategory.name,
     targetCategory: state => state.targetCategory,
     deleteCategoryId: state => state.deleteCategory.id,
     deleteCategoryName: state => state.deleteCategory.name,
@@ -79,6 +87,10 @@ export default {
     doneEditCategory(state, { updateCategory }) {
       state.updateCategory = { ...state.updateCategory, ...updateCategory };
     },
+    // doneEditUser(state, { user }) {
+    //   state.user = { ...state.user, ...user };
+    //   state.loading = false;
+    // },
     updateCategoryName(state, payload) {
       state.categoriesList = [payload.updateCategory.category, ...state.categoriesList];
     },
@@ -136,24 +148,23 @@ export default {
           commit('failRequest', { message: err.message });
         });
     },
-    updateName({ commit, rootGetters }, categoryId) {
-      //console.log(categoryId);
+    updateName({ commit, rootGetters }, updateCategory) {
+      console.log(rootGetters['categories/updateCategory'].name);
       commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('id', rootGetters['categories/updateCategory'].id);
       data.append('name', rootGetters['categories/updateCategory'].name);
+      //data.append('editName', rootGetters['categories/updateCategory'].editName);
         axios(rootGetters['auth/token'])({
           method: 'PUT',
-          url: `/category/${categoryId}`,
-          data,
+          url: `/category/${updateCategory.Id}`,
+          data: updateCategory,
         }).then(res => {
-          const payload = {
-            updateCategory: {
-              id: res.data.category.id,
-              name: res.data.category.name,
-            },
+          const detailName = {
+            id: res.data.category.id,
+            name: res.data.category.name,
           };
-          commit('updateCategory', payload);
+          commit('doneEditCategory', { detailName })
           commit('toggleLoading');
           commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
         }).catch(() => {
@@ -196,6 +207,7 @@ export default {
         type: 'editName',
         name,
       });
+      console.log(name);
     },
     confirmDeleteCategoryId({ commit }, categoryId) {
       commit('confirmDeleteCategoryId', { categoryId });

--- a/src/js/_store/modules/users.js
+++ b/src/js/_store/modules/users.js
@@ -156,6 +156,7 @@ export default {
         };
 
         commit('doneEditUser', { editedUser });
+        console.log(editedUser);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });

--- a/src/js/_store/modules/users.js
+++ b/src/js/_store/modules/users.js
@@ -156,7 +156,6 @@ export default {
         };
 
         commit('doneEditUser', { editedUser });
-        console.log(editedUser);
       }).catch(err => {
         commit('failRequest', { message: err.message });
       });


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-1470

## やったこと
カテゴリー更新機能の実装
・カテゴリー一覧より更新の文字リンククリック後画面が遷移し、対象のカテゴリー名の情報が取得される。
・対象のカテゴリー名を編集後、更新ボタンをクリックすることにより編集されたカテゴリー名に更新される。

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-1472

## 特にレビューをお願いしたい箇所
挙動を確認しながらコードを確認したが、実装にあたって不要なコードが残ってしまっている可能性がある。